### PR TITLE
Add PyPI publishing automation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/docr-mcp
+    permissions:
+      id-token: write  # Required for trusted publishing
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: true
+
+    - name: Build package
+      run: uv build
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
Add automated PyPI publishing using GitHub Actions and trusted publishing.

## Changes
- **GitHub Action workflow** (`.github/workflows/publish.yml`):
  - Triggers on GitHub releases
  - Builds package with `uv`
  - Publishes to PyPI using trusted publishing (no API tokens)

## How It Works
1. Create a GitHub release (e.g., `v0.1.0`)
2. GitHub Action automatically builds and publishes to PyPI
3. Package available at `pip install docr-mcp`

## Setup Required (One-time)
After merging, set up PyPI trusted publishing:
1. Go to https://pypi.org/manage/account/publishing/
2. Add pending publisher with these details:
   - Project: `docr-mcp`
   - Owner: `JacobHuang91`
   - Repository: `docr-mcp`
   - Workflow: `publish.yml`
   - Environment: `pypi`

## Testing
- [x] Package builds locally: `uv build` ✓
- [x] All tests pass
- [x] Workflow syntax validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)