### PR TITLE
Add Vercel documentation support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+.PHONY: help add-strands add-vercel add-strands-local add-vercel-local
+
+PROJECT_DIR := $(shell pwd)
+
+help:
+	@echo "docr-mcp - Add documentation MCP servers to Claude Code"
+	@echo ""
+	@echo "Production (from PyPI):"
+	@echo "  make add-strands           - Add Strands Agents documentation"
+	@echo "  make add-vercel            - Add Vercel documentation"
+	@echo ""
+	@echo "Development (local code):"
+	@echo "  make add-strands-local     - Add Strands with local development code"
+	@echo "  make add-vercel-local      - Add Vercel with local development code"
+
+add-strands:
+	@echo "Adding Strands Agents MCP server to Claude Code..."
+	@claude mcp add docr-mcp-strands -- uvx docr-mcp --library strands
+	@echo "✅ Done! Restart Claude Code to activate."
+
+add-vercel:
+	@echo "Adding Vercel MCP server to Claude Code..."
+	@claude mcp add docr-mcp-vercel -- uvx docr-mcp --library vercel
+	@echo "✅ Done! Restart Claude Code to activate."
+
+add-strands-local:
+	@echo "Adding Strands Agents MCP server (local development)..."
+	@claude mcp add docr-mcp-strands-local -- uv --directory $(PROJECT_DIR) run docr-mcp --library strands
+	@echo "✅ Done! Restart Claude Code to activate."
+
+add-vercel-local:
+	@echo "Adding Vercel MCP server (local development)..."
+	@claude mcp add docr-mcp-vercel-local -- uv --directory $(PROJECT_DIR) run docr-mcp --library vercel
+	@echo "✅ Done! Restart Claude Code to activate."
+

--- a/README.md
+++ b/README.md
@@ -23,17 +23,23 @@ Give LLMs the ability to search and read documentation from any source - public 
 
 ## Supported Documentation
 
-| Library                                      | Status    | Install Command (Claude Code)                                              |
-| -------------------------------------------- | --------- | -------------------------------------------------------------------------- |
+| Library                                      | Status    | Install Command (Claude Code)                                        |
+| -------------------------------------------- | --------- | -------------------------------------------------------------------- |
 | [Strands Agents](https://strandsagents.com) | ✅ Active | `claude mcp add docr-mcp-strands -- uvx docr-mcp --library strands` |
+| [Vercel](https://vercel.com)                 | ✅ Active | `claude mcp add docr-mcp-vercel -- uvx docr-mcp --library vercel`   |
 
 **Want to add a library?** See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## Installation
 
 ```bash
-# Add to Claude Code (for Strands Agents docs)
+# Add to Claude Code (choose the library you need)
+
+# For Strands Agents documentation
 claude mcp add docr-mcp-strands -- uvx docr-mcp --library strands
+
+# For Vercel documentation
+claude mcp add docr-mcp-vercel -- uvx docr-mcp --library vercel
 ```
 
 **For contributors:** See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup.

--- a/src/docr_mcp/config/vercel.yml
+++ b/src/docr_mcp/config/vercel.yml
@@ -1,0 +1,34 @@
+name: "Vercel"
+description: "Vercel is the AI Cloud - a unified platform for building, deploying, and scaling AI-powered applications"
+parser: "vercel"
+
+index:
+  source: "https://vercel.com/llms.txt"
+
+tools:
+  search_docs:
+    description: |
+      Search Vercel platform documentation.
+
+      Vercel is a cloud platform for deploying web applications and AI workloads. Use this tool when the user asks about:
+      - Deploying applications to Vercel
+      - Supported frameworks (Next.js, SvelteKit, Nuxt, Remix, Astro, Vite, etc.)
+      - Frontend and backend deployment
+      - Vercel Functions and compute options
+      - Build system and infrastructure
+      - Production deployment best practices
+      - CI/CD and deployment workflows
+      - Domain management and DNS
+      - Environment variables and secrets
+      - Vercel CLI and APIs
+      - Integration with frameworks and tools
+
+      Returns a list of relevant documentation pages with titles and URLs ranked by relevance.
+
+  fetch_doc:
+    description: |
+      Fetch full content from a Vercel documentation page.
+
+      Retrieves the complete documentation content and returns it formatted
+      for easy reading. Use this after search_docs to get detailed information
+      about a specific topic.

--- a/src/docr_mcp/docrs/__init__.py
+++ b/src/docr_mcp/docrs/__init__.py
@@ -24,5 +24,10 @@ def load_docr(config: LibraryConfig) -> BaseDocr:
 
         return StrandsDocr()
 
+    elif docr_name == "vercel":
+        from .vercel import VercelDocr
+
+        return VercelDocr()
+
     else:
-        raise ValueError(f"Unknown docr: {docr_name}. Available docrs: strands")
+        raise ValueError(f"Unknown docr: {docr_name}. Available docrs: strands, vercel")

--- a/src/docr_mcp/docrs/vercel.py
+++ b/src/docr_mcp/docrs/vercel.py
@@ -272,7 +272,9 @@ class VercelDocr(BaseDocr):
         if first_line.startswith("# "):
             title = first_line[2:].strip()
 
-        return Document(url=url, content=content, metadata={"title": title, "source": "vercel", "format": content_format})
+        return Document(
+            url=url, content=content, metadata={"title": title, "source": "vercel", "format": content_format}
+        )
 
     def close(self):
         """Explicitly close HTTP client."""

--- a/src/docr_mcp/docrs/vercel.py
+++ b/src/docr_mcp/docrs/vercel.py
@@ -1,0 +1,281 @@
+"""Docr for Vercel documentation."""
+
+import logging
+import re
+from typing import List
+from urllib.parse import urlparse
+
+import httpx
+
+from docr_mcp.models import Document, IndexConfig, IndexEntry
+
+from .base import BaseDocr
+
+logger = logging.getLogger(__name__)
+
+
+class VercelDocr(BaseDocr):
+    """Docr for Vercel documentation (vercel.com)."""
+
+    ALLOWED_DOMAINS = {"vercel.com"}
+
+    def __init__(self):
+        self.client = None
+        self._timeout = 30.0
+
+    def __enter__(self):
+        """Context manager entry."""
+        self.client = httpx.Client(
+            timeout=self._timeout, follow_redirects=True, headers={"User-Agent": "docr-mcp/0.1.0"}
+        )
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit - cleanup resources."""
+        if self.client:
+            self.client.close()
+        return False
+
+    def _ensure_client(self):
+        """Ensure HTTP client is initialized."""
+        if not self.client:
+            self.client = httpx.Client(
+                timeout=self._timeout, follow_redirects=True, headers={"User-Agent": "docr-mcp/0.1.0"}
+            )
+
+    def fetch_index_entries(self, index_config: IndexConfig) -> List[IndexEntry]:
+        """Fetch and parse documentation index entries.
+
+        Args:
+            index_config: IndexConfig object with source field pointing to llms.txt URL
+
+        Returns:
+            List of IndexEntry objects with title, URL, section, and tags
+
+        Raises:
+            ValueError: If source URL is invalid or entries list is empty
+            httpx.HTTPError: If HTTP request fails
+        """
+        url = index_config.source
+        self._timeout = index_config.timeout
+
+        # Validate URL
+        self._validate_url(url)
+
+        # Initialize client if not already done
+        self._ensure_client()
+
+        logger.debug(f"Fetching llms.txt from {url}")
+
+        try:
+            # Fetch content
+            response = self.client.get(url)
+            response.raise_for_status()
+            content = response.text
+        except httpx.HTTPError as e:
+            logger.error(f"HTTP error fetching {url}: {e}")
+            raise ValueError(f"Failed to fetch index from {url}: {type(e).__name__}") from e
+
+        # Parse the content
+        entries = self._parse_llms_txt(content)
+
+        # Validate non-empty
+        if not entries:
+            raise ValueError(f"No entries found in index at {url}")
+
+        logger.info(f"Parsed {len(entries)} entries from {url}")
+        return entries
+
+    def _parse_llms_txt(self, content: str) -> List[IndexEntry]:
+        """Parse llms.txt content into IndexEntry objects.
+
+        Args:
+            content: Raw llms.txt content
+
+        Returns:
+            List of parsed IndexEntry objects
+        """
+        docs = []
+        lines = content.split("\n")
+
+        # Track current section hierarchy
+        current_section: List[str] = []
+        section_stack: List[tuple[int, str]] = []  # (indent_level, section_name)
+
+        for line in lines:
+            # Skip empty lines and top-level title (single #)
+            if not line.strip() or line.strip().startswith("# "):
+                continue
+
+            # Detect section headers (## Section Name)
+            section_match = re.match(r"^##\s+(.+)$", line)
+            if section_match:
+                section_name = section_match.group(1)
+                # Start fresh section hierarchy from this top-level section
+                current_section = [section_name]
+                section_stack = [(0, section_name)]
+                continue
+
+            # Calculate indentation level
+            indent_match = re.match(r"^(\s*)(.+)$", line)
+            if not indent_match:
+                continue
+
+            indent = len(indent_match.group(1))
+            line_content = indent_match.group(2).strip()
+
+            # Parse markdown link: - [title](url)
+            link_match = re.match(r"-\s+\[(.+?)\]\((.+?)\)", line_content)
+
+            if link_match:
+                title = link_match.group(1)
+                doc_url = link_match.group(2)
+
+                # Build full section path
+                section_path = " > ".join(current_section)
+
+                # Extract tags from title and section
+                tags = self._extract_tags(title, current_section)
+
+                docs.append(
+                    IndexEntry(
+                        title=title,
+                        url=doc_url,
+                        section=section_path,
+                        tags=tags,
+                    )
+                )
+
+            else:
+                # This is a section header without a link (like "- Quickstart" or "  - Agents")
+                # Update the section hierarchy
+                section_name = line_content.lstrip("- ").strip()
+
+                # Adjust section stack based on indentation
+                # Pop sections at deeper or equal indentation levels
+                while section_stack and section_stack[-1][0] > indent:
+                    section_stack.pop()
+
+                section_stack.append((indent, section_name))
+                current_section = [name for _, name in section_stack]
+
+        logger.debug(f"Parsed {len(docs)} documents from index")
+        return docs
+
+    def _extract_tags(self, title: str, section: List[str]) -> List[str]:
+        """Extract searchable tags from title and section.
+
+        Args:
+            title: Document title
+            section: Section hierarchy
+
+        Returns:
+            List of tags for search
+        """
+        tags = []
+
+        # Add section components as tags
+        tags.extend([s.lower() for s in section if s])
+
+        # Split title by common separators and add as tags
+        title_parts = re.split(r"[-_\s]+", title.lower())
+        tags.extend([p for p in title_parts if len(p) > 2])
+
+        # Remove duplicates while preserving order
+        seen = set()
+        unique_tags = []
+        for tag in tags:
+            if tag not in seen:
+                seen.add(tag)
+                unique_tags.append(tag)
+
+        return unique_tags
+
+    def _validate_url(self, url: str) -> None:
+        """Validate URL is safe to fetch.
+
+        Args:
+            url: URL to validate
+
+        Raises:
+            ValueError: If URL is invalid or not allowed
+        """
+        try:
+            parsed = urlparse(url)
+        except Exception as e:
+            raise ValueError(f"Invalid URL format: {url}") from e
+
+        # Must be HTTPS
+        if parsed.scheme != "https":
+            raise ValueError(f"Only HTTPS URLs are allowed, got: {parsed.scheme}")
+
+        # Must be in allowed domains
+        if parsed.netloc not in self.ALLOWED_DOMAINS:
+            raise ValueError(f"Domain not allowed: {parsed.netloc}. Allowed: {self.ALLOWED_DOMAINS}")
+
+    def fetch_content(self, url: str) -> Document:
+        """Fetch and parse a Vercel documentation page.
+
+        Vercel provides markdown versions by appending .md to URLs. This method
+        attempts to fetch the markdown version first, and falls back to HTML if
+        the markdown version is not available (404).
+
+        Args:
+            url: Documentation page URL
+
+        Returns:
+            Document with markdown content (or HTML if markdown unavailable)
+
+        Raises:
+            ValueError: If URL is invalid
+            httpx.HTTPError: If HTTP request fails (non-404 errors)
+        """
+        # Validate URL
+        self._validate_url(url)
+
+        # Initialize client if not already done
+        self._ensure_client()
+
+        # Convert HTML URL to markdown URL by appending .md
+        markdown_url = url if url.endswith(".md") else f"{url}.md"
+
+        logger.debug(f"Fetching markdown content from {markdown_url}")
+
+        try:
+            response = self.client.get(markdown_url)
+            response.raise_for_status()
+            content = response.text
+            content_format = "markdown"
+        except httpx.HTTPStatusError as e:
+            # Fallback to HTML if markdown version doesn't exist
+            if e.response.status_code == 404:
+                logger.warning(f"Markdown not found at {markdown_url}, falling back to HTML")
+                try:
+                    response = self.client.get(url)
+                    response.raise_for_status()
+                    content = response.text
+                    content_format = "html"
+                    logger.info(f"Successfully fetched HTML from {url}")
+                except httpx.HTTPError as html_error:
+                    logger.error(f"Failed to fetch HTML from {url}: {html_error}")
+                    raise
+            else:
+                logger.error(f"HTTP error fetching {markdown_url}: {e}")
+                raise
+        except httpx.HTTPError as e:
+            logger.error(f"HTTP error fetching {markdown_url}: {e}")
+            raise
+
+        # Extract title from first # heading if available
+        title = ""
+        first_line = content.split("\n")[0] if content else ""
+        if first_line.startswith("# "):
+            title = first_line[2:].strip()
+
+        return Document(url=url, content=content, metadata={"title": title, "source": "vercel", "format": content_format})
+
+    def close(self):
+        """Explicitly close HTTP client."""
+        if self.client:
+            self.client.close()
+            self.client = None

--- a/tests/docrs/vercel/__init__.py
+++ b/tests/docrs/vercel/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Vercel docr."""

--- a/tests/docrs/vercel/test_vercel_docr.py
+++ b/tests/docrs/vercel/test_vercel_docr.py
@@ -1,0 +1,329 @@
+"""Tests for Vercel docr."""
+
+from pathlib import Path
+
+import pytest
+
+from docr_mcp.core.search import SearchIndex
+from docr_mcp.docrs.vercel import VercelDocr
+from docr_mcp.models import IndexConfig
+
+# Path to fixtures
+FIXTURES_DIR = Path(__file__).parent.parent.parent / "fixtures" / "vercel"
+
+
+def load_fixture(filename: str) -> str:
+    """Load a test fixture file.
+
+    Args:
+        filename: Name of the fixture file
+
+    Returns:
+        File contents as string
+    """
+    fixture_path = FIXTURES_DIR / filename
+    with open(fixture_path, "r") as f:
+        return f.read()
+
+
+class TestVercelDocr:
+    """Test cases for Vercel docr."""
+
+    def test_parse_index_structure(self):
+        """Test that docr correctly extracts documents with sections."""
+        docr = VercelDocr()
+
+        # Mock the HTTP client with real fixture data
+        class MockResponse:
+            def __init__(self):
+                self.text = load_fixture("llms.txt")
+
+            def raise_for_status(self):
+                pass
+
+        class MockClient:
+            def get(self, url):
+                return MockResponse()
+
+            def close(self):
+                pass
+
+        docr.client = MockClient()
+
+        # Parse index
+        config = IndexConfig(source="https://vercel.com/llms.txt")
+        docs = docr.fetch_index_entries(config)
+
+        # Verify we got documents (full llms.txt has 1700+ entries)
+        assert len(docs) > 1700, f"Should parse 1700+ documents, got {len(docs)}"
+
+        # Check first few documents have expected structure
+        for doc in docs[:5]:
+            assert doc.title
+            assert doc.url
+            assert hasattr(doc, "section")
+            assert hasattr(doc, "tags")
+
+    def test_section_hierarchy(self):
+        """Test that section hierarchy is correctly tracked."""
+        docr = VercelDocr()
+
+        class MockResponse:
+            def __init__(self):
+                self.text = load_fixture("llms.txt")
+
+            def raise_for_status(self):
+                pass
+
+        class MockClient:
+            def get(self, url):
+                return MockResponse()
+
+            def close(self):
+                pass
+
+        docr.client = MockClient()
+
+        config = IndexConfig(source="https://vercel.com/llms.txt")
+        docs = docr.fetch_index_entries(config)
+
+        # Find specific documents and check their sections
+        # Check if Next.js framework exists
+        nextjs = next((d for d in docs if "Next.js" in d.title), None)
+        if nextjs:
+            # Should have section hierarchy
+            assert len(nextjs.section) > 0
+
+        # Check for framework-related sections
+        sections = {d.section for d in docs}
+        assert len(sections) > 0
+
+    def test_tags_extraction(self):
+        """Test that tags are correctly extracted from titles and sections."""
+        docr = VercelDocr()
+
+        class MockResponse:
+            def __init__(self):
+                self.text = load_fixture("llms.txt")
+
+            def raise_for_status(self):
+                pass
+
+        class MockClient:
+            def get(self, url):
+                return MockResponse()
+
+            def close(self):
+                pass
+
+        docr.client = MockClient()
+
+        config = IndexConfig(source="https://vercel.com/llms.txt")
+        docs = docr.fetch_index_entries(config)
+
+        # Check that docs have tags
+        docs_with_tags = [d for d in docs if len(d.tags) > 0]
+        assert len(docs_with_tags) > 0
+
+        # Check a specific doc has relevant tags
+        if docs:
+            first_doc = docs[0]
+            assert len(first_doc.tags) > 0
+
+    def test_url_validation(self):
+        """Test URL validation for Vercel docs."""
+        docr = VercelDocr()
+
+        # Valid Vercel URL
+        docr._validate_url("https://vercel.com/docs/frameworks")
+
+        # Invalid scheme
+        with pytest.raises(ValueError, match="HTTPS"):
+            docr._validate_url("http://vercel.com/docs")
+
+        # Invalid domain
+        with pytest.raises(ValueError, match="not allowed"):
+            docr._validate_url("https://evil.com/docs")
+
+    def test_markdown_url_conversion(self):
+        """Test that HTML URLs are converted to markdown URLs."""
+        docr = VercelDocr()
+
+        class MockResponse:
+            def __init__(self, url):
+                # Verify .md was appended
+                assert url.endswith(".md"), f"Expected markdown URL, got {url}"
+                self.text = "# Test Content\n\nTest markdown content"
+
+            def raise_for_status(self):
+                pass
+
+        class MockClient:
+            def get(self, url):
+                return MockResponse(url)
+
+            def close(self):
+                pass
+
+        docr.client = MockClient()
+
+        # Fetch content - should append .md
+        doc = docr.fetch_content("https://vercel.com/docs/test")
+
+        assert doc.url == "https://vercel.com/docs/test"
+        assert doc.metadata["format"] == "markdown"
+        assert "Test markdown content" in doc.content
+
+    def test_markdown_fallback_to_html(self):
+        """Test fallback to HTML when markdown is not available."""
+        docr = VercelDocr()
+
+        class MockResponse:
+            def __init__(self, url, status_code=200):
+                self.url = url
+                self.status_code = status_code
+                if url.endswith(".md"):
+                    # Simulate 404 for markdown
+                    self.text = ""
+                else:
+                    # Return HTML for non-.md URLs
+                    self.text = "<!DOCTYPE html><html><body><h1>Test HTML Content</h1></body></html>"
+
+            def raise_for_status(self):
+                if self.status_code == 404:
+                    import httpx
+
+                    raise httpx.HTTPStatusError("Not Found", request=None, response=self)
+
+        call_count = {"count": 0}
+
+        class MockClient:
+            def get(self, url):
+                call_count["count"] += 1
+                if url.endswith(".md"):
+                    # First call: markdown 404
+                    return MockResponse(url, status_code=404)
+                else:
+                    # Second call: HTML success
+                    return MockResponse(url, status_code=200)
+
+            def close(self):
+                pass
+
+        docr.client = MockClient()
+
+        # Fetch content - should try .md, get 404, then fallback to HTML
+        doc = docr.fetch_content("https://vercel.com/docs/test")
+
+        assert doc.url == "https://vercel.com/docs/test"
+        assert doc.metadata["format"] == "html"
+        assert "Test HTML Content" in doc.content
+        assert call_count["count"] == 2  # Should have tried both .md and HTML
+
+    def test_full_real_index(self):
+        """Test parsing the full real Vercel llms.txt file."""
+        docr = VercelDocr()
+
+        class MockResponse:
+            def __init__(self):
+                self.text = load_fixture("llms.txt")
+
+            def raise_for_status(self):
+                pass
+
+        class MockClient:
+            def get(self, url):
+                return MockResponse()
+
+            def close(self):
+                pass
+
+        docr.client = MockClient()
+
+        config = IndexConfig(source="https://vercel.com/llms.txt")
+        docs = docr.fetch_index_entries(config)
+
+        # Should have all docs from real file (1742 entries as of 2024)
+        assert len(docs) > 1700, f"Expected 1700+ docs, got {len(docs)}"
+
+        # Verify some known sections exist
+        sections = {d.section for d in docs}
+        # Check for actual sections that exist in Vercel's llms.txt
+        assert any("Build & Deploy" in s for s in sections)
+        assert any("CDN" in s for s in sections)
+        assert any("AI" in s for s in sections)
+
+        # Verify known documentation pages exist
+        titles = {d.title for d in docs}
+        assert any("Next.js" in t for t in titles)
+        assert any("Getting Started" in t for t in titles)
+
+
+class TestSearchWithVercel:
+    """Test search functionality with Vercel documents."""
+
+    def get_sample_docs(self):
+        """Helper to get parsed sample documents."""
+        docr = VercelDocr()
+
+        class MockResponse:
+            def __init__(self):
+                self.text = load_fixture("llms.txt")
+
+            def raise_for_status(self):
+                pass
+
+        class MockClient:
+            def get(self, url):
+                return MockResponse()
+
+            def close(self):
+                pass
+
+        docr.client = MockClient()
+
+        config = IndexConfig(source="https://vercel.com/llms.txt")
+        return docr.fetch_index_entries(config)
+
+    def test_search_by_title(self):
+        """Test searching by title."""
+        docs = self.get_sample_docs()
+        search_index = SearchIndex(docs)
+
+        # Search for a common term in Vercel docs
+        results = search_index.search("Next.js", top_k=5)
+
+        assert len(results) > 0
+        # Should find Next.js related docs
+        assert any("next" in r["title"].lower() for r in results)
+
+    def test_search_by_framework(self):
+        """Test searching for framework names."""
+        docs = self.get_sample_docs()
+        search_index = SearchIndex(docs)
+
+        results = search_index.search("framework", top_k=10)
+
+        assert len(results) > 0
+
+    def test_search_returns_limited_results(self):
+        """Test that search respects top_k limit."""
+        docs = self.get_sample_docs()
+        search_index = SearchIndex(docs)
+
+        results = search_index.search("vercel", top_k=3)
+
+        assert len(results) <= 3
+
+    def test_search_no_match(self):
+        """Test searching for something that doesn't exist."""
+        docs = self.get_sample_docs()
+        search_index = SearchIndex(docs)
+
+        results = search_index.search("nonexistentxyz123", top_k=5)
+
+        assert len(results) == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/fixtures/vercel/__init__.py
+++ b/tests/fixtures/vercel/__init__.py
@@ -1,0 +1,1 @@
+"""Vercel test fixtures."""

--- a/tests/fixtures/vercel/llms.txt
+++ b/tests/fixtures/vercel/llms.txt
@@ -1,0 +1,2017 @@
+# Documentation
+
+# Vercel Documentation
+
+[Vercel Documentation](https://vercel.com/docs): Vercel is the AI Cloud - a unified platform for building, deploying, and scaling AI-powered applications and agentic workloads.
+
+- [Getting Started](https://vercel.com/docs/getting-started-with-vercel): Install the Vercel CLI, add the Vercel Plugin or agent skills, and deploy your first project.
+- [Fundamental Concepts](https://vercel.com/docs/fundamentals): Learn about the core concepts of Vercel
+  - [Request Lifecycle](https://vercel.com/docs/fundamentals/infrastructure): Learn how Vercel routes, secures, and serves requests from your users to your application.
+  - [Build System](https://vercel.com/docs/fundamentals/builds): Learn how Vercel transforms your source code into optimized assets ready to serve globally.
+  - [What is Compute?](https://vercel.com/docs/fundamentals/what-is-compute): Learn about the different models for compute and how they can be used with Vercel.
+- [Supported Frameworks](https://vercel.com/docs/frameworks): Vercel supports a wide range of the most popular frameworks, optimizing how your application builds and runs no matter what tool you use.
+  - [Full-stack](https://vercel.com/docs/frameworks/full-stack): Vercel supports a wide range of the most popular backend frameworks, optimizing how your application builds and runs no matter what tooling you use.
+    - [Next.js](https://vercel.com/docs/frameworks/full-stack/nextjs): Vercel is the native Next.js platform, designed to enhance the Next.js experience.
+    - [SvelteKit](https://vercel.com/docs/frameworks/full-stack/sveltekit): Learn how to use Vercel
+    - [Nuxt](https://vercel.com/docs/frameworks/full-stack/nuxt): Learn how to use Vercel
+    - [Remix](https://vercel.com/docs/frameworks/full-stack/remix): Learn how to use Vercel
+    - [TanStack Start](https://vercel.com/docs/frameworks/full-stack/tanstack-start): Learn how to use Vercel
+    - [Vite + Nitro](https://vercel.com/docs/frameworks/full-stack/vite-with-nitro): Add a backend to any Vite app with Nitro and deploy to Vercel with zero configuration.
+    - [Django](https://vercel.com/docs/frameworks/full-stack/django): Deploy a Django app on Vercel. Learn how the Python runtime, WSGI, ASGI, static assets, and Vercel Functions work together.
+  - [Frontends](https://vercel.com/docs/frameworks/frontend): Vercel supports a wide range of the most popular frontend frameworks, optimizing how your application builds and runs no matter what tooling you use.
+    - [Astro](https://vercel.com/docs/frameworks/frontend/astro): Learn how to use Vercel
+    - [Vite](https://vercel.com/docs/frameworks/frontend/vite): Learn how to use Vercel
+    - [React Router](https://vercel.com/docs/frameworks/frontend/react-router): Learn how to use Vercel
+    - [Create React App](https://vercel.com/docs/frameworks/frontend/create-react-app): Learn how to use Vercel
+  - [Backends](https://vercel.com/docs/frameworks/backend): Vercel supports a wide range of the most popular backend frameworks, optimizing how your application builds and runs no matter what tooling you use.
+    - [Nitro](https://vercel.com/docs/frameworks/backend/nitro): Deploy Nitro applications to Vercel with zero configuration. Learn about observability, ISR, and custom build configurations.
+    - [Express](https://vercel.com/docs/frameworks/backend/express): Deploy Express applications to Vercel with zero configuration. Learn about middleware and Vercel Functions.
+    - [Elysia](https://vercel.com/docs/frameworks/backend/elysia): Build fast TypeScript backends with Elysia and deploy to Vercel. Learn the project structure, plugins, middleware, and how to run locally and in production.
+    - [FastAPI](https://vercel.com/docs/frameworks/backend/fastapi): Deploy a FastAPI app on Vercel. Learn how the Python runtime, ASGI, static assets, and Vercel Functions work together.
+    - [Fastify](https://vercel.com/docs/frameworks/backend/fastify): Deploy Fastify applications to Vercel with zero configuration.
+    - [Flask](https://vercel.com/docs/frameworks/backend/flask): Deploy a Flask app on Vercel. Learn how the Python runtime, WSGI, static assets, and Vercel Functions work together.
+    - [Hono](https://vercel.com/docs/frameworks/backend/hono): Deploy Hono applications to Vercel with zero configuration. Learn about observability, ISR, and custom build configurations.
+    - [Koa](https://vercel.com/docs/frameworks/backend/koa): Deploy Koa applications to Vercel with zero configuration.
+    - [NestJS](https://vercel.com/docs/frameworks/backend/nestjs): Deploy NestJS applications to Vercel with zero configuration.
+    - [xmcp](https://vercel.com/docs/frameworks/backend/xmcp): Build MCP-compatible backends with xmcp and deploy to Vercel. Learn the project structure, tool format, middleware, and how to run locally and in production.
+  - [All Frameworks](https://vercel.com/docs/frameworks/more-frameworks): Learn about the frameworks that can be deployed to Vercel.
+- [Incremental Migration](https://vercel.com/docs/incremental-migration): Learn how to migrate your app or website to Vercel with minimal risk and high impact.
+- [Production Checklist](https://vercel.com/docs/production-checklist): Ensure your application is ready for launch with this comprehensive production checklist by the Vercel engineering team. Covering operational excellence, security, reliability, performance efficiency, and cost optimization.
+- APIs & SDKs
+  - [Marketplace Partner API](https://vercel.com/docs/integrations/create-integration/marketplace-api/reference/partner): Partner API overview page with list of all endpoints
+  - [Marketplace Vercel API](https://vercel.com/docs/integrations/create-integration/marketplace-api/reference/vercel): Vercel API overview page with list of all endpoints
+
+## Access
+- [Account Management](https://vercel.com/docs/accounts): Learn how to manage your Vercel account and team members.
+- [Sign in with Vercel](https://vercel.com/docs/sign-in-with-vercel): Learn how to Sign in with Vercel
+  - [Getting Started](https://vercel.com/docs/sign-in-with-vercel/getting-started): Learn how to get started with Sign in with Vercel
+  - [Scopes & Permissions](https://vercel.com/docs/sign-in-with-vercel/scopes-and-permissions): Learn how to manage scopes and permissions for Sign in with Vercel
+  - [Tokens](https://vercel.com/docs/sign-in-with-vercel/tokens): Learn how to Sign in with Vercel
+  - [Authorization Server API](https://vercel.com/docs/sign-in-with-vercel/authorization-server-api): Learn how to use the Authorization Server API
+  - [Manage from Dashboard](https://vercel.com/docs/sign-in-with-vercel/manage-from-dashboard): Learn how to manage Sign in with Vercel from the Dashboard
+  - [Consent Page](https://vercel.com/docs/sign-in-with-vercel/consent-page): Learn how the consent page works when users authorize your app
+  - [Troubleshooting](https://vercel.com/docs/sign-in-with-vercel/troubleshooting): Learn how to troubleshoot common errors with Sign in with Vercel
+- [Activity Log](https://vercel.com/docs/activity-log): Learn how to use the Activity Log, which provides a list of all events on a team, chronologically organized since its creation.
+- [Deployment Protection](https://vercel.com/docs/deployment-protection): Learn how to control access to your Vercel project
+  - [Bypass Deployment Protection](https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection): Learn how to bypass Deployment Protection for specific domains, or for all deployments in a project.
+    - [Exceptions](https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection/deployment-protection-exceptions): Disable Deployment Protection for a list of preview domains.
+    - [OPTIONS Allowlist](https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection/options-allowlist): Learn how to disable Deployment Protection for CORS preflight requests for a list of paths.
+    - [Protection Bypass for Automation](https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation): Learn how to bypass Vercel Deployment Protection for automated tooling (e.g. E2E testing).
+    - [Sharable Links](https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection/sharable-links): Learn how to share your deployments with external users.
+  - [Protect Deployments](https://vercel.com/docs/deployment-protection/methods-to-protect-deployments): Vercel offers three methods to protect your deployments: Vercel Authentication, Password Protection, and Trusted IPs.
+    - [Password Protection](https://vercel.com/docs/deployment-protection/methods-to-protect-deployments/password-protection): Require visitors to enter a password before they can view your deployments.
+    - [Restrict access to deployments with Vercel Authentication](https://vercel.com/docs/deployment-protection/methods-to-protect-deployments/vercel-authentication): Vercel Authentication restricts access to your deployments so only authorized users can view and comment on your site.
+    - [Trusted IPs](https://vercel.com/docs/deployment-protection/methods-to-protect-deployments/trusted-ips): Trusted IPs let you restrict access to your deployments to a list of allowed IP addresses.
+  - [Automated & Agent Access](https://vercel.com/docs/deployment-protection/automated-agent-access): Grant AI agents, CI/CD pipelines, MCP servers, and testing tools access to Vercel deployments that have Deployment Protection enabled.
+- [Directory Sync](https://vercel.com/docs/directory-sync): Learn how to configure Directory Sync for your Vercel Team.
+- [SAML SSO](https://vercel.com/docs/saml): Learn how to configure SAML SSO for your organization on Vercel.
+- [Two-factor (2FA)](https://vercel.com/docs/two-factor-authentication): Learn how to configure two-factor authentication for your Vercel account.
+
+## AI
+- [Vercel Agent](https://vercel.com/docs/agent): AI-powered development tools that speed up your workflow and help resolve issues faster
+  - [Code Review](https://vercel.com/docs/agent/pr-review): Get automatic AI-powered code reviews on your pull requests
+    - [Managing Reviews](https://vercel.com/docs/agent/pr-review/usage): Customize which repositories get reviewed and track your review metrics and spending.
+  - [Investigation](https://vercel.com/docs/agent/investigation): Let AI investigate your error alerts to help you debug faster
+  - [Installation](https://vercel.com/docs/agent/installation): Let AI automatically install Web Analytics and Speed Insights in your app
+  - [Pricing](https://vercel.com/docs/agent/pricing): Understand how Vercel Agent pricing works and how to manage your credits
+- [AI SDK](https://vercel.com/docs/ai-sdk): TypeScript toolkit for building AI-powered applications with React, Next.js, Vue, Svelte and Node.js
+- [AI Gateway](https://vercel.com/docs/ai-gateway): AI Gateway provides a unified API to access hundreds of AI models through a single endpoint, with built-in budgets, usage monitoring, and fallbacks.
+  - [Getting Started](https://vercel.com/docs/ai-gateway/getting-started): Get started with AI Gateway by generating text, images, or video.
+    - [Text](https://vercel.com/docs/ai-gateway/getting-started/text): Generate and stream text responses using AI Gateway.
+    - [Image](https://vercel.com/docs/ai-gateway/getting-started/image): Generate images from text prompts using AI Gateway.
+    - [Video](https://vercel.com/docs/ai-gateway/getting-started/video): Generate videos from text prompts, images, or video input using AI Gateway.
+  - [Models & Providers](https://vercel.com/docs/ai-gateway/models-and-providers): Learn about models and providers for the AI Gateway.
+    - [Provider Options](https://vercel.com/docs/ai-gateway/models-and-providers/provider-options): Configure provider routing, ordering, and fallback behavior in Vercel AI Gateway
+    - [Model Fallbacks](https://vercel.com/docs/ai-gateway/models-and-providers/model-fallbacks): Configure model-level failover to try backup models when the primary model is unavailable
+    - [Provider Timeouts](https://vercel.com/docs/ai-gateway/models-and-providers/provider-timeouts): Configure per-provider timeouts for fast failover when a provider is slow to respond.
+    - [Automatic Caching](https://vercel.com/docs/ai-gateway/models-and-providers/automatic-caching): Enable automatic prompt caching across providers with AI Gateway to reduce costs and latency.
+    - [Filtering, Ordering & Sorting](https://vercel.com/docs/ai-gateway/models-and-providers/provider-filtering-and-ordering): Control which providers handle your requests, in what order, and how they are ranked using order, only, and sort options.
+    - [Model Variants](https://vercel.com/docs/ai-gateway/models-and-providers/model-variants): Enable provider-specific capabilities via headers when calling models through AI Gateway.
+  - [Capabilities](https://vercel.com/docs/ai-gateway/capabilities): Explore AI Gateway capabilities including reasoning, image generation, video generation, web search, embeddings, reranking, observability, usage tracking, data retention, and prompt training policies.
+    - [Custom Reporting](https://vercel.com/docs/ai-gateway/capabilities/custom-reporting): Query AI Gateway usage data grouped by model, user, tag, provider, or credential type using the Custom Reporting API.
+    - [Observability](https://vercel.com/docs/ai-gateway/capabilities/observability): Learn how to monitor and debug your AI Gateway requests.
+    - [Usage & Billing](https://vercel.com/docs/ai-gateway/capabilities/usage): Monitor your AI Gateway credit balance, usage, and generation details.
+    - [Image Generation](https://vercel.com/docs/ai-gateway/capabilities/image-generation): Generate and edit images using AI models through Vercel AI Gateway with support for multiple providers and modalities.
+      - [Using AI SDK](https://vercel.com/docs/ai-gateway/capabilities/image-generation/ai-sdk): Generate and edit images using AI models through Vercel AI Gateway with the AI SDK.
+      - [Using Chat Completions API](https://vercel.com/docs/ai-gateway/capabilities/image-generation/openai): Generate and edit images using AI models through Vercel AI Gateway with the Chat Completions API.
+    - [Video Generation](https://vercel.com/docs/ai-gateway/capabilities/video-generation): Generate videos from text prompts, images, or video input using AI models through Vercel AI Gateway.
+      - [Text-to-Video](https://vercel.com/docs/ai-gateway/capabilities/video-generation/text-to-video): Generate videos from text prompts using Google Veo, KlingAI, Wan, Grok Imagine Video, or ByteDance Seedance through AI Gateway.
+      - [Image-to-Video](https://vercel.com/docs/ai-gateway/capabilities/video-generation/image-to-video): Animate static images into videos using Google Veo, KlingAI, Wan, Grok Imagine Video, or ByteDance Seedance through AI Gateway.
+      - [Reference-to-Video](https://vercel.com/docs/ai-gateway/capabilities/video-generation/reference-to-video): Generate videos featuring characters from reference images or videos using Wan through AI Gateway.
+      - [Motion Control](https://vercel.com/docs/ai-gateway/capabilities/video-generation/motion-control): Transfer motion from a reference video to a character image using KlingAI through AI Gateway.
+      - [Video Editing](https://vercel.com/docs/ai-gateway/capabilities/video-generation/video-editing): Edit existing videos using text prompts with Grok Imagine Video through AI Gateway.
+    - [Web Search](https://vercel.com/docs/ai-gateway/capabilities/web-search): Enable AI models to search the web for current information using built-in tools through AI Gateway.
+    - [Embeddings](https://vercel.com/docs/ai-gateway/capabilities/embeddings): Generate vector embeddings for semantic search, similarity matching, and retrieval-augmented generation (RAG) through Vercel AI Gateway.
+    - [Reasoning](https://vercel.com/docs/ai-gateway/capabilities/reasoning): Enable reasoning and extended thinking across providers with the AI SDK and AI Gateway.
+      - [OpenAI](https://vercel.com/docs/ai-gateway/capabilities/reasoning/openai): Configure reasoning and thinking for OpenAI models with the AI SDK and AI Gateway.
+      - [Anthropic](https://vercel.com/docs/ai-gateway/capabilities/reasoning/anthropic): Configure extended thinking for Anthropic Claude models with the AI SDK and AI Gateway.
+      - [Google / Vertex](https://vercel.com/docs/ai-gateway/capabilities/reasoning/google): Configure thinking for Google Gemini and Gemma models with the AI SDK and AI Gateway.
+      - [Amazon Bedrock](https://vercel.com/docs/ai-gateway/capabilities/reasoning/amazon-bedrock): Configure reasoning for models hosted on Amazon Bedrock with the AI SDK and AI Gateway.
+    - [Reranking](https://vercel.com/docs/ai-gateway/capabilities/reranking): Rerank documents by relevance to a search query for improved retrieval-augmented generation (RAG) pipelines through Vercel AI Gateway.
+    - [Zero Data Retention](https://vercel.com/docs/ai-gateway/capabilities/zdr): Learn about zero data retention policies and how to enforce ZDR on a per-request basis with AI Gateway.
+    - [Disallow Prompt Training](https://vercel.com/docs/ai-gateway/capabilities/disallow-prompt-training): Learn how to prevent AI providers from using your prompts and responses for model training through AI Gateway.
+    - [Service Tiers](https://vercel.com/docs/ai-gateway/capabilities/service-tiers): Control processing priority and cost for OpenAI models using service tiers through AI Gateway, available via all supported APIs.
+  - [SDKs & APIs](https://vercel.com/docs/ai-gateway/sdks-and-apis): Use the AI Gateway with various SDKs and API specifications including OpenAI, Anthropic, and OpenResponses.
+    - [AI SDK](https://vercel.com/docs/ai-gateway/sdks-and-apis/ai-sdk): Build AI-powered TypeScript applications using the AI SDK with AI Gateway for unified access to 200+ models.
+    - [OpenAI Responses API](https://vercel.com/docs/ai-gateway/sdks-and-apis/responses): Use the OpenAI Responses API with AI Gateway to generate text, call tools, stream tokens, and more across any supported provider.
+    - [OpenAI Chat Completions API](https://vercel.com/docs/ai-gateway/sdks-and-apis/openai-chat-completions): Use the OpenAI Chat Completions API with AI Gateway for seamless integration with existing tools and libraries.
+      - [Chat Completions](https://vercel.com/docs/ai-gateway/sdks-and-apis/openai-chat-completions/chat-completions): Create chat completions using the Chat Completions API with support for streaming, image attachments, and PDF documents.
+      - [Tool Calls](https://vercel.com/docs/ai-gateway/sdks-and-apis/openai-chat-completions/tool-calls): Use function calling with the Chat Completions API to enable models to call tools and functions through AI Gateway.
+      - [Structured Outputs](https://vercel.com/docs/ai-gateway/sdks-and-apis/openai-chat-completions/structured-outputs): Generate structured JSON responses that conform to a specific schema using the Chat Completions API.
+      - [Advanced](https://vercel.com/docs/ai-gateway/sdks-and-apis/openai-chat-completions/advanced): Configure reasoning, provider options, model fallbacks, BYOK credentials, and prompt caching.
+      - [Embeddings](https://vercel.com/docs/ai-gateway/sdks-and-apis/openai-chat-completions/embeddings): Generate vector embeddings from input text for semantic search, similarity matching, and RAG applications.
+      - [Image Generation](https://vercel.com/docs/ai-gateway/sdks-and-apis/openai-chat-completions/image-generation): Generate images using AI models that support multimodal output through the Chat Completions API.
+      - [REST API](https://vercel.com/docs/ai-gateway/sdks-and-apis/openai-chat-completions/rest-api): Use the AI Gateway API directly without client libraries using curl and fetch.
+    - [Anthropic Messages API](https://vercel.com/docs/ai-gateway/sdks-and-apis/anthropic-messages-api): Use the Anthropic Messages API with AI Gateway for seamless integration with Anthropic SDK tools.
+      - [Messages](https://vercel.com/docs/ai-gateway/sdks-and-apis/anthropic-messages-api/messages): Create messages using the Anthropic Messages API format with support for streaming.
+      - [Tool Calls](https://vercel.com/docs/ai-gateway/sdks-and-apis/anthropic-messages-api/tool-calls): Use function calling with the Anthropic Messages API to allow models to call tools and functions.
+      - [Advanced](https://vercel.com/docs/ai-gateway/sdks-and-apis/anthropic-messages-api/advanced): Advanced Anthropic API features including extended thinking, web search, and automatic caching.
+      - [File Attachments](https://vercel.com/docs/ai-gateway/sdks-and-apis/anthropic-messages-api/file-attachments): Send images and PDF documents as part of your Anthropic API message requests.
+      - [Structured Outputs](https://vercel.com/docs/ai-gateway/sdks-and-apis/anthropic-messages-api/structured-outputs): Get JSON responses conforming to a JSON Schema from Anthropic models through AI Gateway.
+    - [OpenResponses API](https://vercel.com/docs/ai-gateway/sdks-and-apis/openresponses): Use the OpenResponses API specification with AI Gateway for a unified, provider-agnostic interface.
+      - [Text Generation](https://vercel.com/docs/ai-gateway/sdks-and-apis/openresponses/text-generation): Generate text responses using the OpenResponses API.
+      - [Streaming](https://vercel.com/docs/ai-gateway/sdks-and-apis/openresponses/streaming): Stream responses token by token using the OpenResponses API.
+      - [Image Input](https://vercel.com/docs/ai-gateway/sdks-and-apis/openresponses/image-input): Send images for analysis using the OpenResponses API.
+      - [Tool Calling](https://vercel.com/docs/ai-gateway/sdks-and-apis/openresponses/tool-calling): Define tools the model can call using the OpenResponses API.
+      - [Provider Options](https://vercel.com/docs/ai-gateway/sdks-and-apis/openresponses/provider-options): Configure provider routing, fallbacks, and restrictions using the OpenResponses API.
+    - [Python](https://vercel.com/docs/ai-gateway/sdks-and-apis/python): Use the AI Gateway with Python through OpenAI or Anthropic SDKs with full streaming, tool calling, and async support.
+  - [Authentication & BYOK](https://vercel.com/docs/ai-gateway/authentication-and-byok): Learn how to authenticate with the AI Gateway and configure your own provider keys.
+    - [Authentication](https://vercel.com/docs/ai-gateway/authentication-and-byok/authentication): Learn how to authenticate with the AI Gateway using API keys and OIDC tokens.
+    - [BYOK](https://vercel.com/docs/ai-gateway/authentication-and-byok/byok): Learn how to configure your own provider keys with the AI Gateway.
+  - [Ecosystem](https://vercel.com/docs/ai-gateway/ecosystem): Explore community framework integrations and ecosystem features for the AI Gateway.
+    - [Framework Integrations](https://vercel.com/docs/ai-gateway/ecosystem/framework-integrations): Explore available community framework integrations with Vercel AI Gateway
+      - [LangChain](https://vercel.com/docs/ai-gateway/ecosystem/framework-integrations/langchain): Learn how to integrate Vercel AI Gateway with LangChain to access multiple AI models through a unified interface
+      - [LangFuse](https://vercel.com/docs/ai-gateway/ecosystem/framework-integrations/langfuse): Learn how to integrate Vercel AI Gateway with LangFuse to access multiple AI models through a unified interface
+      - [LiteLLM](https://vercel.com/docs/ai-gateway/ecosystem/framework-integrations/litellm): Learn how to integrate Vercel AI Gateway with LiteLLM to access multiple AI models through a unified interface
+      - [LlamaIndex](https://vercel.com/docs/ai-gateway/ecosystem/framework-integrations/llamaindex): Learn how to integrate Vercel AI Gateway with LlamaIndex to access multiple AI models through a unified interface
+      - [Mastra](https://vercel.com/docs/ai-gateway/ecosystem/framework-integrations/mastra): Learn how to integrate Vercel AI Gateway with Mastra to access multiple AI models through a unified interface
+      - [Pydantic AI](https://vercel.com/docs/ai-gateway/ecosystem/framework-integrations/pydantic-ai): Learn how to integrate Vercel AI Gateway with Pydantic AI to access multiple AI models through a unified interface
+    - [App Attribution](https://vercel.com/docs/ai-gateway/ecosystem/app-attribution): Attribute your requests so Vercel can identify and feature your app on AI Gateway pages
+    - [Stripe Billing](https://vercel.com/docs/ai-gateway/ecosystem/stripe-billing): Add usage-based billing to your AI application with Stripe and AI Gateway.
+  - [Pricing](https://vercel.com/docs/ai-gateway/pricing): Learn about pricing for AI Gateway.
+  - [Chat Platforms](https://vercel.com/docs/ai-gateway/chat-platforms): Configure AI chat platforms to use the AI Gateway for unified model access and spend monitoring.
+    - [LibreChat](https://vercel.com/docs/ai-gateway/chat-platforms/librechat): Use LibreChat with the AI Gateway.
+    - [OpenClaw (Clawdbot)](https://vercel.com/docs/ai-gateway/chat-platforms/openclaw): Use OpenClaw (formerly Clawdbot) with AI Gateway.
+    - [Chatbox](https://vercel.com/docs/ai-gateway/chat-platforms/chatbox): Use Chatbox with the AI Gateway.
+    - [Open WebUI](https://vercel.com/docs/ai-gateway/chat-platforms/open-webui): Use Open WebUI with the AI Gateway.
+- [MCP](https://vercel.com/docs/mcp): Learn more about MCP and how you can use it on Vercel.
+  - [Deploy MCP servers](https://vercel.com/docs/mcp/deploy-mcp-servers-to-vercel): Learn how to deploy Model Context Protocol (MCP) servers on Vercel with OAuth authentication and efficient scaling.
+- [Agent Resources](https://vercel.com/docs/agent-resources): Resources for building with AI on Vercel, including documentation access, MCP servers, and agent skills.
+  - [Markdown Access](https://vercel.com/docs/agent-resources/markdown-access): Access Vercel documentation as markdown using .md endpoints or the copy button.
+  - [Vercel Plugin](https://vercel.com/docs/agent-resources/vercel-plugin): Install the Vercel plugin to give supported AI coding tools Vercel context, skills, specialist agents, slash commands, and lightweight session-start activation.
+  - [Vercel MCP server](https://vercel.com/docs/agent-resources/vercel-mcp): Vercel MCP has tools available for searching docs along with managing teams, projects, and deployments.
+    - [Tools](https://vercel.com/docs/agent-resources/vercel-mcp/tools): Available tools in Vercel MCP for searching docs, managing teams, projects, deployments, and viewing runtime logs.
+  - [Coding Agents](https://vercel.com/docs/agent-resources/coding-agents): Configure popular AI coding agents to use the AI Gateway for unified model access and spend monitoring.
+    - [Claude Code](https://vercel.com/docs/agent-resources/coding-agents/claude-code): Use Claude Code and the Claude Agent SDK with AI Gateway.
+    - [Conductor](https://vercel.com/docs/agent-resources/coding-agents/conductor): Use Conductor with the AI Gateway.
+    - [OpenAI Codex](https://vercel.com/docs/agent-resources/coding-agents/openai-codex): Use OpenAI Codex CLI with the AI Gateway.
+    - [Roo Code](https://vercel.com/docs/agent-resources/coding-agents/roo-code): Use Roo Code with the AI Gateway.
+    - [Cline](https://vercel.com/docs/agent-resources/coding-agents/cline): Use Cline with the AI Gateway.
+    - [Blackbox AI](https://vercel.com/docs/agent-resources/coding-agents/blackbox): Use the Blackbox AI CLI with the AI Gateway.
+    - [Crush](https://vercel.com/docs/agent-resources/coding-agents/crush): Use Crush with the AI Gateway.
+    - [OpenCode](https://vercel.com/docs/agent-resources/coding-agents/opencode): Use OpenCode with the AI Gateway.
+    - [Superset](https://vercel.com/docs/agent-resources/coding-agents/superset): Use Superset with the AI Gateway.
+  - [Integrations for Agents](https://vercel.com/docs/agent-resources/integrations-for-agents): Install AI agents and services through the Vercel Marketplace to automate workflows and build custom AI systems.
+  - [Integrations for Models](https://vercel.com/docs/agent-resources/integrations-for-models): Integrate powerful AI services and models seamlessly into your Vercel projects.
+    - [Adding a Provider](https://vercel.com/docs/agent-resources/integrations-for-models/adding-a-provider): Learn how to add a new AI provider to your Vercel projects.
+    - [Adding a Model](https://vercel.com/docs/agent-resources/integrations-for-models/adding-a-model): Learn how to add a new AI model to your Vercel projects
+    - [xAI](https://vercel.com/docs/agent-resources/integrations-for-models/xai): Learn how to add the xAI native integration with Vercel.
+    - [Groq](https://vercel.com/docs/agent-resources/integrations-for-models/groq): Learn how to add the Groq native integration with Vercel.
+    - [fal](https://vercel.com/docs/agent-resources/integrations-for-models/fal): Learn how to add the fal native integration with Vercel.
+    - [Deep Infra](https://vercel.com/docs/agent-resources/integrations-for-models/deepinfra): Learn how to add the Deep Infra native integration with Vercel.
+    - [ElevenLabs](https://vercel.com/docs/agent-resources/integrations-for-models/elevenlabs): Learn how to add the ElevenLabs connectable account integration with Vercel.
+    - [LMNT](https://vercel.com/docs/agent-resources/integrations-for-models/lmnt): Learn how to add LMNT connectable account integration with Vercel.
+    - [OpenAI](https://vercel.com/docs/agent-resources/integrations-for-models/openai): Integrate your Vercel project with OpenAI
+    - [Perplexity](https://vercel.com/docs/agent-resources/integrations-for-models/perplexity): Learn how to add Perplexity connectable account integration with Vercel.
+    - [Pinecone](https://vercel.com/docs/agent-resources/integrations-for-models/pinecone): Learn how to add Pinecone connectable account integration with Vercel.
+    - [Replicate](https://vercel.com/docs/agent-resources/integrations-for-models/replicate): Learn how to add Replicate connectable account integration with Vercel.
+    - [Together AI](https://vercel.com/docs/agent-resources/integrations-for-models/togetherai): Learn how to add Together AI connectable account integration with Vercel.
+  - [CLI Workflows](https://vercel.com/docs/agent-resources/workflows): End-to-end workflows that show how to compose Vercel CLI commands into complete debugging, deployment, and recovery sessions.
+  - [Skills](https://vercel.com/docs/agent-resources/skills): Install skills to enhance AI coding agents with specialized capabilities for React, Next.js, deployment, and more.
+
+## Build & Deploy
+- [Builds](https://vercel.com/docs/builds): Understand how the build step works when creating a Vercel Deployment.
+  - [Build Features](https://vercel.com/docs/builds/build-features): Learn how to customize your deployments using Vercel
+  - [Build Image](https://vercel.com/docs/builds/build-image): Learn about the container image used for Vercel builds.
+  - [Build Queues](https://vercel.com/docs/builds/build-queues): Understand how concurrency and same branch build queues manage multiple simultaneous deployments.
+  - [Configuring a Build](https://vercel.com/docs/builds/configure-a-build): Vercel automatically configures the build settings for many front-end frameworks, but you can also customize the build according to your requirements.
+  - [Managing Builds](https://vercel.com/docs/builds/managing-builds): Vercel allows you to increase the speed of your builds when needed in specific situations and workflows.
+- [Deploy Hooks](https://vercel.com/docs/deploy-hooks): Learn how to create and trigger deploy hooks to integrate Vercel deployments with other systems.
+- [Deployment Checks](https://vercel.com/docs/deployment-checks): Set conditions that must be met before proceeding to the next phase of the deployment lifecycle.
+- [Deployment Retention](https://vercel.com/docs/deployment-retention): Learn how Deployment Retention policies affect a deployment
+- [Deployments](https://vercel.com/docs/deployments): Learn how to create and manage deployments on Vercel.
+  - [Environments](https://vercel.com/docs/deployments/environments): Environments are for developing locally, testing changes in a pre-production environment, and serving end-users in production.
+  - [Generated URLs](https://vercel.com/docs/deployments/generated-urls): When you create a new deployment, Vercel will automatically generate a unique URL which you can use to access that particular deployment.
+  - [Managing Deployments](https://vercel.com/docs/deployments/managing-deployments): Learn how to manage your current and previously deployed projects to Vercel through the dashboard. You can redeploy at any time and even delete a deployment.
+  - [Promoting Deployments](https://vercel.com/docs/deployments/promoting-a-deployment): Learn how to promote deployments to production on Vercel.
+  - [Troubleshoot Build Errors](https://vercel.com/docs/deployments/troubleshoot-a-build): Learn how to resolve common scenarios you may encounter during the Build step, including build errors that cancel a deployment and long build times.
+  - [Accessing Build Logs](https://vercel.com/docs/deployments/logs): Learn how to use Vercel
+  - [Claim Deployments](https://vercel.com/docs/deployments/claim-deployments): Learn how to take ownership of deployments on Vercel with the Claim Deployments feature.
+  - [Inspect OG Metadata](https://vercel.com/docs/deployments/og-preview): Learn how to inspect and validate your Open Graph metadata through the Open Graph deployment tab.
+  - [Preview Deployment Suffix](https://vercel.com/docs/deployments/preview-deployment-suffix): When you create a new deployment, Vercel will automatically generate a unique URL which you can use to access that particular deployment.
+  - [Promote Preview to Production](https://vercel.com/docs/deployments/promote-preview-to-production): Test a preview deployment and promote it to production using the CLI.
+  - [Rollback Production](https://vercel.com/docs/deployments/rollback-production-deployment): Recover from a bad production deployment by rolling back, investigating the root cause, and redeploying a fix.
+  - [Sharing a Preview Deployment](https://vercel.com/docs/deployments/sharing-deployments): Learn how to share a preview deployment with your team and external collaborators.
+  - [Troubleshoot project collaboration](https://vercel.com/docs/deployments/troubleshoot-project-collaboration): Learn about common reasons for deployment issues related to team member requirements and how to resolve them.
+- [Environment Variables](https://vercel.com/docs/environment-variables): Learn more about environment variables on Vercel.
+  - [Framework Environment Variables](https://vercel.com/docs/environment-variables/framework-environment-variables): Framework environment variables are automatically populated by the Vercel, based on your project
+  - [Manage Across Environments](https://vercel.com/docs/environment-variables/manage-across-environments): Add, sync, and verify environment variables across development, preview, production, and custom environments using the CLI.
+  - [Managing Environment Variables](https://vercel.com/docs/environment-variables/managing-environment-variables): Learn how to create and manage environment variables for Vercel.
+  - [Reserved Environment Variables](https://vercel.com/docs/environment-variables/reserved-environment-variables): Reserved environment variables are reserved by Vercel Vercel Function runtimes.
+  - [Rotating Environment Variables](https://vercel.com/docs/environment-variables/rotating-secrets): Safely rotate API keys, tokens, and other secrets in your Vercel environment variables.
+  - [Sensitive Environment Variables](https://vercel.com/docs/environment-variables/sensitive-environment-variables): Environment variables that cannot be decrypted once created.
+  - [Shared Environment Variables](https://vercel.com/docs/environment-variables/shared-environment-variables): Learn how to use Shared environment variables, which are environment variables that you define at the Team level and can link to multiple projects.
+  - [System Environment Variables](https://vercel.com/docs/environment-variables/system-environment-variables): System environment variables are automatically populated by Vercel, such as the URL of the deployment or the name of the Git branch deployed.
+- [Git Integrations](https://vercel.com/docs/git): Vercel allows for automatic deployments on every branch push and merges onto the production branch of your GitHub, GitLab, and Bitbucket projects.
+  - [GitHub](https://vercel.com/docs/git/vercel-for-github): Vercel for GitHub automatically deploys your GitHub projects with Vercel, providing Preview Deployment URLs, and automatic Custom Domain updates.
+  - [Azure DevOps](https://vercel.com/docs/git/vercel-for-azure-pipelines): ​Vercel for Azure DevOps allows you to deploy from Azure Pipelines to Vercel automatically.
+  - [Bitbucket](https://vercel.com/docs/git/vercel-for-bitbucket): ​Vercel for Bitbucket automatically deploys your Bitbucket projects with Vercel, providing Preview Deployment URLs, and automatic Custom Domain updates.
+  - [GitLab](https://vercel.com/docs/git/vercel-for-gitlab): ​Vercel for GitLab automatically deploys your GitLab projects with Vercel, providing Preview Deployment URLs, and automatic Custom Domain updates.
+- [Instant Rollback](https://vercel.com/docs/instant-rollback): Learn how to perform an Instant Rollback on your production deployments and quickly roll back to a previously deployed production deployment.
+- [Microfrontends](https://vercel.com/docs/microfrontends): Learn how to use microfrontends on Vercel to split apart large applications, improve developer experience and make incremental migrations easier.
+  - [Getting Started](https://vercel.com/docs/microfrontends/quickstart): Learn how to get started with microfrontends on Vercel.
+  - [Local Development](https://vercel.com/docs/microfrontends/local-development): Learn how to run and test your microfrontends locally.
+  - [Path Routing](https://vercel.com/docs/microfrontends/path-routing): Route paths on your domain to different microfrontends.
+  - [Configuration](https://vercel.com/docs/microfrontends/configuration): Configure your microfrontends.json.
+  - [Managing Microfrontends](https://vercel.com/docs/microfrontends/managing-microfrontends): Learn how to manage your microfrontends on Vercel.
+    - [Security](https://vercel.com/docs/microfrontends/managing-microfrontends/security): Learn how to manage your Deployment Protection and Firewall for your microfrontend on Vercel.
+    - [Using Vercel Toolbar](https://vercel.com/docs/microfrontends/managing-microfrontends/vercel-toolbar): Learn how to use the Vercel Toolbar to make it easier to manage microfrontends.
+  - [Testing & Troubleshooting](https://vercel.com/docs/microfrontends/troubleshooting): Learn about testing, common issues, and how to troubleshoot microfrontends on Vercel.
+- [Monorepos](https://vercel.com/docs/monorepos): Vercel provides support for monorepos. Learn how to deploy a monorepo here.
+  - [Turborepo](https://vercel.com/docs/monorepos/turborepo): Learn about Turborepo, a build system for monorepos that allows you to have faster incremental builds, content-aware hashing, and Remote Caching.
+  - [Remote Caching](https://vercel.com/docs/monorepos/remote-caching): Vercel Remote Cache allows you to share build outputs and artifacts across distributed teams.
+  - [Nx](https://vercel.com/docs/monorepos/nx): Nx is an extensible build system with support for monorepos, integrations, and Remote Caching on Vercel. Learn how to deploy Nx to Vercel with this guide.
+  - [Monorepos FAQ](https://vercel.com/docs/monorepos/monorepo-faq): Learn the answer to common questions about deploying monorepos on Vercel.
+- [Package Managers](https://vercel.com/docs/package-managers): Discover the package managers supported by Vercel for dependency management. Learn how Vercel detects and uses npm, Yarn, pnpm, and Bun for optimal build performance.
+- [Restricting Git Connections to a single Vercel team](https://vercel.com/docs/protected-git-scopes): Information to stop developers from deploying their repositories to a personal Vercel account by using Protected Git Scopes.
+- [Rolling Releases](https://vercel.com/docs/rolling-releases): Learn how to use Rolling Releases for more cautious deployments.
+  - [Rolling Release Deployment](https://vercel.com/docs/rolling-releases/rolling-release-deployment): Gradually roll out a production deployment using traffic stages, monitoring, and automated abort.
+- [Services](https://vercel.com/docs/services): Deploy multiple backends and frontends within a single Vercel project using services.
+  - [Routing](https://vercel.com/docs/services/routing): Learn how Vercel routes requests between services and how services communicate with each other.
+- [Skew Protection](https://vercel.com/docs/skew-protection): Learn how Vercel
+- [Webhooks](https://vercel.com/docs/webhooks): Learn how to set up webhooks and use them with Vercel Integrations.
+  - [Webhooks API Reference](https://vercel.com/docs/webhooks/webhooks-api): Vercel Integrations allow you to subscribe to certain trigger-based events through webhooks. Learn about the supported webhook events and how to use them.
+
+## CDN
+- [Overview](https://vercel.com/docs/cdn): Vercel
+- [How Vercel CDN works](https://vercel.com/docs/how-vercel-cdn-works): Learn how Vercel
+  - [Compression](https://vercel.com/docs/how-vercel-cdn-works/compression): Vercel helps reduce data transfer and improve performance by supporting both Gzip and Brotli compression
+- [Global Network & Regions](https://vercel.com/docs/regions): View the list of regions supported by Vercel
+- [Routing](https://vercel.com/docs/routing): Learn how Vercel
+  - [Redirects](https://vercel.com/docs/routing/redirects): Learn how to use redirects on Vercel to instruct Vercel
+    - [Configuration Redirects](https://vercel.com/docs/routing/redirects/configuration-redirects): Learn how to define static redirects in your framework configuration or vercel.json with support for wildcards, pattern matching, and geolocation.
+    - [Bulk Redirects](https://vercel.com/docs/routing/redirects/bulk-redirects): Learn how to import thousands of simple redirects from CSV, JSON, or JSONL files.
+      - [Getting Started](https://vercel.com/docs/routing/redirects/bulk-redirects/getting-started): Learn how to import thousands of simple redirects from CSV, JSON, or JSONL files.
+  - [Rewrites](https://vercel.com/docs/routing/rewrites): Learn how to use rewrites to send users to different URLs without modifying the visible URL.
+  - [Project Routing Rules](https://vercel.com/docs/routing/project-routing-rules): Add redirects, rewrites, headers, and status codes to your project from the dashboard or API, without deploying new code.
+- [Security](https://vercel.com/docs/cdn-security): Learn how Vercel
+  - [Encryption & TLS](https://vercel.com/docs/cdn-security/encryption): Learn how Vercel encrypts data in transit and at rest.
+  - [Security Headers](https://vercel.com/docs/cdn-security/security-headers): Learn how the Content Security Policy (CSP) offers defense against web vulnerabilities, its key features, and best practices.
+- [Incremental Static Regeneration](https://vercel.com/docs/incremental-static-regeneration): ISR serves cached static pages while regenerating content in the background. Vercel\
+  - [Getting Started](https://vercel.com/docs/incremental-static-regeneration/quickstart): Learn how to set up Incremental Static Regeneration (ISR) with time-based and on-demand revalidation.
+  - [Usage & Pricing](https://vercel.com/docs/incremental-static-regeneration/limits-and-pricing): Learn about ISR costs, usage metrics, and strategies to optimize your ISR reads and writes.
+  - [Request Collapsing](https://vercel.com/docs/incremental-static-regeneration/request-collapsing): Learn how Vercel
+- [Caching](https://vercel.com/docs/caching): Learn how Vercel caches content across multiple layers to deliver fast responses and reduce load on your backend.
+  - [CDN Cache](https://vercel.com/docs/caching/cdn-cache): Learn how Vercel
+    - [Purge CDN Cache](https://vercel.com/docs/caching/cdn-cache/purge): Learn how to invalidate and delete cached content on Vercel
+  - [Runtime Cache](https://vercel.com/docs/caching/runtime-cache): Vercel Runtime Cache is a specialized cache that stores responses from data fetches in Vercel functions
+    - [Data Cache](https://vercel.com/docs/caching/runtime-cache/data-cache): Vercel Data Cache is a specialized cache that stores responses from data fetches in Next.js App Router
+  - [Cache-Control Headers](https://vercel.com/docs/caching/cache-control-headers): Learn about the cache-control headers sent to each Vercel deployment and how to use them to control the caching behavior of your application.
+- [System Headers](https://vercel.com/docs/headers): This reference covers the list of request, response, cache-control, and custom response headers included with deployments with Vercel.
+  - [Request Headers](https://vercel.com/docs/headers/request-headers): Learn about the request headers sent to each Vercel deployment and how to use them to process requests before sending a response.
+  - [Response Headers](https://vercel.com/docs/headers/response-headers): Learn about the response headers sent to each Vercel deployment and how to use them to process responses before sending a response.
+- [Image Optimization](https://vercel.com/docs/image-optimization): Transform and optimize images to improve page load performance.
+  - [Getting Started](https://vercel.com/docs/image-optimization/quickstart): Learn how you can leverage Vercel Image Optimization in your projects.
+  - [Limits and Pricing](https://vercel.com/docs/image-optimization/limits-and-pricing): This page outlines information on the limits that are applicable when using Image Optimization, and the costs they can incur.
+  - [Managing Usage & Costs](https://vercel.com/docs/image-optimization/managing-image-optimization-costs): Learn how to measure and manage Image Optimization usage with this guide to avoid any unexpected costs.
+  - [Legacy Pricing](https://vercel.com/docs/image-optimization/legacy-pricing): This page outlines information on the pricing and limits for the source images-based legacy option.
+- [Custom Error Pages](https://vercel.com/docs/custom-error-pages): Learn how to configure custom error pages for 5xx server errors on Vercel.
+- [Pricing & Usage](https://vercel.com/docs/manage-cdn-usage): Understand CDN pricing resources, monitor usage from your dashboard, and optimize Fast Data Transfer, Fast Origin Transfer, and CDN Requests.
+
+## CLI
+- [Deploying from CLI](https://vercel.com/docs/cli/deploying-from-cli): Learn how to deploy your Vercel Projects from Vercel CLI using the vercel or vercel deploy commands.
+- [Project Linking](https://vercel.com/docs/cli/project-linking): Learn how to link existing Vercel Projects with Vercel CLI.
+- [Telemetry](https://vercel.com/docs/cli/about-telemetry): Vercel CLI collects telemetry data about general usage.
+- [Global Options](https://vercel.com/docs/cli/global-options): Global options are commonly available to use with multiple Vercel CLI commands. Learn about Vercel CLI
+- [vercel activity](https://vercel.com/docs/cli/activity): View activity events for your Vercel project or team, filtered by type, date range, and project.
+- [vercel alerts](https://vercel.com/docs/cli/alerts): List recent alerts for a linked project, a specific project, or an entire team with the Vercel CLI.
+- [vercel alias](https://vercel.com/docs/cli/alias): Learn how to apply custom domain aliases to your Vercel deployments using the vercel alias CLI command.
+- [vercel api](https://vercel.com/docs/cli/api): Learn how to make authenticated HTTP requests to the Vercel API using the vercel api CLI command.
+- [vercel bisect](https://vercel.com/docs/cli/bisect): Learn how to perform a binary search on your deployments to help surface issues using the vercel bisect CLI command.
+- [vercel blob](https://vercel.com/docs/cli/blob): Learn how to interact with Vercel Blob storage using the vercel blob CLI command.
+- [vercel build](https://vercel.com/docs/cli/build): Learn how to build a Vercel Project locally or in your own CI environment using the vercel build CLI command.
+- [vercel buy](https://vercel.com/docs/cli/buy): Learn how to purchase Vercel products like credits, addons, subscriptions, and domains using the vercel buy CLI command.
+- [vercel cache](https://vercel.com/docs/cli/cache): Learn how to manage cache for your project using the vercel cache CLI command.
+- [vercel certs](https://vercel.com/docs/cli/certs): Learn how to manage certificates for your domains using the vercel certs CLI command.
+- [vercel contract](https://vercel.com/docs/cli/contract): Learn how to view contract commitment information for your Vercel account using the vercel contract CLI command.
+- [vercel curl](https://vercel.com/docs/cli/curl): Learn how to make HTTP requests to your Vercel deployments with automatic deployment protection bypass using the vercel curl CLI command.
+- [vercel deploy](https://vercel.com/docs/cli/deploy): Learn how to deploy your Vercel projects using the vercel deploy CLI command.
+- [vercel dev](https://vercel.com/docs/cli/dev): Learn how to replicate the Vercel deployment environment locally and test your Vercel Project before deploying using the vercel dev CLI command.
+- [vercel dns](https://vercel.com/docs/cli/dns): Learn how to manage your DNS records for your domains using the vercel dns CLI command.
+- [vercel domains](https://vercel.com/docs/cli/domains): Learn how to buy, sell, transfer, and manage your domains using the vercel domains CLI command.
+- [vercel env](https://vercel.com/docs/cli/env): Learn how to manage your environment variables in your Vercel Projects using the vercel env CLI command.
+- [vercel flags](https://vercel.com/docs/cli/flags): Learn how to manage feature flags for your Vercel project using the vercel flags CLI command.
+- [vercel git](https://vercel.com/docs/cli/git): Learn how to manage your Git provider connections using the vercel git CLI command.
+- [vercel guidance](https://vercel.com/docs/cli/guidance): Enable or disable guidance messages in the Vercel CLI using the vercel guidance command.
+- [vercel help](https://vercel.com/docs/cli/help): Learn how to use the vercel help CLI command to get information about all available Vercel CLI commands.
+- [vercel httpstat](https://vercel.com/docs/cli/httpstat): Learn how to visualize HTTP request timing statistics for your Vercel deployments using the vercel httpstat CLI command.
+- [vercel init](https://vercel.com/docs/cli/init): Learn how to initialize Vercel supported framework examples locally using the vercel init CLI command.
+- [vercel inspect](https://vercel.com/docs/cli/inspect): Learn how to retrieve information about your Vercel deployments using the vercel inspect CLI command.
+- [vercel install](https://vercel.com/docs/cli/install): Learn how to install marketplace native integrations and provision resources with the vercel install CLI command.
+- [vercel integration](https://vercel.com/docs/cli/integration): Learn how to manage marketplace native integrations, provision resources, and discover available products using the vercel integration CLI command.
+- [vercel integration-resource](https://vercel.com/docs/cli/integration-resource): Learn how to manage marketplace native integration resources using the vercel integration-resource CLI command.
+- [vercel link](https://vercel.com/docs/cli/link): Learn how to link a local directory to a Vercel Project using the vercel link CLI command.
+- [vercel list](https://vercel.com/docs/cli/list): Learn how to list out all recent deployments for the current Vercel Project using the vercel list CLI command.
+- [vercel login](https://vercel.com/docs/cli/login): Learn how to login into your Vercel account using the vercel login CLI command.
+- [vercel logout](https://vercel.com/docs/cli/logout): Learn how to logout from your Vercel account using the vercel logout CLI command.
+- [vercel logs](https://vercel.com/docs/cli/logs): View and filter request logs for your Vercel project, or stream live runtime logs from a deployment.
+- [vercel mcp](https://vercel.com/docs/cli/mcp): Set up Model Context Protocol (MCP) usage with a Vercel project using the vercel mcp CLI command.
+- [vercel metrics](https://vercel.com/docs/cli/metrics): Query observability metrics and inspect available metrics, dimensions, and aggregations using the Vercel CLI.
+- [vercel microfrontends](https://vercel.com/docs/cli/microfrontends): Manage microfrontends groups from the CLI. Learn how to create groups, inspect group metadata, add and remove projects, and pull configuration for local development.
+- [vercel open](https://vercel.com/docs/cli/open): Learn how to open your current project in the Vercel Dashboard using the vercel open CLI command.
+- [vercel project](https://vercel.com/docs/cli/project): Learn how to list, add, remove, and manage your Vercel Projects using the vercel project CLI command.
+- [vercel promote](https://vercel.com/docs/cli/promote): Learn how to promote an existing deployment using the vercel promote CLI command.
+- [vercel pull](https://vercel.com/docs/cli/pull): Learn how to update your local project with remote environment variables using the vercel pull CLI command.
+- [vercel redeploy](https://vercel.com/docs/cli/redeploy): Learn how to redeploy your project using the vercel redeploy CLI command.
+- [vercel redirects](https://vercel.com/docs/cli/redirects): Learn how to manage project-level redirects using the vercel redirects CLI command.
+- [vercel remove](https://vercel.com/docs/cli/remove): Learn how to remove a deployment using the vercel remove CLI command.
+- [vercel rollback](https://vercel.com/docs/cli/rollback): Learn how to roll back your production deployments to previous deployments using the vercel rollback CLI command.
+- [vercel rolling-release](https://vercel.com/docs/cli/rolling-release): Learn how to manage your project
+- [vercel routes](https://vercel.com/docs/cli/routes): Learn how to manage project-level routing rules using the vercel routes CLI command.
+- [vercel switch](https://vercel.com/docs/cli/switch): Learn how to switch between different team scopes using the vercel switch CLI command.
+- [vercel target](https://vercel.com/docs/cli/target): Work with custom environments using the --target flag in Vercel CLI.
+- [vercel teams](https://vercel.com/docs/cli/teams): Learn how to list, add, remove, and manage your teams using the vercel teams CLI command.
+- [vercel telemetry](https://vercel.com/docs/cli/telemetry): Learn how to manage telemetry collection.
+- [vercel usage](https://vercel.com/docs/cli/usage): Learn how to view billing usage and costs, for your Vercel account using the vercel usage CLI command.
+- [vercel webhooks](https://vercel.com/docs/cli/webhooks): Learn how to manage webhooks for your Vercel account using the vercel webhooks CLI command.
+- [vercel whoami](https://vercel.com/docs/cli/whoami): Learn how to display the username of the currently logged in user with the vercel whoami CLI command.
+
+## Collaboration
+- [Comments](https://vercel.com/docs/comments): Comments allow teams and invited participants to give direct feedback on preview deployments. Learn more about Comments in this overview.
+  - [Enabling Comments](https://vercel.com/docs/comments/how-comments-work): Learn when and where Comments are available, and how to enable and disable Comments at the account, project, and session or interface levels.
+  - [Using Comments](https://vercel.com/docs/comments/using-comments): This guide will help you get started with using Comments with your Vercel Preview Deployments.
+  - [Managing Comments](https://vercel.com/docs/comments/managing-comments): Learn how to manage Comments on your Preview Deployments from Team members and invited collaborators.
+  - [Integrations](https://vercel.com/docs/comments/integrations): Learn how Comments integrates with Git providers like GitHub, GitLab, and BitBucket, as well as Vercel
+- [Draft Mode](https://vercel.com/docs/draft-mode): Vercel
+- [Edit Mode](https://vercel.com/docs/edit-mode): Discover how Vercel
+- [Toolbar](https://vercel.com/docs/vercel-toolbar): Learn how to use the Vercel Toolbar to leave feedback, navigate through important dashboard pages, share deployments, use Draft Mode for previewing unpublished content, and Edit Mode for editing content in real-time.
+  - [Add to Environments](https://vercel.com/docs/vercel-toolbar/in-production-and-localhost): Learn how to use the Vercel Toolbar in production and local environments.
+    - [Add to Localhost](https://vercel.com/docs/vercel-toolbar/in-production-and-localhost/add-to-localhost): Learn how to use the Vercel Toolbar in your local environment.
+    - [Add to Production](https://vercel.com/docs/vercel-toolbar/in-production-and-localhost/add-to-production): Learn how to add the Vercel Toolbar to your production environment and how your team members can use tooling to access the toolbar.
+  - [Managing Toolbar](https://vercel.com/docs/vercel-toolbar/managing-toolbar): Learn how to enable or disable the Vercel Toolbar for your team, project, and session.
+  - [Browser Extensions](https://vercel.com/docs/vercel-toolbar/browser-extension): The browser extensions enable you to use the toolbar in production environments, take screenshots and attach them to comments, and set personal preferences for how the toolbar behaves.
+  - [Accessibility Audit Tool](https://vercel.com/docs/vercel-toolbar/accessibility-audit-tool): Learn how to use the Accessibility Audit Tool to automatically check the Web Content Accessibility Guidelines 2.0 level A and AA rules.
+  - [Interaction Timing Tool](https://vercel.com/docs/vercel-toolbar/interaction-timing-tool): The interaction timing tool allows you to inspect in detail each interaction
+  - [Layout Shift Tool](https://vercel.com/docs/vercel-toolbar/layout-shift-tool): The layout shift tool gives you insight into any elements that may cause layout shifts on the page.
+
+## Compute
+- [Fluid Compute](https://vercel.com/docs/fluid-compute): Learn about fluid compute, an execution model for Vercel Functions that provides a more flexible and efficient way to run your functions.
+- [Functions](https://vercel.com/docs/functions): Run server-side code on Vercel without managing a server.
+  - [Getting Started](https://vercel.com/docs/functions/quickstart): Build your first Vercel Function in a few steps.
+  - [Streaming](https://vercel.com/docs/functions/streaming-functions): Learn how to stream responses from Vercel Functions.
+  - [Runtimes](https://vercel.com/docs/functions/runtimes): Runtimes transform your source code into Functions, which are served by our CDN. Learn about the official runtimes supported by Vercel.
+    - [Node.js](https://vercel.com/docs/functions/runtimes/node-js): Learn how to use the Node.js runtime with Vercel Functions to create functions.
+      - [Advanced Node.js Usage](https://vercel.com/docs/functions/runtimes/node-js/advanced-node-configuration): Learn about advanced configurations for Vercel functions on Vercel.
+      - [Supported Node.js versions](https://vercel.com/docs/functions/runtimes/node-js/node-js-versions): Learn about the supported Node.js versions on Vercel.
+    - [Bun](https://vercel.com/docs/functions/runtimes/bun): Learn how to use the Bun runtime with Vercel Functions to create fast, efficient functions.
+    - [Python](https://vercel.com/docs/functions/runtimes/python): Learn how to use the Python runtime to run Python applications on Vercel.
+      - [Python version](https://vercel.com/docs/functions/runtimes/python/python-version): Set the Python version for your Vercel project with pyproject.toml, .python-version, or Pipfile.lock.
+    - [Rust](https://vercel.com/docs/functions/runtimes/rust): Build fast, memory-safe serverless functions with Rust on Vercel.
+    - [Go](https://vercel.com/docs/functions/runtimes/go): Learn how to use the Go runtime to run Go APIs on Vercel.
+    - [Ruby](https://vercel.com/docs/functions/runtimes/ruby): Learn how to use the Ruby runtime to compile Ruby Vercel Functions on Vercel.
+    - [Wasm](https://vercel.com/docs/functions/runtimes/wasm): Learn how to use WebAssembly (Wasm) to enable low-level languages to run on Vercel Functions and Routing Middleware.
+    - [Edge Runtime](https://vercel.com/docs/functions/runtimes/edge): Learn about the Edge runtime, an environment in which Vercel Functions can run.
+  - [Configuring Functions](https://vercel.com/docs/functions/configuring-functions): Learn how to configure the runtime, region, maximum duration, and memory for Vercel Functions.
+    - [Duration](https://vercel.com/docs/functions/configuring-functions/duration): Learn how to set the maximum duration of a Vercel Function.
+    - [Memory](https://vercel.com/docs/functions/configuring-functions/memory): Learn how to set the memory / CPU of a Vercel Function.
+    - [Runtime](https://vercel.com/docs/functions/configuring-functions/runtime): Learn how to configure the runtime for Vercel Functions.
+    - [Region](https://vercel.com/docs/functions/configuring-functions/region): Learn how to configure regions for Vercel Functions.
+    - [Advanced Configuration](https://vercel.com/docs/functions/configuring-functions/advanced-configuration): Learn how to add utility files to the /api directory, and bundle Vercel Functions.
+  - [API Reference](https://vercel.com/docs/functions/functions-api-reference): Learn about available APIs when working with Vercel Functions.
+    - [Node.js](https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package): Learn about available APIs when working with Vercel Functions.
+    - [Python](https://vercel.com/docs/functions/functions-api-reference/vercel-sdk-python): Learn about available APIs when working with Vercel Functions in Python.
+  - [Logs](https://vercel.com/docs/functions/logs): Use runtime logs to debug and monitor your Vercel Functions.
+  - [Limits](https://vercel.com/docs/functions/limitations): Learn about the limits and restrictions of using Vercel Functions with the Node.js runtime.
+  - [Concurrency Scaling](https://vercel.com/docs/functions/concurrency-scaling): Learn how Vercel automatically scales your functions to handle traffic surges.
+  - [Debug Slow Functions](https://vercel.com/docs/functions/debug-slow-functions): Diagnose and fix slow Vercel Functions using CLI tools, logs, and timing analysis.
+  - [Pricing](https://vercel.com/docs/functions/usage-and-pricing): Learn about usage and pricing for fluid compute on Vercel.
+    - [Legacy Usage & Pricing](https://vercel.com/docs/functions/usage-and-pricing/legacy-pricing): Learn about legacy usage and pricing for Vercel Functions.
+- [Routing Middleware](https://vercel.com/docs/routing-middleware): Learn how you can use Routing Middleware, code that executes before a request is processed on a site, to provide speed and personalization to your users.
+  - [Getting Started](https://vercel.com/docs/routing-middleware/getting-started): Learn how you can use Routing Middleware, code that executes before a request is processed on a site, to provide speed and personalization to your users.
+  - [API](https://vercel.com/docs/routing-middleware/api): Learn how you can use Routing Middleware, code that executes before a request is processed on a site, to provide speed and personalization to your users.
+- [Cron Jobs](https://vercel.com/docs/cron-jobs): Learn about cron jobs, how they work, and how to use them on Vercel.
+  - [Getting Started](https://vercel.com/docs/cron-jobs/quickstart): Learn how to schedule cron jobs to run at specific times or intervals.
+  - [Managing Cron Jobs](https://vercel.com/docs/cron-jobs/manage-cron-jobs): Learn how to manage Cron Jobs effectively in Vercel. Explore cron job duration, error handling, deployments, concurrency control, local execution, and more to optimize your serverless workflows.
+  - [Usage & Pricing](https://vercel.com/docs/cron-jobs/usage-and-pricing): Learn about cron jobs usage and pricing details.
+- [OG Image Generation](https://vercel.com/docs/og-image-generation): Learn how to optimize social media image generation through the Open Graph Protocol and @vercel/og library.
+  - [@vercel/og](https://vercel.com/docs/og-image-generation/og-image-api): This reference provides information on how the @vercel/og package works on Vercel.
+  - [Examples](https://vercel.com/docs/og-image-generation/examples): Learn how to use the @vercel/og library with examples.
+- [Sandbox](https://vercel.com/docs/vercel-sandbox): Vercel Sandbox allows you to run arbitrary code in isolated, ephemeral Linux VMs.
+  - [Quickstart](https://vercel.com/docs/vercel-sandbox/quickstart): Learn how to run your first code in a Vercel Sandbox.
+  - [Concepts](https://vercel.com/docs/vercel-sandbox/concepts): Learn how Vercel Sandboxes provide on-demand, isolated compute environments for running untrusted code, testing applications, and executing AI-generated scripts.
+    - [Authentication](https://vercel.com/docs/vercel-sandbox/concepts/authentication): Learn how to authenticate with Vercel Sandbox using OIDC tokens or access tokens.
+    - [Snapshots](https://vercel.com/docs/vercel-sandbox/concepts/snapshots): Save and restore sandbox state with snapshots for faster startups and environment sharing.
+    - [Firewall](https://vercel.com/docs/vercel-sandbox/concepts/firewall): Define network policies on sandboxes, preventing data exfiltration.
+    - [Persistent Sandboxes](https://vercel.com/docs/vercel-sandbox/concepts/persistent-sandboxes): Sandboxes that automatically save their filesystem state when stopped and restore it when resumed, removing the need to manage snapshots manually.
+    - [Tags](https://vercel.com/docs/vercel-sandbox/concepts/tags): Categorize sandboxes by environment, team, or any other criteria using key-value tags.
+  - [Examples](https://vercel.com/docs/vercel-sandbox/working-with-sandbox): Task-oriented guides for common Vercel Sandbox operations.
+  - [SDK Reference](https://vercel.com/docs/vercel-sandbox/sdk-reference): A comprehensive reference for the Vercel Sandbox SDK, which allows you to run code in a secure, isolated environment.
+  - [CLI Reference](https://vercel.com/docs/vercel-sandbox/cli-reference): Based on the Docker CLI, you can use the Sandbox CLI to manage your Vercel Sandbox from the command line.
+  - [System Specifications](https://vercel.com/docs/vercel-sandbox/system-specifications): Detailed specifications for the Vercel Sandbox environment.
+  - [Pricing and Limits](https://vercel.com/docs/vercel-sandbox/pricing): Understand how Vercel Sandbox billing works, what
+  - [Run Commands in Vercel Sandbox](https://vercel.com/docs/vercel-sandbox/run-commands-in-sandbox): Create isolated sandbox environments to run builds, tests, and commands safely.
+- [Queues](https://vercel.com/docs/queues): Durable event streaming for serverless. Publish messages to topics and process them reliably with managed consumer groups, automatic scaling, and built-in retries.
+  - [Quickstart](https://vercel.com/docs/queues/quickstart): Set up Vercel Queues with the SDK.
+  - [Concepts](https://vercel.com/docs/queues/concepts): Learn delivery, retries, visibility timeouts, and deployment isolation in Vercel Queues.
+  - [SDK Reference](https://vercel.com/docs/queues/sdk): Publish and consume messages with the @vercel/queue SDK.
+  - [API Reference](https://vercel.com/docs/queues/api): HTTP API reference for Vercel Queues. Publish, consume, acknowledge, and manage messages.
+  - [Observability](https://vercel.com/docs/queues/observability): Monitor queue throughput, message age, and consumer performance to optimize your queue-based workflows.
+  - [Poll Mode](https://vercel.com/docs/queues/poll-mode): Consume messages from Vercel Queues by polling on your own schedule, from any environment.
+  - [Pricing and Limits](https://vercel.com/docs/queues/pricing): Understand how Vercel Queues billing works, what
+- [Workflows](https://vercel.com/docs/workflows): Vercel Workflows is a fully managed platform for building durable, reliable, and observable applications and AI agents with the Workflow SDK.
+  - [Concepts](https://vercel.com/docs/workflows/concepts): Learn how workflows, steps, sleeps, and hooks work together to build durable applications.
+  - [Pricing and Limits](https://vercel.com/docs/workflows/pricing): Understand how Vercel Workflows billing works and the limits that apply to runs, streams, and platform resources.
+  - [Python](https://vercel.com/docs/workflows/python): Build durable workflows and AI agents in Python with the Vercel SDK.
+
+## Flags
+- [Vercel Flags](https://vercel.com/docs/flags/vercel-flags): Use Vercel as your feature flag provider to create and manage flags, define targeting rules, and run experiments directly from the dashboard.
+  - [Getting Started](https://vercel.com/docs/flags/vercel-flags/quickstart): Create your first feature flag and evaluate it in your application using the Flags SDK, OpenFeature, or the core library.
+  - [Dashboard](https://vercel.com/docs/flags/vercel-flags/dashboard): Learn how to manage your feature flags using the Vercel Dashboard.
+    - [Feature Flag](https://vercel.com/docs/flags/vercel-flags/dashboard/feature-flag): Learn how to configure individual feature flags in the Vercel Dashboard.
+    - [Entities](https://vercel.com/docs/flags/vercel-flags/dashboard/entities): Define entities and their attributes for precise feature flag targeting.
+    - [Segments](https://vercel.com/docs/flags/vercel-flags/dashboard/segments): Create reusable user segments for targeting feature flags.
+    - [SDK Keys](https://vercel.com/docs/flags/vercel-flags/dashboard/sdk-keys): Manage SDK Keys that connect your application to Vercel Flags.
+    - [Drafts](https://vercel.com/docs/flags/vercel-flags/dashboard/drafts): Learn how draft flags work and how to promote them to Vercel Flags.
+    - [Archive](https://vercel.com/docs/flags/vercel-flags/dashboard/archive): Archive unused feature flags and restore them when needed.
+  - [SDKs](https://vercel.com/docs/flags/vercel-flags/sdks): Learn how to integrate Vercel Flags into your application using the Flags SDK, OpenFeature, or the core library.
+    - [Flags SDK](https://vercel.com/docs/flags/vercel-flags/sdks/flags-sdk): Integrate Vercel Flags into your Next.js or SvelteKit application using the Flags SDK.
+    - [OpenFeature](https://vercel.com/docs/flags/vercel-flags/sdks/openfeature): Use the vendor-neutral OpenFeature API with Vercel Flags as your provider.
+    - [Core](https://vercel.com/docs/flags/vercel-flags/sdks/core): Use the Vercel Flags core evaluation library directly for custom setups.
+  - [Limits and Pricing](https://vercel.com/docs/flags/vercel-flags/limits-and-pricing): Learn about limits and pricing for Vercel Flags.
+    - [Clean Up After Rollout](https://vercel.com/docs/flags/vercel-flags/cli/clean-up-after-rollout): Audit active flags, remove a fully rolled-out flag from your codebase, and archive it using the Vercel CLI.
+    - [Roll Out a Feature](https://vercel.com/docs/flags/vercel-flags/cli/roll-out-feature): Create a feature flag, wire it into your application with the Flags SDK, and start a staged rollout using the Vercel CLI.
+    - [Run an A/B Test](https://vercel.com/docs/flags/vercel-flags/cli/run-ab-test): Set up an A/B test with a feature flag, track results through Web Analytics, and clean up afterward using the Vercel CLI.
+    - [Set Up Flags Explorer](https://vercel.com/docs/flags/vercel-flags/cli/set-up-flags-explorer): Add the Flags Explorer to the Vercel Toolbar so you can override flag values on preview deployments without affecting other users.
+- [Flags Explorer](https://vercel.com/docs/flags/flags-explorer): View and override your application
+  - [Getting Started](https://vercel.com/docs/flags/flags-explorer/getting-started): Learn how to set up the Flags Explorer so you can see and override your application
+  - [Reference](https://vercel.com/docs/flags/flags-explorer/reference): In-depth reference for configuring the Flags Explorer
+  - [Pricing](https://vercel.com/docs/flags/flags-explorer/limits-and-pricing): Learn about pricing for Flags Explorer.
+- [Marketplace](https://vercel.com/docs/flags/marketplace): Connect your preferred feature flag provider through the Vercel Marketplace for a unified flags experience.
+- [Flags SDK](https://vercel.com/docs/flags/flags-sdk-reference): API reference for the Flags SDK for Next.js and SvelteKit.
+- [Observability](https://vercel.com/docs/flags/observability): Track feature flag evaluations and analyze their impact with Web Analytics.
+  - [Web Analytics](https://vercel.com/docs/flags/observability/web-analytics): Learn how to tag your page views and custom events with feature flags
+
+## Integrations
+- [Overview](https://vercel.com/docs/integrations): Learn how to extend Vercel
+- [Install an Integration](https://vercel.com/docs/integrations/install-an-integration): Learn how to pair Vercel
+  - [Add a Native Integration](https://vercel.com/docs/integrations/install-an-integration/product-integration): Learn how you can add a product to your Vercel project through a native integration.
+  - [Add a Connectable Account](https://vercel.com/docs/integrations/install-an-integration/add-a-connectable-account): Learn how to connect Vercel to your third-party account.
+  - [Agent Tools](https://vercel.com/docs/integrations/install-an-integration/agent-tools): Use Agent Tools to query, debug, and manage your installed integrations through a chat interface with natural language.
+  - [Permissions and Access](https://vercel.com/docs/integrations/install-an-integration/manage-integrations-reference): Learn how to manage project access and added products for your integrations.
+- [Create an Integration](https://vercel.com/docs/integrations/create-integration): Learn how to create and manage your own integration for internal or public use with Vercel.
+  - [Native integration concepts](https://vercel.com/docs/integrations/create-integration/native-integration): As an integration provider, understanding how your service interacts with Vercel
+  - [Create a Native Integration](https://vercel.com/docs/integrations/create-integration/marketplace-product): Learn how to create a product for your Vercel native integration
+  - [Deployment integration actions](https://vercel.com/docs/integrations/create-integration/deployment-integration-action): These actions allow integration providers to set up automated tasks with Vercel deployments.
+  - [Native Integration Flows](https://vercel.com/docs/integrations/create-integration/marketplace-flows): Learn how information flows between the integration user, Vercel, and the integration provider for Vercel native integrations.
+  - [Integration Approval Checklist](https://vercel.com/docs/integrations/create-integration/approval-checklist): Review this checklist before submitting your native or connectable account integration for approval on the Vercel Marketplace.
+  - [Using Integrations API](https://vercel.com/docs/integrations/create-integration/marketplace-api): Learn how to authenticate and use the Integrations REST API to build your integration server.
+  - [Billing and Refunds](https://vercel.com/docs/integrations/create-integration/billing): Learn how billing works for native integrations, including invoice lifecycle, pricing models, and refunds.
+  - [Integration Image Guidelines](https://vercel.com/docs/integrations/create-integration/integration-image-guidelines): Guidelines for creating images for integrations, including layout, content, visual assets, descriptions, and design standards.
+  - [Requirements for listing an Integration](https://vercel.com/docs/integrations/create-integration/submit-integration): Learn about all the requirements and guidelines needed when creating your Integration.
+  - [Upgrade an Integration](https://vercel.com/docs/integrations/create-integration/upgrade-integration): Lean more about when you may need to upgrade your Integration.
+  - [Building Integrations with Vercel REST API](https://vercel.com/docs/integrations/create-integration/vercel-api-integrations): Learn how to use Vercel REST API to build your integrations and work with redirect URLs.
+  - [Secrets Rotation](https://vercel.com/docs/integrations/create-integration/secrets-rotation): Learn how to implement secrets rotation in your integration to allow users to rotate credentials securely.
+- [CMS Integrations](https://vercel.com/docs/integrations/cms): Learn how to integrate Vercel with CMS platforms, including Contentful, Sanity, and Sitecore XM Cloud.
+  - [Agility CMS](https://vercel.com/docs/integrations/cms/agility-cms): Learn how to integrate Agility CMS with Vercel. Follow our tutorial to deploy the Agility CMS template or install the integration for flexible and scalable content management.
+  - [ButterCMS](https://vercel.com/docs/integrations/cms/butter-cms): Learn how to integrate ButterCMS with Vercel. Follow our tutorial to set up the ButterCMS template on Vercel and manage content seamlessly using ButterCMS API.
+  - [Contentful](https://vercel.com/docs/integrations/cms/contentful): Integrate Vercel with Contentful to deploy your content.
+  - [DatoCMS](https://vercel.com/docs/integrations/cms/dato-cms): Learn how to integrate DatoCMS with Vercel. Follow our step-by-step tutorial to set up and manage your digital content seamlessly using DatoCMS API.
+  - [Formspree](https://vercel.com/docs/integrations/cms/formspree): Learn how to integrate Formspree with Vercel. Follow our tutorial to set up Formspree and manage form submissions on your static website without needing a server. 
+  - [Makeswift](https://vercel.com/docs/integrations/cms/makeswift): Learn how to integrate Makeswift with Vercel. Makeswift is a no-code website builder designed for creating and managing React websites. Follow our tutorial to set up Makeswift and deploy your website on Vercel.
+  - [Sanity](https://vercel.com/docs/integrations/cms/sanity): Learn how to integrate Sanity with Vercel. Follow our tutorial to deploy the Sanity template or install the integration for real-time collaboration and structured content management.
+  - [Sitecore](https://vercel.com/docs/integrations/cms/sitecore): Integrate Vercel with Sitecore XM Cloud to deploy your content.
+- [Commerce and Payments](https://vercel.com/docs/integrations/ecommerce): Learn how to integrate Vercel with payment processors and ecommerce platforms, including Stripe, Shopify, BigCommerce, and more.
+  - [Stripe](https://vercel.com/docs/integrations/ecommerce/stripe): Connect your Stripe account to Vercel and accept payments in your applications.
+  - [Kubernetes](https://vercel.com/docs/integrations/external-platforms/kubernetes): Deploy your frontend on Vercel alongside your existing Kubernetes infrastructure.
+
+## Multi-tenant
+- [Domain Management](https://vercel.com/docs/multi-tenant/domain-management): Manage custom domains, wildcard subdomains, and SSL certificates programmatically for multi-tenant applications using Vercel for Platforms.
+- [Limits](https://vercel.com/docs/multi-tenant/limits): Understand the limits and features available for Vercel for Platforms.
+
+## Observability
+- [Overview](https://vercel.com/docs/observability): Observability on Vercel provides framework-aware insights enabling you to optimize infrastructure and application performance.
+  - [Insights](https://vercel.com/docs/observability/insights): List of available data sources that you can view and monitor with Observability on Vercel.
+  - [Debug 500 Errors](https://vercel.com/docs/observability/debug-production-errors): Find, fix, and verify production 500 errors using the Vercel CLI.
+  - [Observability Plus](https://vercel.com/docs/observability/observability-plus): Learn about using Observability Plus and its limits.
+- [Alerts](https://vercel.com/docs/alerts): Get notified when something
+- [Logs](https://vercel.com/docs/logs): Use logs to find information on deployment builds, function executions, and more.
+  - [Runtime](https://vercel.com/docs/logs/runtime): Learn how to search, inspect, and share your runtime logs with the Logs tab.
+- [Tracing](https://vercel.com/docs/tracing): Learn how to trace your application to understand performance and infrastructure details.
+  - [Instrumentation](https://vercel.com/docs/tracing/instrumentation): Learn how to instrument your application to understand performance and infrastructure details.
+  - [Session Tracing](https://vercel.com/docs/tracing/session-tracing): Learn how to trace your sessions to understand performance and infrastructure details.
+- [Query](https://vercel.com/docs/query): Query and visualize your Vercel usage, traffic, and more in observability.
+  - [Query Reference](https://vercel.com/docs/query/reference): This reference covers the dimensions and operators used to create a query.
+  - [Monitoring](https://vercel.com/docs/query/monitoring): Query and visualize your Vercel usage, traffic, and more with Monitoring.
+    - [Getting Started](https://vercel.com/docs/query/monitoring/quickstart): In this quickstart guide, you
+    - [Monitoring Reference](https://vercel.com/docs/query/monitoring/monitoring-reference): This reference covers the clauses, fields, and variables used to create a Monitoring query.
+    - [Limits and Pricing](https://vercel.com/docs/query/monitoring/limits-and-pricing): Learn about our limits and pricing when using Monitoring. Different limitations are applied depending on your plan.
+- [Notebooks](https://vercel.com/docs/notebooks): Learn more about Notebooks and how they allow you to organize and save your queries.
+- [Speed Insights](https://vercel.com/docs/speed-insights): This page lists out and explains all the performance metrics provided by Vercel
+  - [Getting Started](https://vercel.com/docs/speed-insights/quickstart): Vercel Speed Insights provides you detailed insights into your website
+  - [Using Speed Insights](https://vercel.com/docs/speed-insights/using-speed-insights): Learn how to use Speed Insights to analyze your application
+  - [Metrics](https://vercel.com/docs/speed-insights/metrics): Learn what each performance metric on Speed Insights means and how the scores are calculated.
+  - [Privacy](https://vercel.com/docs/speed-insights/privacy-policy): Learn how Vercel follows the latest privacy and data compliance standards with its Speed Insights feature.
+  - [@vercel/speed-insights](https://vercel.com/docs/speed-insights/package): Learn how to configure your application to capture and send web performance metrics to Vercel using the @vercel/speed-insights npm package.
+  - [Limits and Pricing](https://vercel.com/docs/speed-insights/limits-and-pricing): Learn about our limits and pricing when using Vercel Speed Insights. Different limitations are applied depending on your plan.
+  - [Managing Usage & Costs](https://vercel.com/docs/speed-insights/managing-usage): Learn how to measure and manage Speed Insights usage with this guide to reduce data points and avoid unexpected costs.
+  - [Troubleshooting](https://vercel.com/docs/speed-insights/troubleshooting): Learn about common issues and how to troubleshoot Vercel Speed Insights.
+- [Drains](https://vercel.com/docs/drains): Drains collect logs, traces, speed insights, and analytics from your applications. Forward observability data to custom endpoints or popular services.
+  - [Using Drains](https://vercel.com/docs/drains/using-drains): Learn how to configure drains to forward observability data to custom HTTP endpoints and add integrations.
+    - [Logs](https://vercel.com/docs/drains/reference/logs): Learn about Log Drains - data formats, sources, environments, and security configuration.
+    - [Traces](https://vercel.com/docs/drains/reference/traces): Learn about Trace Drains - OpenTelemetry-compliant distributed tracing data formats and configuration.
+    - [Speed Insights](https://vercel.com/docs/drains/reference/speed-insights): Learn about Speed Insights Drains - data formats and performance metrics configuration.
+    - [Web Analytics](https://vercel.com/docs/drains/reference/analytics): Learn about Web Analytics Drains - data formats and custom events configuration.
+  - [Security](https://vercel.com/docs/drains/security): Learn how to secure your Drains endpoints with authentication and signature verification.
+- [Web Analytics](https://vercel.com/docs/analytics): With Web Analytics, you can get detailed insights into your website
+  - [Getting Started](https://vercel.com/docs/analytics/quickstart): Vercel Web Analytics provides you detailed insights into your website
+  - [Using Web Analytics](https://vercel.com/docs/analytics/using-web-analytics): Learn how to use Vercel
+  - [Filtering](https://vercel.com/docs/analytics/filtering): Learn how filters allow you to explore insights about your website
+  - [Custom Events](https://vercel.com/docs/analytics/custom-events): Learn how to send custom analytics events from your application.
+  - [Redacting Sensitive Data](https://vercel.com/docs/analytics/redacting-sensitive-data): Learn how to redact sensitive data from your Web Analytics events.
+  - [Privacy](https://vercel.com/docs/analytics/privacy-policy): Learn how Vercel supports privacy and data compliance standards with Vercel Web Analytics.
+  - [@vercel/analytics](https://vercel.com/docs/analytics/package): With the @vercel/analytics npm package, you are able to configure your application to send analytics data to Vercel.
+  - [Pricing](https://vercel.com/docs/analytics/limits-and-pricing): Learn about pricing for Vercel Web Analytics.
+  - [Troubleshooting](https://vercel.com/docs/analytics/troubleshooting): Learn how to troubleshoot common issues with Vercel Web Analytics.
+- [Manage & Optimize](https://vercel.com/docs/manage-and-optimize-observability): Learn how to understand the different charts in the Vercel dashboard, how usage relates to billing, and how to optimize your usage of Web Analytics and Speed Insights.
+- [Debug Cache Issues](https://vercel.com/docs/cdn-cache/debug-cache-issues): Diagnose stale content and fix CDN cache, data cache, and build cache issues using the CLI.
+
+## Platform
+- [Project Configuration](https://vercel.com/docs/project-configuration): Learn how to configure your Vercel projects using vercel.json, vercel.ts, or the dashboard to control builds, routing, functions, and more.
+  - [vercel.json](https://vercel.com/docs/project-configuration/vercel-json): Learn how to use vercel.json to configure and override the default behavior of Vercel from within your project. 
+  - [vercel.ts](https://vercel.com/docs/project-configuration/vercel-ts): Define your Vercel configuration in vercel.ts with @vercel/config for type-safe routing and build settings.
+  - [General Settings](https://vercel.com/docs/project-configuration/general-settings): Configure basic settings for your Vercel project, including the project name, build and development settings, root directory, Node.js version, Project ID, and Vercel Toolbar settings.
+  - [Project Settings](https://vercel.com/docs/project-configuration/project-settings): Use the project settings, to configure custom domains, environment variables, Git, integrations, deployment protection, functions, cron jobs, project members, webhooks, Drains, and security settings.
+  - [Git Configuration](https://vercel.com/docs/project-configuration/git-configuration): Learn how to configure Git for your project through vercel.json or vercel.ts.
+  - [Git Settings](https://vercel.com/docs/project-configuration/git-settings): Use the project settings to manage the Git connection, enable Git LFS, and create deploy hooks.
+  - [Global Configuration](https://vercel.com/docs/project-configuration/global-configuration): Learn how to configure Vercel CLI under your system user.
+  - [Security settings](https://vercel.com/docs/project-configuration/security-settings): Configure security settings for your Vercel project, including Logs and Source Protection, Vercel Support Code Visibility, Git Fork Protection, and Secure Backend Access with OIDC Federation.
+- [Projects](https://vercel.com/docs/projects): A project is the application that you have deployed to Vercel.
+  - [Deploy from CLI](https://vercel.com/docs/projects/deploy-from-cli): Set up and deploy a Vercel project using the CLI, from linking to production.
+  - [Managing projects](https://vercel.com/docs/projects/managing-projects): Learn how to manage your projects through the Vercel Dashboard.
+  - [Transferring a project](https://vercel.com/docs/projects/transferring-projects): Learn how to transfer a project between Vercel teams.
+- [Domains](https://vercel.com/docs/domains): Learn the fundamentals of how domains, DNS, and nameservers work on Vercel.
+  - [Working with Domains](https://vercel.com/docs/domains/working-with-domains): Learn how domains work and the options Vercel provides for managing them.
+    - [Adding a Domain](https://vercel.com/docs/domains/working-with-domains/add-a-domain): Learn how to add a custom domain to your Vercel project, verify it, and correctly set the DNS or Nameserver values.
+    - [Adding a Domain to an Environment](https://vercel.com/docs/domains/working-with-domains/add-a-domain-to-environment): Learn how to add a custom domain to your Vercel project, verify it, and correctly set the DNS or Nameserver values.
+    - [Assigning a Domain to a Git Branch](https://vercel.com/docs/domains/working-with-domains/assign-domain-to-a-git-branch): Learn how to assign a domain to a different Git branch with this guide.
+    - [Claiming Ownership](https://vercel.com/docs/domains/working-with-domains/claim-domain-ownership): Learn how to claim ownership of a domain that is registered with another Vercel account by verifying DNS ownership.
+    - [Deploying & Redirecting Domains](https://vercel.com/docs/domains/working-with-domains/deploying-and-redirecting): Learn how to deploy your domains and set up domain redirects with this guide.
+    - [Removing a Domain](https://vercel.com/docs/domains/working-with-domains/remove-a-domain): Learn how to remove a domain from a Project and from your account completely with this guide.
+    - [Renewing a Domain](https://vercel.com/docs/domains/working-with-domains/renew-a-domain): Learn how to manage automatic and manual renewals for custom domains purchased through or registered with Vercel, and how to redeem expired domains with this guide.
+    - [Transferring Domains](https://vercel.com/docs/domains/working-with-domains/transfer-your-domain): Domains can be transferred to another team or project within Vercel, or to and from a third-party registrar. Learn how to transfer domains with this guide.
+    - [Viewing & Searching Domains](https://vercel.com/docs/domains/working-with-domains/view-and-search-domains): Learn how to view and search all registered domains that are assigned to Vercel Projects through the Vercel dashboard.
+  - [Working with DNS](https://vercel.com/docs/domains/working-with-dns): Learn how DNS works in order to properly configure your domain.
+  - [Managing DNS Records](https://vercel.com/docs/domains/managing-dns-records): Learn how to add, verify, and remove DNS records for your domains on Vercel with this guide.
+  - [Domain Connect](https://vercel.com/docs/domains/domain-connect): Learn how to integrate your service with Vercel DNS using the Domain Connect protocol to automatically configure DNS records for your users.
+  - [Working with Nameservers](https://vercel.com/docs/domains/working-with-nameservers): Learn about nameservers and the benefits Vercel nameservers provide.
+  - [Managing Nameservers](https://vercel.com/docs/domains/managing-nameservers): Learn how to add custom nameservers and restore original nameservers for your domains on Vercel with this guide.
+  - [Working with SSL](https://vercel.com/docs/domains/working-with-ssl): Learn how Vercel uses SSL certification to keep your site secure.
+  - [Custom SSL Certificates](https://vercel.com/docs/domains/custom-SSL-certificate): By default, Vercel provides all domains with a custom SSL certificates. However, Enterprise teams can upload their own custom SSL certificate.
+  - [Pre-Generate SSL Certificates](https://vercel.com/docs/domains/pre-generating-ssl-certs): test
+  - [Supported Domains](https://vercel.com/docs/domains/supported-domains): Supported domains page with dynamically fetched TLD data table
+  - [Troubleshooting Domains](https://vercel.com/docs/domains/troubleshooting): Learn about common reasons for domain misconfigurations and how to troubleshoot your domain on Vercel.
+  - [Set Up Custom Domain](https://vercel.com/docs/domains/set-up-custom-domain): Add and configure a custom domain for your Vercel project using the CLI.
+  - [Using Domains API](https://vercel.com/docs/domains/registrar-api): Programmatically search, price, purchase, renew, and manage domains with Vercel
+- [Notifications](https://vercel.com/docs/notifications): Learn how to use Notifications to view and manage important alerts about your deployments, domains, integrations, account, and usage.
+- [Build Output API](https://vercel.com/docs/build-output-api): The Build Output API is a file-system-based specification for a directory structure that can produce a Vercel deployment.
+  - [Build Output Configuration](https://vercel.com/docs/build-output-api/configuration): Learn about the Build Output Configuration file, which is used to configure the behavior of a Deployment.
+  - [Features](https://vercel.com/docs/build-output-api/features): Learn how to implement common Vercel platform features through the Build Output API.
+  - [Vercel Primitives](https://vercel.com/docs/build-output-api/primitives): Learn about the Vercel platform primitives and how they work together to create a Vercel Deployment.
+- [Glossary](https://vercel.com/docs/glossary): Learn about the terms and concepts used in Vercel
+- [Limits](https://vercel.com/docs/limits): Look up account limits, included usage, rate limits, and resource constraints for every Vercel plan.
+  - [Fair Use Guidelines](https://vercel.com/docs/limits/fair-use-guidelines): Learn about all subscription plans included usage that is subject to Vercel
+- [Checks](https://vercel.com/docs/checks): Vercel automatically keeps an eye on various aspects of your web application using the Checks API. Learn how to use Checks in your Vercel workflow here.
+  - [Checks API](https://vercel.com/docs/checks/checks-api): The Vercel Checks API let you create tests and assertions that run after each deployment has been built, and are powered by Vercel Integrations.
+  - [Checks Reference](https://vercel.com/docs/checks/creating-checks): Learn how to create your own Checks with Vercel Integrations. You can build your own Integration in order to register any arbitrary Check for your deployments.
+- [Manage Redirects at Scale](https://vercel.com/docs/redirects/manage-redirects-at-scale): Add, bulk upload, version, and roll back project-level redirects using the CLI.
+- [Support Center](https://vercel.com/docs/support-center): Learn how to communicate securely with the Vercel support team
+
+## Pricing
+- [Plans](https://vercel.com/docs/plans): Learn about the different plans available on Vercel.
+  - [Hobby Plan](https://vercel.com/docs/plans/hobby): Learn about the Hobby plan and how it compares to the Pro plan.
+  - [Pro Plan](https://vercel.com/docs/plans/pro-plan): Learn about the Vercel Pro plan with credit-based billing, free viewer seats, and self-serve enterprise features for professional teams.
+    - [Pro Plan Trial](https://vercel.com/docs/plans/pro-plan/trials): Learn all about Vercel
+    - [Billing FAQ](https://vercel.com/docs/plans/pro-plan/billing): This page covers frequently asked questions around payments, invoices, and billing on the Pro plan.
+  - [Enterprise Plan](https://vercel.com/docs/plans/enterprise): Learn about the Enterprise plan for Vercel, including features, pricing, and more.
+    - [Billing FAQ](https://vercel.com/docs/plans/enterprise/billing): This page covers frequently asked questions around payments, invoices, and billing on the Enterprise plan.
+- [Pricing](https://vercel.com/docs/pricing): Learn about Vercel
+  - [Regional Pricing](https://vercel.com/docs/pricing/regional-pricing): Vercel pricing for Managed Infrastructure resources in different regions.
+    - [Cape Town, South Africa (cpt1)](https://vercel.com/docs/pricing/regional-pricing/cpt1): Vercel pricing for the Cape Town, South Africa (cpt1) region.
+    - [Cleveland, USA (cle1)](https://vercel.com/docs/pricing/regional-pricing/cle1): Vercel pricing for the Cleveland, USA (cle1) region.
+    - [Dubai, UAE (dxb1)](https://vercel.com/docs/pricing/regional-pricing/dxb1): Vercel pricing for the Dubai, UAE (dxb1) region.
+    - [Dublin, Ireland (dub1)](https://vercel.com/docs/pricing/regional-pricing/dub1): Vercel pricing for the Dublin, Ireland (dub1) region.
+    - [Frankfurt, Germany (fra1)](https://vercel.com/docs/pricing/regional-pricing/fra1): Vercel pricing for the Frankfurt, Germany (fra1) region.
+    - [Hong Kong (hkg1)](https://vercel.com/docs/pricing/regional-pricing/hkg1): Vercel pricing for the Hong Kong (hkg1) region.
+    - [London, UK (lhr1)](https://vercel.com/docs/pricing/regional-pricing/lhr1): Vercel pricing for the London, UK (lhr1) region.
+    - [Montréal, Canada (yul1)](https://vercel.com/docs/pricing/regional-pricing/yul1): Vercel pricing for the Montréal, Canada (yul1) region.
+    - [Mumbai, India (bom1)](https://vercel.com/docs/pricing/regional-pricing/bom1): Vercel pricing for the Mumbai, India (bom1) region.
+    - [Osaka, Japan (kix1)](https://vercel.com/docs/pricing/regional-pricing/kix1): Vercel pricing for the Osaka, Japan (kix1) region.
+    - [Paris, France (cdg1)](https://vercel.com/docs/pricing/regional-pricing/cdg1): Vercel pricing for the Paris, France (cdg1) region.
+    - [Portland, USA (pdx1)](https://vercel.com/docs/pricing/regional-pricing/pdx1): Vercel pricing for the Portland, USA (pdx1) region.
+    - [San Francisco, USA (sfo1)](https://vercel.com/docs/pricing/regional-pricing/sfo1): Vercel pricing for the San Francisco, USA (sfo1) region.
+    - [São Paulo, Brazil (gru1)](https://vercel.com/docs/pricing/regional-pricing/gru1): Vercel pricing for the São Paulo, Brazil (gru1) region.
+    - [Seoul, South Korea (icn1)](https://vercel.com/docs/pricing/regional-pricing/icn1): Vercel pricing for the Seoul, South Korea (icn1) region.
+    - [Singapore (sin1)](https://vercel.com/docs/pricing/regional-pricing/sin1): Vercel pricing for the Singapore (sin1) region.
+    - [Stockholm, Sweden (arn1)](https://vercel.com/docs/pricing/regional-pricing/arn1): Vercel pricing for the Stockholm, Sweden (arn1) region.
+    - [Sydney, Australia (syd1)](https://vercel.com/docs/pricing/regional-pricing/syd1): Vercel pricing for the Sydney, Australia (syd1) region.
+    - [Tokyo, Japan (hnd1)](https://vercel.com/docs/pricing/regional-pricing/hnd1): Vercel pricing for the Tokyo, Japan (hnd1) region.
+    - [Washington D.C., USA (iad1)](https://vercel.com/docs/pricing/regional-pricing/iad1): Vercel pricing for the Washington D.C., USA (iad1) region.
+  - [Manage and Optimize Usage](https://vercel.com/docs/pricing/manage-and-optimize-usage): Understand how to manage and optimize your usage on Vercel, learn how to track your usage, set up alerts, and optimize your usage to save costs.
+  - [Calculating Usage of Resources](https://vercel.com/docs/pricing/how-does-vercel-calculate-usage-of-resources): Understand how Vercel measures and calculates your resource usage based on a typical user journey.
+  - [Billing & Invoices](https://vercel.com/docs/pricing/understanding-my-invoice): Learn how Vercel invoices get structured for Pro and Enterprise plans. Learn how usage allotments and on-demand charges get included.
+  - [Legacy Metrics](https://vercel.com/docs/pricing/legacy): Learn about Bandwidth, Requests, Vercel Function Invocations, and Vercel Function Execution metrics.
+  - [Taxes](https://vercel.com/docs/pricing/taxes): This page covers frequently asked questions around taxes.
+- [Spend Management](https://vercel.com/docs/spend-management): Learn how to get notified about your account spend and configure a webhook.
+
+## Security
+- [Overview](https://vercel.com/docs/security): Vercel provides built-in and customizable features to ensure that your site is secure.
+  - [Security & Compliance Measures](https://vercel.com/docs/security/compliance): Learn about the protection and compliance measures Vercel takes to ensure the security of your data, including DDoS mitigation and SOC 2 compliance.
+  - [Shared Responsibility Model](https://vercel.com/docs/security/shared-responsibility): Discover the essentials of our Shared Responsibility Model, outlining the key roles and responsibilities for customers, Vercel, and shared aspects in ensuring secure and efficient cloud computing services.
+  - [PCI DSS iframe Integration](https://vercel.com/docs/security/pci-dss): Learn how to integrate an iframe into your application to support PCI DSS compliance.
+  - [Reverse Proxy Servers and Vercel](https://vercel.com/docs/security/reverse-proxy): Learn why reverse proxy servers are not recommended with Vercel
+  - [Access Control](https://vercel.com/docs/security/access-control): Learn about the protection and compliance measures Vercel takes to ensure the security of your data, including DDoS mitigation, SOC 2 compliance and more.
+- [Audit Logs](https://vercel.com/docs/audit-log): Learn how to track and analyze your team members
+- [Firewall](https://vercel.com/docs/vercel-firewall): Learn how Vercel Firewall helps protect your applications and websites from malicious attacks and unauthorized access.
+  - [Firewall Concepts](https://vercel.com/docs/vercel-firewall/firewall-concepts): Understand the fundamentals behind the Vercel Firewall.
+  - [DDoS Mitigation](https://vercel.com/docs/vercel-firewall/ddos-mitigation): Learn how the Vercel Firewall mitigates against DoS and DDoS attacks
+  - [Attack Challenge Mode](https://vercel.com/docs/vercel-firewall/attack-challenge-mode): Learn how to use Attack Challenge Mode to help control who has access to your site when it
+  - [Web Application Firewall](https://vercel.com/docs/vercel-firewall/vercel-waf): Learn how to secure your website with the Vercel Web Application Firewall (WAF)
+    - [Custom Rules](https://vercel.com/docs/vercel-firewall/vercel-waf/custom-rules): Learn how to add and manage custom rules to configure the Vercel Web Application Firewall (WAF).
+    - [Rate Limiting](https://vercel.com/docs/vercel-firewall/vercel-waf/rate-limiting): Learn how to configure custom rate limiting rules with the Vercel Web Application Firewall (WAF).
+    - [Rule Configuration](https://vercel.com/docs/vercel-firewall/vercel-waf/rule-configuration): List of configurable options with the Vercel WAF
+    - [System Bypass Rules](https://vercel.com/docs/vercel-firewall/vercel-waf/system-bypass-rules): Learn how to configure IP-based system bypass rules with the Vercel Web Application Firewall (WAF).
+    - [Rate Limiting SDK](https://vercel.com/docs/vercel-firewall/vercel-waf/rate-limiting-sdk): Learn how to configure a custom rule with rate limit in your code.
+    - [IP Blocking](https://vercel.com/docs/vercel-firewall/vercel-waf/ip-blocking): Learn how to customize the Vercel WAF to restrict access to certain IP addresses.
+    - [WAF Managed Rulesets](https://vercel.com/docs/vercel-firewall/vercel-waf/managed-rulesets): Learn how to use WAF Managed Rulesets with the Vercel Web Application Firewall (WAF)
+    - [Examples](https://vercel.com/docs/vercel-firewall/vercel-waf/examples): Learn how to use Vercel WAF to protect your site in specific situations.
+    - [Usage & Pricing](https://vercel.com/docs/vercel-firewall/vercel-waf/usage-and-pricing): Learn how the Vercel WAF can affect your usage and how specific features are priced.
+  - [Firewall API](https://vercel.com/docs/vercel-firewall/firewall-api): Learn how to interact with the security endpoints of the Vercel REST API programmatically.
+  - [Firewall Observability](https://vercel.com/docs/vercel-firewall/firewall-observability): Learn how firewall traffic monitoring and alerts help you react quickly to potential security threats.
+- [Bot Management](https://vercel.com/docs/bot-management): Learn how to manage bot traffic to your site.
+- [BotID](https://vercel.com/docs/botid): Protect your applications from automated attacks with intelligent bot detection and verification, powered by Kasada.
+  - [Get Started with BotID](https://vercel.com/docs/botid/get-started): Step-by-step guide to setting up BotID protection in your Vercel project
+  - [Handling Verified Bots](https://vercel.com/docs/botid/verified-bots): Information about verified bots and their handling in BotID
+  - [Advanced BotID Configuration](https://vercel.com/docs/botid/advanced-configuration): Fine-grained control over BotID detection levels and backend domain configuration
+  - [Form Submissions](https://vercel.com/docs/botid/form-submissions): How to properly handle form submissions with BotID protection
+  - [Local Development Behavior](https://vercel.com/docs/botid/local-development-behavior): How BotID behaves in local development environments and testing options
+- [Connectivity](https://vercel.com/docs/connectivity): Connect your Vercel projects to backend services with static IPs and secure networking options.
+  - [Secure Compute](https://vercel.com/docs/connectivity/secure-compute): Secure Compute provides dedicated private networks with VPC peering for Enterprise teams.
+  - [Static IPs](https://vercel.com/docs/connectivity/static-ips): Access IP-restricted backend services through shared static egress IPs for Pro and Enterprise teams.
+    - [Getting Started](https://vercel.com/docs/connectivity/static-ips/getting-started): Learn how to set up Static IPs for your Vercel projects to connect to IP-restricted backend services.
+- [OIDC](https://vercel.com/docs/oidc): Secure the access to your backend using OIDC Federation to enable auto-generated, short-lived, and non-persistent credentials.
+  - [AWS](https://vercel.com/docs/oidc/aws): Learn how to configure your AWS account to trust Vercel
+  - [Azure](https://vercel.com/docs/oidc/azure): Learn how to configure your Microsoft Azure account to trust Vercel
+  - [Connect your API](https://vercel.com/docs/oidc/api): Learn how to configure your own API to trust Vercel
+  - [Google Cloud Platform](https://vercel.com/docs/oidc/gcp): Learn how to configure your GCP project to trust Vercel
+  - [OIDC Reference](https://vercel.com/docs/oidc/reference): Review helper libraries to help you connect with your backend and understand the structure of an OIDC token.
+- [RBAC](https://vercel.com/docs/rbac): Learn how to manage team members on Vercel, and how to assign roles to each member with role-based access control (RBAC).
+  - [Access Roles](https://vercel.com/docs/rbac/access-roles): Learn about the different roles available for team members on a Vercel account.
+    - [Extended Permissions](https://vercel.com/docs/rbac/access-roles/extended-permissions): Learn about extended permissions in Vercel
+    - [Project Level Roles](https://vercel.com/docs/rbac/access-roles/project-level-roles): Learn about the project level roles and their permissions.
+    - [Team Level Roles](https://vercel.com/docs/rbac/access-roles/team-level-roles): Learn about the different team level roles and the permissions they provide.
+  - [Access Groups](https://vercel.com/docs/rbac/access-groups): Learn how to configure access groups for team members on a Vercel account.
+  - [Managing Team Members](https://vercel.com/docs/rbac/managing-team-members): Learn how to manage team members on Vercel, and how to assign roles to each member with role-based access control (RBAC).
+- [Two-factor Enforcement](https://vercel.com/docs/two-factor-enforcement): Learn how to enforce two-factor authentication (2FA) for your Vercel team members to enhance security.
+
+## Storage
+- [Overview](https://vercel.com/docs/storage): Store large files and global configuration with Vercel
+- [Blob](https://vercel.com/docs/vercel-blob): Vercel Blob is a scalable, cost-effective object storage service with private and public access modes for files of any size.
+  - [Private Storage](https://vercel.com/docs/vercel-blob/private-storage): Learn how to use private Vercel Blob storage to serve files with authentication
+  - [Public Storage](https://vercel.com/docs/vercel-blob/public-storage): Learn how to use public Vercel Blob storage to serve files accessible to anyone with the URL
+  - [Server Uploads](https://vercel.com/docs/vercel-blob/server-upload): Learn how to upload files to Vercel Blob using Server Actions and Route Handlers
+  - [Client Uploads](https://vercel.com/docs/vercel-blob/client-upload): Learn how to upload files larger than 4.5 MB directly from the browser to Vercel Blob
+  - [Using the SDK](https://vercel.com/docs/vercel-blob/using-blob-sdk): Learn how to use the Vercel Blob SDK to access your blob store from your apps.
+  - [Pricing](https://vercel.com/docs/vercel-blob/usage-and-pricing): Learn about the pricing for Vercel Blob.
+  - [Security](https://vercel.com/docs/vercel-blob/security): Learn how your Vercel Blob store is secured
+  - [Examples](https://vercel.com/docs/vercel-blob/examples): Examples on how to use Vercel Blob in your applications
+  - [Manage Vercel Blob Storage](https://vercel.com/docs/vercel-blob/manage-blob-storage): Create blob stores, upload files, list contents, and manage storage using the CLI.
+- [Edge Config](https://vercel.com/docs/edge-config): An Edge Config is a global data store that enables experimentation with feature flags, A/B testing, critical redirects, and more.
+  - [Getting Started](https://vercel.com/docs/edge-config/get-started): Learn how to create an Edge Config store and read from it in your project.
+  - [Using Edge Config](https://vercel.com/docs/edge-config/using-edge-config): Learn how to use Edge Configs in your projects.
+  - [Edge Configs & REST API](https://vercel.com/docs/edge-config/vercel-api): Learn how to use the Vercel REST API to create and update Edge Configs. You can also read data stored in Edge Configs with the Vercel REST API.
+  - [Edge Configs & Dashboard](https://vercel.com/docs/edge-config/edge-config-dashboard): Learn how to create, view and update your Edge Configs and the data inside them in your Vercel Dashboard at the Hobby team, team, and project levels.
+  - [Edge Config SDK](https://vercel.com/docs/edge-config/edge-config-sdk): The Edge Config client SDK is the most ergonomic way to read data from Edge Configs. Learn how to set up the SDK so you can start reading Edge Configs.
+  - [Limits & Pricing](https://vercel.com/docs/edge-config/edge-config-limits): Learn about the Edge Configs limits and pricing based on account plans.
+  - [Integrations](https://vercel.com/docs/edge-config/edge-config-integrations): Learn how to use Edge Config with popular A/B testing and feature flag service integrations.
+    - [DevCycle](https://vercel.com/docs/edge-config/edge-config-integrations/devcycle-edge-config): Learn how to use Edge Config with Vercel
+    - [Hypertune](https://vercel.com/docs/edge-config/edge-config-integrations/hypertune-edge-config): Learn how to use Hypertune
+    - [LaunchDarkly](https://vercel.com/docs/edge-config/edge-config-integrations/launchdarkly-edge-config): Learn how to use Edge Config with Vercel
+    - [Split](https://vercel.com/docs/edge-config/edge-config-integrations/split-edge-config): Learn how to use Edge Config with Vercel
+    - [Statsig](https://vercel.com/docs/edge-config/edge-config-integrations/statsig-edge-config): Learn how to use Edge Config with Vercel
+- [Marketplace](https://vercel.com/docs/marketplace-storage): Connect Postgres, Redis, NoSQL, and other storage solutions through the Vercel Marketplace. Run SQL queries, edit data, and inspect schemas from the dashboard.
+
+# REST API Reference
+
+Base URL: https://api.vercel.com
+OpenAPI spec: https://openapi.vercel.sh/
+Errors reference: https://vercel.com/docs/rest-api/errors
+
+## Endpoints
+
+### access-groups
+
+- [Reads an access group](https://vercel.com/docs/rest-api/access-groups/reads-an-access-group) `GET /v1/access-groups/{idOrName}` — Allows to read an access group
+- [Update an access group](https://vercel.com/docs/rest-api/access-groups/update-an-access-group) `POST /v1/access-groups/{idOrName}` — Allows to update an access group metadata
+- [Deletes an access group](https://vercel.com/docs/rest-api/access-groups/deletes-an-access-group) `DELETE /v1/access-groups/{idOrName}` — Allows to delete an access group
+- [List members of an access group](https://vercel.com/docs/rest-api/access-groups/list-members-of-an-access-group) `GET /v1/access-groups/{idOrName}/members` — List members of an access group
+- [List access groups for a team, project or member](https://vercel.com/docs/rest-api/access-groups/list-access-groups-for-a-team-project-or-member) `GET /v1/access-groups` — List access groups
+- [Creates an access group](https://vercel.com/docs/rest-api/access-groups/creates-an-access-group) `POST /v1/access-groups` — Allows to create an access group
+- [List projects of an access group](https://vercel.com/docs/rest-api/access-groups/list-projects-of-an-access-group) `GET /v1/access-groups/{idOrName}/projects` — List projects of an access group
+- [Create an access group project](https://vercel.com/docs/rest-api/access-groups/create-an-access-group-project) `POST /v1/access-groups/{accessGroupIdOrName}/projects` — Allows creation of an access group project
+- [Reads an access group project](https://vercel.com/docs/rest-api/access-groups/reads-an-access-group-project) `GET /v1/access-groups/{accessGroupIdOrName}/projects/{projectId}` — Allows reading an access group project
+- [Update an access group project](https://vercel.com/docs/rest-api/access-groups/update-an-access-group-project) `PATCH /v1/access-groups/{accessGroupIdOrName}/projects/{projectId}` — Allows update of an access group project
+- [Delete an access group project](https://vercel.com/docs/rest-api/access-groups/delete-an-access-group-project) `DELETE /v1/access-groups/{accessGroupIdOrName}/projects/{projectId}` — Allows deletion of an access group project
+
+### aliases
+
+- [List Deployment Aliases](https://vercel.com/docs/rest-api/aliases/list-deployment-aliases) `GET /v2/deployments/{id}/aliases` — Retrieves all Aliases for the Deployment with the given ID. The authenticated user or team must own ...
+- [Assign an Alias](https://vercel.com/docs/rest-api/aliases/assign-an-alias) `POST /v2/deployments/{id}/aliases` — Creates a new alias for the deployment with the given deployment ID. The authenticated user or team ...
+- [List aliases](https://vercel.com/docs/rest-api/aliases/list-aliases) `GET /v4/aliases` — Retrieves a list of aliases for the authenticated User or Team. When `domain` is provided, only alia...
+- [Get an Alias](https://vercel.com/docs/rest-api/aliases/get-an-alias) `GET /v4/aliases/{idOrAlias}` — Retrieves an Alias for the given host name or alias ID.
+- [Delete an Alias](https://vercel.com/docs/rest-api/aliases/delete-an-alias) `DELETE /v2/aliases/{aliasId}` — Delete an Alias with the specified ID.
+- [Update the protection bypass for a URL](https://vercel.com/docs/rest-api/aliases/update-the-protection-bypass-for-a-url) `PATCH /aliases/{id}/protection-bypass` — Update the protection bypass for the alias or deployment URL (used for user access & comment access ...
+
+### api-observability
+
+- [Lists disabled Observability Plus projects](https://vercel.com/docs/rest-api/api-observability/lists-disabled-observability-plus-projects) `GET /v1/observability/manage/configuration/projects` — Lists the projects that are currently configured as disabled for Observability Plus on a team.
+- [Updates a disabled Observability Plus project setting](https://vercel.com/docs/rest-api/api-observability/updates-a-disabled-observability-plus-project-setting) `PUT /v1/observability/manage/configuration/projects/{projectIdOrName}` — Updates whether Observability Plus is disabled for a single project.
+
+### artifacts
+
+- [Record an artifacts cache usage event](https://vercel.com/docs/rest-api/artifacts/record-an-artifacts-cache-usage-event) `POST /v8/artifacts/events` — Records an artifacts cache usage event. The body of this request is an array of cache usage events. ...
+- [Get status of Remote Caching for this principal](https://vercel.com/docs/rest-api/artifacts/get-status-of-remote-caching-for-this-principal) `GET /v8/artifacts/status` — Check the status of Remote Caching for this principal. Returns a JSON-encoded status indicating if R...
+- [Upload a cache artifact](https://vercel.com/docs/rest-api/artifacts/upload-a-cache-artifact) `PUT /v8/artifacts/{hash}` — Uploads a cache artifact identified by the `hash` specified on the path. The cache artifact can then...
+- [Download a cache artifact](https://vercel.com/docs/rest-api/artifacts/download-a-cache-artifact) `GET /v8/artifacts/{hash}` — Downloads a cache artifact indentified by its `hash` specified on the request path. The artifact is ...
+- [Check if a cache artifact exists](https://vercel.com/docs/rest-api/artifacts/check-if-a-cache-artifact-exists) `HEAD /v8/artifacts/{hash}` — Check that a cache artifact with the given `hash` exists. This request returns response headers only...
+- [Query information about an artifact](https://vercel.com/docs/rest-api/artifacts/query-information-about-an-artifact) `POST /v8/artifacts` — Query information about an array of artifacts.
+
+### authentication
+
+- [SSO Token Exchange](https://vercel.com/docs/rest-api/authentication/sso-token-exchange) `POST /v1/integrations/sso/token` — During the autorization process, Vercel sends the user to the provider [redirectLoginUrl](https://ve...
+- [List Auth Tokens](https://vercel.com/docs/rest-api/authentication/list-auth-tokens) `GET /v6/user/tokens` — Retrieve a list of the current User's authentication tokens.
+- [Create an Auth Token](https://vercel.com/docs/rest-api/authentication/create-an-auth-token) `POST /v3/user/tokens` — Creates and returns a new authentication token for the currently authenticated User. The `bearerToke...
+- [Get Auth Token Metadata](https://vercel.com/docs/rest-api/authentication/get-auth-token-metadata) `GET /v5/user/tokens/{tokenId}` — Retrieve metadata about an authentication token belonging to the currently authenticated User.
+- [Delete an authentication token](https://vercel.com/docs/rest-api/authentication/delete-an-authentication-token) `DELETE /v3/user/tokens/{tokenId}` — Invalidate an authentication token, such that it will no longer be valid for future HTTP requests.
+
+### billing
+
+- [List FOCUS billing charges](https://vercel.com/docs/rest-api/billing/list-focus-billing-charges) `GET /v1/billing/charges` — Returns the billing charge data in FOCUS v1.3 JSONL format for a specified Vercel team, within a dat...
+- [List FOCUS contract commitments](https://vercel.com/docs/rest-api/billing/list-focus-contract-commitments) `GET /v1/billing/contract-commitments` — Returns commitment allocations per contract period in FOCUS v1.3 JSONL format for a specified Vercel...
+- [Purchase credits](https://vercel.com/docs/rest-api/billing/purchase-credits) `POST /v1/billing/buy` — Purchases credits for a Vercel team using the default payment method on file. The purchase is charge...
+
+### bulk-redirects
+
+- [Stages new redirects for a project.](https://vercel.com/docs/rest-api/bulk-redirects/stages-new-redirects-for-a-project) `PUT /v1/bulk-redirects` — Stages new redirects for a project and returns the new version.
+- [Gets project-level redirects.](https://vercel.com/docs/rest-api/bulk-redirects/gets-project-level-redirects) `GET /v1/bulk-redirects` — Get the version history for a project's bulk redirects
+- [Delete project-level redirects.](https://vercel.com/docs/rest-api/bulk-redirects/delete-project-level-redirects) `DELETE /v1/bulk-redirects` — Deletes the provided redirects from the latest version of the projects' bulk redirects. Stages a new...
+- [Edit a project-level redirect.](https://vercel.com/docs/rest-api/bulk-redirects/edit-a-project-level-redirect) `PATCH /v1/bulk-redirects` — Edits a single redirect identified by its source path. Stages a new change with the modified redirec...
+- [Restore staged project-level redirects to their production version.](https://vercel.com/docs/rest-api/bulk-redirects/restore-staged-project-level-redirects-to-their-production-version) `POST /v1/bulk-redirects/restore` — Restores the provided redirects in the staging version to the value in the production version. If no...
+- [Get the version history for a project's redirects.](https://vercel.com/docs/rest-api/bulk-redirects/get-the-version-history-for-a-project-s-redirects) `GET /v1/bulk-redirects/versions` — Get the version history for a project's bulk redirects
+- [Promote a staging version to production or restore a previous production version.](https://vercel.com/docs/rest-api/bulk-redirects/promote-a-staging-version-to-production-or-restore-a-previous-production-version) `POST /v1/bulk-redirects/versions` — Update a version by promoting staging to production or restoring a previous production version
+
+### certs
+
+- [Get cert by id](https://vercel.com/docs/rest-api/certs/get-cert-by-id) `GET /v8/certs/{id}` — Get cert by id
+- [Remove cert](https://vercel.com/docs/rest-api/certs/remove-cert) `DELETE /v8/certs/{id}` — Remove cert
+- [Issue a new cert](https://vercel.com/docs/rest-api/certs/issue-a-new-cert) `POST /v8/certs` — Issue a new cert
+- [Upload a cert](https://vercel.com/docs/rest-api/certs/upload-a-cert) `PUT /v8/certs` — Upload a cert
+
+### checks
+
+- [Creates a new Check](https://vercel.com/docs/rest-api/checks/creates-a-new-check) `POST /v1/deployments/{deploymentId}/checks` — Creates a new check. This endpoint must be called with an OAuth2 or it will produce a 400 error.
+- [Retrieve a list of all checks](https://vercel.com/docs/rest-api/checks/retrieve-a-list-of-all-checks) `GET /v1/deployments/{deploymentId}/checks` — List all of the checks created for a deployment.
+- [Get a single check](https://vercel.com/docs/rest-api/checks/get-a-single-check) `GET /v1/deployments/{deploymentId}/checks/{checkId}` — Return a detailed response for a single check.
+- [Update a check](https://vercel.com/docs/rest-api/checks/update-a-check) `PATCH /v1/deployments/{deploymentId}/checks/{checkId}` — Update an existing check. This endpoint must be called with an OAuth2 or it will produce a 400 error...
+- [Rerequest a check](https://vercel.com/docs/rest-api/checks/rerequest-a-check) `POST /v1/deployments/{deploymentId}/checks/{checkId}/rerequest` — Rerequest a selected check that has failed.
+
+### checks-v2
+
+- [List all checks for a project](https://vercel.com/docs/rest-api/checks-v2/list-all-checks-for-a-project) `GET /v2/projects/{projectIdOrName}/checks` — List all checks for a project, optionally filtered by target.
+- [Create a check](https://vercel.com/docs/rest-api/checks-v2/create-a-check) `POST /v2/projects/{projectIdOrName}/checks` — Creates a new check for a project.
+- [Get a check](https://vercel.com/docs/rest-api/checks-v2/get-a-check) `GET /v2/projects/{projectIdOrName}/checks/{checkId}` — Return a detailed response for a single check.
+- [Update a check](https://vercel.com/docs/rest-api/checks-v2/update-a-check) `PATCH /v2/projects/{projectIdOrName}/checks/{checkId}` — Update an existing check.
+- [Delete a check](https://vercel.com/docs/rest-api/checks-v2/delete-a-check) `DELETE /v2/projects/{projectIdOrName}/checks/{checkId}` — Delete an existing check and all of its runs.
+- [List runs for a check](https://vercel.com/docs/rest-api/checks-v2/list-runs-for-a-check) `GET /v2/projects/{projectIdOrName}/checks/{checkId}/runs` — List all runs associated with a given check.
+- [List check runs for a deployment](https://vercel.com/docs/rest-api/checks-v2/list-check-runs-for-a-deployment) `GET /v2/deployments/{deploymentId}/check-runs` — List all check runs for a deployment.
+- [Create a check run](https://vercel.com/docs/rest-api/checks-v2/create-a-check-run) `POST /v2/deployments/{deploymentId}/check-runs` — Creates a new check run for a deployment.
+- [Get a check run](https://vercel.com/docs/rest-api/checks-v2/get-a-check-run) `GET /v2/deployments/{deploymentId}/check-runs/{checkRunId}` — Return a detailed response for a single check run.
+- [Update a check run](https://vercel.com/docs/rest-api/checks-v2/update-a-check-run) `PATCH /v2/deployments/{deploymentId}/check-runs/{checkRunId}` — Update an existing check run for a deployment.
+
+### connect
+
+- [List Secure Compute networks](https://vercel.com/docs/rest-api/connect/list-secure-compute-networks) `GET /v1/connect/networks` — Allows to list Secure Compute networks.
+- [Create a Secure Compute network](https://vercel.com/docs/rest-api/connect/create-a-secure-compute-network) `POST /v1/connect/networks` — Allows to create a Secure Compute network.
+- [Delete a Secure Compute network](https://vercel.com/docs/rest-api/connect/delete-a-secure-compute-network) `DELETE /v1/connect/networks/{networkId}` — Allows to delete a Secure Compute network.
+- [Update a Secure Compute network](https://vercel.com/docs/rest-api/connect/update-a-secure-compute-network) `PATCH /v1/connect/networks/{networkId}` — Allows to update a Secure Compute network.
+- [Read a Secure Compute network](https://vercel.com/docs/rest-api/connect/read-a-secure-compute-network) `GET /v1/connect/networks/{networkId}` — Allows to read a Secure Compute network.
+- [Configures Static IPs for a project](https://vercel.com/docs/rest-api/connect/configures-static-ip-s-for-a-project) `PATCH /v1/projects/{idOrName}/shared-connect-links` — Allows configuring Static IPs for a project
+
+### deployments
+
+- [Get deployment events](https://vercel.com/docs/rest-api/deployments/get-deployment-events) `GET /v3/deployments/{idOrUrl}/events` — Get the build logs of a deployment by deployment ID and build ID. It can work as an infinite stream ...
+- [Update deployment integration action](https://vercel.com/docs/rest-api/deployments/update-deployment-integration-action) `PATCH /v1/deployments/{deploymentId}/integrations/{integrationConfigurationId}/resources/{resourceId}/actions/{action}` — Updates the deployment integration action for the specified integration installation
+- [Get a deployment by ID or URL](https://vercel.com/docs/rest-api/deployments/get-a-deployment-by-id-or-url) `GET /v13/deployments/{idOrUrl}` — Retrieves information for a deployment either by supplying its ID (`id` property) or Hostname (`url`...
+- [Create a new deployment](https://vercel.com/docs/rest-api/deployments/create-a-new-deployment) `POST /v13/deployments` — Create a new deployment with all the required and intended data. If the deployment is not a git depl...
+- [Cancel a deployment](https://vercel.com/docs/rest-api/deployments/cancel-a-deployment) `PATCH /v12/deployments/{id}/cancel` — This endpoint allows you to cancel a deployment which is currently building, by supplying its `id` i...
+- [Upload Deployment Files](https://vercel.com/docs/rest-api/deployments/upload-deployment-files) `POST /v2/files` — Before you create a deployment you need to upload the required files for that deployment. To do it, ...
+- [List Deployment Files](https://vercel.com/docs/rest-api/deployments/list-deployment-files) `GET /v6/deployments/{id}/files` — Allows to retrieve the file structure of the source code of a deployment by supplying the deployment...
+- [Get Deployment File Contents](https://vercel.com/docs/rest-api/deployments/get-deployment-file-contents) `GET /v8/deployments/{id}/files/{fileId}` — Allows to retrieve the content of a file by supplying the file identifier and the deployment unique ...
+- [List deployments](https://vercel.com/docs/rest-api/deployments/list-deployments) `GET /v6/deployments` — List deployments under the authenticated user or team. If a deployment hasn't finished uploading (is...
+- [Delete a Deployment](https://vercel.com/docs/rest-api/deployments/delete-a-deployment) `DELETE /v13/deployments/{id}` — This API allows you to delete a deployment, either by supplying its `id` in the URL or the `url` of ...
+
+### dns
+
+- [List existing DNS records](https://vercel.com/docs/rest-api/dns/list-existing-dns-records) `GET /v5/domains/{domain}/records` — Retrieves a list of DNS records created for a domain name. By default it returns 20 records if no li...
+- [Create a DNS record](https://vercel.com/docs/rest-api/dns/create-a-dns-record) `POST /v2/domains/{domain}/records` — Creates a DNS record for a domain.
+- [Update an existing DNS record](https://vercel.com/docs/rest-api/dns/update-an-existing-dns-record) `PATCH /v1/domains/records/{recordId}` — Updates an existing DNS record for a domain name.
+- [Delete a DNS record](https://vercel.com/docs/rest-api/dns/delete-a-dns-record) `DELETE /v2/domains/{domain}/records/{recordId}` — Removes an existing DNS record from a domain name.
+
+### domains
+
+- [Get a Domain's configuration](https://vercel.com/docs/rest-api/domains/get-a-domain-s-configuration) `GET /v6/domains/{domain}/config` — Get a Domain's configuration.
+- [Get Information for a Single Domain](https://vercel.com/docs/rest-api/domains/get-information-for-a-single-domain) `GET /v5/domains/{domain}` — Get information for a single domain in an account or team.
+- [List all the domains](https://vercel.com/docs/rest-api/domains/list-all-the-domains) `GET /v5/domains` — Retrieves a list of domains registered for the authenticated user or team. By default it returns the...
+- [Add an existing domain to the Vercel platform](https://vercel.com/docs/rest-api/domains/add-an-existing-domain-to-the-vercel-platform) `POST /v7/domains` — This endpoint is used for adding a new apex domain name with Vercel for the authenticating user. Not...
+- [Update or move apex domain](https://vercel.com/docs/rest-api/domains/update-or-move-apex-domain) `PATCH /v3/domains/{domain}` — Update or move apex domain. Note: This endpoint is no longer used for updating auto-renew or nameser...
+- [Remove a domain by name](https://vercel.com/docs/rest-api/domains/remove-a-domain-by-name) `DELETE /v6/domains/{domain}` — Delete a previously registered domain name from Vercel. Deleting a domain will automatically remove ...
+
+### domains-registrar
+
+- [Get supported TLDs](https://vercel.com/docs/rest-api/domains-registrar/get-supported-tld-s) `GET /v1/registrar/tlds/supported` — Get a list of TLDs supported by Vercel
+- [Get TLD](https://vercel.com/docs/rest-api/domains-registrar/get-tld) `GET /v1/registrar/tlds/{tld}` — Get the metadata for a specific TLD.
+- [Get TLD price data](https://vercel.com/docs/rest-api/domains-registrar/get-tld-price-data) `GET /v1/registrar/tlds/{tld}/price` — Get price data for a specific TLD. This only reflects base prices for the given TLD. Premium domains...
+- [Get availability for a domain](https://vercel.com/docs/rest-api/domains-registrar/get-availability-for-a-domain) `GET /v1/registrar/domains/{domain}/availability` — Get availability for a specific domain. If the domain is available, it can be purchased using the [B...
+- [Get price data for a domain](https://vercel.com/docs/rest-api/domains-registrar/get-price-data-for-a-domain) `GET /v1/registrar/domains/{domain}/price` — Get price data for a specific domain
+- [Get availability for multiple domains](https://vercel.com/docs/rest-api/domains-registrar/get-availability-for-multiple-domains) `POST /v1/registrar/domains/availability` — Get availability for multiple domains. If the domains are available, they can be purchased using the...
+- [Get the auth code for a domain](https://vercel.com/docs/rest-api/domains-registrar/get-the-auth-code-for-a-domain) `GET /v1/registrar/domains/{domain}/auth-code` — Get the auth code for a domain. This is required to transfer a domain from Vercel to another registr...
+- [Buy a domain](https://vercel.com/docs/rest-api/domains-registrar/buy-a-domain) `POST /v1/registrar/domains/{domain}/buy` — Buy a domain
+- [Buy multiple domains](https://vercel.com/docs/rest-api/domains-registrar/buy-multiple-domains) `POST /v1/registrar/domains/buy` — Buy multiple domains at once
+- [Transfer-in a domain](https://vercel.com/docs/rest-api/domains-registrar/transfer-in-a-domain) `POST /v1/registrar/domains/{domain}/transfer` — Transfer a domain in from another registrar
+- [Get a domain's transfer status](https://vercel.com/docs/rest-api/domains-registrar/get-a-domain-s-transfer-status) `GET /v1/registrar/domains/{domain}/transfer` — Get the transfer status for a domain
+- [Renew a domain](https://vercel.com/docs/rest-api/domains-registrar/renew-a-domain) `POST /v1/registrar/domains/{domain}/renew` — Renew a domain
+- [Update auto-renew for a domain](https://vercel.com/docs/rest-api/domains-registrar/update-auto-renew-for-a-domain) `PATCH /v1/registrar/domains/{domain}/auto-renew` — Update the auto-renew setting for a domain
+- [Update nameservers for a domain](https://vercel.com/docs/rest-api/domains-registrar/update-nameservers-for-a-domain) `PATCH /v1/registrar/domains/{domain}/nameservers` — Update the nameservers for a domain. Pass an empty array to use Vercel's default nameservers.
+- [Get contact info schema](https://vercel.com/docs/rest-api/domains-registrar/get-contact-info-schema) `GET /v1/registrar/domains/{domain}/contact-info/schema` — Some TLDs require additional contact information. Use this endpoint to get the schema for the tld-sp...
+- [Get a domain order](https://vercel.com/docs/rest-api/domains-registrar/get-a-domain-order) `GET /v1/registrar/orders/{orderId}` — Get information about a domain order by its ID
+
+### drains
+
+- [Create a new Drain](https://vercel.com/docs/rest-api/drains/create-a-new-drain) `POST /v1/drains` — Create a new Drain with the provided configuration.
+- [Retrieve a list of all Drains](https://vercel.com/docs/rest-api/drains/retrieve-a-list-of-all-drains) `GET /v1/drains` — Allows to retrieve the list of Drains of the authenticated team.
+- [Delete a drain](https://vercel.com/docs/rest-api/drains/delete-a-drain) `DELETE /v1/drains/{id}` — Delete a specific Drain by passing the drain id in the URL.
+- [Find a Drain by id](https://vercel.com/docs/rest-api/drains/find-a-drain-by-id) `GET /v1/drains/{id}` — Get the information for a specific Drain by passing the drain id in the URL.
+- [Update an existing Drain](https://vercel.com/docs/rest-api/drains/update-an-existing-drain) `PATCH /v1/drains/{id}` — Update the configuration of an existing drain.
+- [Validate Drain delivery configuration](https://vercel.com/docs/rest-api/drains/validate-drain-delivery-configuration) `POST /v1/drains/test` — Validate the delivery configuration of a Drain using sample events.
+
+### edge-cache
+
+- [Invalidate by tag](https://vercel.com/docs/rest-api/edge-cache/invalidate-by-tag) `POST /v1/edge-cache/invalidate-by-tags` — Marks a cache tag as stale, causing cache entries associated with that tag to be revalidated in the ...
+- [Dangerously delete by tag](https://vercel.com/docs/rest-api/edge-cache/dangerously-delete-by-tag) `POST /v1/edge-cache/dangerously-delete-by-tags` — Marks a cache tag as deleted, causing cache entries associated with that tag to be revalidated in th...
+- [Invalidate by source image](https://vercel.com/docs/rest-api/edge-cache/invalidate-by-source-image) `POST /v1/edge-cache/invalidate-by-src-images` — Marks a source image as stale, causing its corresponding transformed images to be revalidated in the...
+- [Dangerously delete by source image](https://vercel.com/docs/rest-api/edge-cache/dangerously-delete-by-source-image) `POST /v1/edge-cache/dangerously-delete-by-src-images` — Marks a source image as deleted, causing cache entries associated with that source image to be reval...
+
+### edge-config
+
+- [Get Edge Configs](https://vercel.com/docs/rest-api/edge-config/get-edge-configs) `GET /v1/edge-config` — Returns all Edge Configs.
+- [Create an Edge Config](https://vercel.com/docs/rest-api/edge-config/create-an-edge-config) `POST /v1/edge-config` — Creates an Edge Config.
+- [Get an Edge Config](https://vercel.com/docs/rest-api/edge-config/get-an-edge-config) `GET /v1/edge-config/{edgeConfigId}` — Returns an Edge Config.
+- [Update an Edge Config](https://vercel.com/docs/rest-api/edge-config/update-an-edge-config) `PUT /v1/edge-config/{edgeConfigId}` — Updates an Edge Config.
+- [Delete an Edge Config](https://vercel.com/docs/rest-api/edge-config/delete-an-edge-config) `DELETE /v1/edge-config/{edgeConfigId}` — Delete an Edge Config by id.
+- [Get Edge Config items](https://vercel.com/docs/rest-api/edge-config/get-edge-config-items) `GET /v1/edge-config/{edgeConfigId}/items` — Returns all items of an Edge Config.
+- [Update Edge Config items in batch](https://vercel.com/docs/rest-api/edge-config/update-edge-config-items-in-batch) `PATCH /v1/edge-config/{edgeConfigId}/items` — Update multiple Edge Config Items in batch.
+- [Get Edge Config schema](https://vercel.com/docs/rest-api/edge-config/get-edge-config-schema) `GET /v1/edge-config/{edgeConfigId}/schema` — Returns the schema of an Edge Config.
+- [Update Edge Config schema](https://vercel.com/docs/rest-api/edge-config/update-edge-config-schema) `POST /v1/edge-config/{edgeConfigId}/schema` — Update an Edge Config's schema.
+- [Delete an Edge Config's schema](https://vercel.com/docs/rest-api/edge-config/delete-an-edge-config-s-schema) `DELETE /v1/edge-config/{edgeConfigId}/schema` — Deletes the schema of existing Edge Config.
+- [Get an Edge Config item](https://vercel.com/docs/rest-api/edge-config/get-an-edge-config-item) `GET /v1/edge-config/{edgeConfigId}/item/{edgeConfigItemKey}` — Returns a specific Edge Config Item.
+- [Get all tokens of an Edge Config](https://vercel.com/docs/rest-api/edge-config/get-all-tokens-of-an-edge-config) `GET /v1/edge-config/{edgeConfigId}/tokens` — Returns all tokens of an Edge Config.
+- [Delete one or more Edge Config tokens](https://vercel.com/docs/rest-api/edge-config/delete-one-or-more-edge-config-tokens) `DELETE /v1/edge-config/{edgeConfigId}/tokens` — Deletes one or more tokens of an existing Edge Config.
+- [Get Edge Config token meta data](https://vercel.com/docs/rest-api/edge-config/get-edge-config-token-meta-data) `GET /v1/edge-config/{edgeConfigId}/token/{token}` — Return meta data about an Edge Config token.
+- [Create an Edge Config token](https://vercel.com/docs/rest-api/edge-config/create-an-edge-config-token) `POST /v1/edge-config/{edgeConfigId}/token` — Adds a token to an existing Edge Config.
+- [Get Edge Config backup](https://vercel.com/docs/rest-api/edge-config/get-edge-config-backup) `GET /v1/edge-config/{edgeConfigId}/backups/{edgeConfigBackupVersionId}` — Retrieves a specific version of an Edge Config from backup storage.
+- [Get Edge Config backups](https://vercel.com/docs/rest-api/edge-config/get-edge-config-backups) `GET /v1/edge-config/{edgeConfigId}/backups` — Returns backups of an Edge Config.
+
+### environment
+
+- [Create one or more shared environment variables](https://vercel.com/docs/rest-api/environment/create-one-or-more-shared-environment-variables) `POST /v1/env` — Creates shared environment variable(s) for a team.
+- [Lists all Shared Environment Variables for a team](https://vercel.com/docs/rest-api/environment/lists-all-shared-environment-variables-for-a-team) `GET /v1/env` — Lists all Shared Environment Variables for a team, taking into account optional filters.
+- [Updates one or more shared environment variables](https://vercel.com/docs/rest-api/environment/updates-one-or-more-shared-environment-variables) `PATCH /v1/env` — Updates a given Shared Environment Variable for a Team.
+- [Delete one or more Env Var](https://vercel.com/docs/rest-api/environment/delete-one-or-more-env-var) `DELETE /v1/env` — Deletes one or many Shared Environment Variables for a given team.
+- [Retrieve the decrypted value of a Shared Environment Variable by id.](https://vercel.com/docs/rest-api/environment/retrieve-the-decrypted-value-of-a-shared-environment-variable-by-id) `GET /v1/env/{id}` — Retrieve the decrypted value of a Shared Environment Variable by id.
+- [Disconnects a shared environment variable for a given project](https://vercel.com/docs/rest-api/environment/disconnects-a-shared-environment-variable-for-a-given-project) `PATCH /v1/env/{id}/unlink/{projectId}` — Disconnects a shared environment variable for a given project
+- [Create a custom environment for the current project.](https://vercel.com/docs/rest-api/environment/create-a-custom-environment-for-the-current-project) `POST /v9/projects/{idOrName}/custom-environments` — Creates a custom environment for the current project. Cannot be named 'Production' or 'Preview'.
+- [Retrieve custom environments](https://vercel.com/docs/rest-api/environment/retrieve-custom-environments) `GET /v9/projects/{idOrName}/custom-environments` — Retrieve custom environments for the project. Must not be named 'Production' or 'Preview'.
+- [Retrieve a custom environment](https://vercel.com/docs/rest-api/environment/retrieve-a-custom-environment) `GET /v9/projects/{idOrName}/custom-environments/{environmentSlugOrId}` — Retrieve a custom environment for the project. Must not be named 'Production' or 'Preview'.
+- [Update a custom environment](https://vercel.com/docs/rest-api/environment/update-a-custom-environment) `PATCH /v9/projects/{idOrName}/custom-environments/{environmentSlugOrId}` — Update a custom environment for the project. Must not be named 'Production' or 'Preview'.
+- [Remove a custom environment](https://vercel.com/docs/rest-api/environment/remove-a-custom-environment) `DELETE /v9/projects/{idOrName}/custom-environments/{environmentSlugOrId}` — Remove a custom environment for the project. Must not be named 'Production' or 'Preview'.
+
+### feature-flags
+
+- [List flags](https://vercel.com/docs/rest-api/feature-flags/list-flags) `GET /v1/projects/{projectIdOrName}/feature-flags/flags` — Retrieve feature flags for a project. The list can be filtered by state and supports pagination.
+- [Create a flag](https://vercel.com/docs/rest-api/feature-flags/create-a-flag) `PUT /v1/projects/{projectIdOrName}/feature-flags/flags` — Create a new feature flag for a project. The flag must have a unique slug within the project and spe...
+- [Get a flag](https://vercel.com/docs/rest-api/feature-flags/get-a-flag) `GET /v1/projects/{projectIdOrName}/feature-flags/flags/{flagIdOrSlug}` — Retrieve a specific feature flag by its ID or slug.
+- [Update a flag](https://vercel.com/docs/rest-api/feature-flags/update-a-flag) `PATCH /v1/projects/{projectIdOrName}/feature-flags/flags/{flagIdOrSlug}` — Update an existing feature flag. This endpoint supports partial updates, allowing you to modify spec...
+- [Delete a flag](https://vercel.com/docs/rest-api/feature-flags/delete-a-flag) `DELETE /v1/projects/{projectIdOrName}/feature-flags/flags/{flagIdOrSlug}` — Permanently delete a feature flag from the project. This action cannot be undone. Consider archiving...
+- [List flag versions](https://vercel.com/docs/rest-api/feature-flags/list-flag-versions) `GET /v1/projects/{projectIdOrName}/feature-flags/flags/{flagIdOrSlug}/versions` — Lists flag versions for a given flag.
+- [Get project flag settings](https://vercel.com/docs/rest-api/feature-flags/get-project-flag-settings) `GET /v1/projects/{projectIdOrName}/feature-flags/settings` — Retrieve feature flag settings for a project.
+- [Update project flag settings](https://vercel.com/docs/rest-api/feature-flags/update-project-flag-settings) `PATCH /v1/projects/{projectIdOrName}/feature-flags/settings` — Update feature flag settings for a project.
+- [List team project flag settings](https://vercel.com/docs/rest-api/feature-flags/list-team-project-flag-settings) `GET /v1/teams/{teamId}/feature-flags/settings` — Retrieve feature flag settings for projects in a team.
+- [List all flags for a team](https://vercel.com/docs/rest-api/feature-flags/list-all-flags-for-a-team) `GET /v1/teams/{teamId}/feature-flags/flags` — Retrieve all feature flags for a team across all projects. The list can be filtered by state and sup...
+- [Create a segment](https://vercel.com/docs/rest-api/feature-flags/create-a-segment) `PUT /v1/projects/{projectIdOrName}/feature-flags/segments` — Create a new feature flag segment.
+- [List segments](https://vercel.com/docs/rest-api/feature-flags/list-segments) `GET /v1/projects/{projectIdOrName}/feature-flags/segments` — List all feature flag segments for a project.
+- [Get a segment](https://vercel.com/docs/rest-api/feature-flags/get-a-segment) `GET /v1/projects/{projectIdOrName}/feature-flags/segments/{segmentIdOrSlug}` — Retrieve a feature flag segment by ID or slug.
+- [Delete a segment](https://vercel.com/docs/rest-api/feature-flags/delete-a-segment) `DELETE /v1/projects/{projectIdOrName}/feature-flags/segments/{segmentIdOrSlug}` — Delete a feature flag segment.
+- [Update a segment](https://vercel.com/docs/rest-api/feature-flags/update-a-segment) `PATCH /v1/projects/{projectIdOrName}/feature-flags/segments/{segmentIdOrSlug}` — Update an existing feature flag segment.
+- [Retrieve the feature flags of a deployment](https://vercel.com/docs/rest-api/feature-flags/retrieve-the-feature-flags-of-a-deployment) `GET /v1/deployments/{deploymentId}/feature-flags` — Retrieve the feature flags of a deployment.
+- [Get all SDK keys](https://vercel.com/docs/rest-api/feature-flags/get-all-sdk-keys) `GET /v1/projects/{projectIdOrName}/feature-flags/sdk-keys` — Gets all SDK keys for a project.
+- [Create an SDK key](https://vercel.com/docs/rest-api/feature-flags/create-an-sdk-key) `PUT /v1/projects/{projectIdOrName}/feature-flags/sdk-keys` — Creates an SDK key.
+- [Delete an SDK key](https://vercel.com/docs/rest-api/feature-flags/delete-an-sdk-key) `DELETE /v1/projects/{projectIdOrName}/feature-flags/sdk-keys/{hashKey}` — Deletes an SDK key.
+
+### integrations
+
+- [List git namespaces by provider](https://vercel.com/docs/rest-api/integrations/list-git-namespaces-by-provider) `GET /v1/integrations/git-namespaces` — Lists git namespaces for a supported provider. Supported providers are `github`, `gitlab` and `bitbu...
+- [List git repositories linked to namespace by provider](https://vercel.com/docs/rest-api/integrations/list-git-repositories-linked-to-namespace-by-provider) `GET /v1/integrations/search-repo` — Lists git repositories linked to a namespace `id` for a supported provider. A specific namespace `id...
+- [List integration billing plans](https://vercel.com/docs/rest-api/integrations/list-integration-billing-plans) `GET /v1/integrations/integration/{integrationIdOrSlug}/products/{productIdOrSlug}/plans` — Get a list of billing plans for an integration and product.
+- [Connect integration resource to project](https://vercel.com/docs/rest-api/integrations/connect-integration-resource-to-project) `POST /v1/integrations/installations/{integrationConfigurationId}/resources/{resourceId}/connections` — Connects an integration resource to a Vercel project. This endpoint establishes a connection between...
+- [Get configurations for the authenticated user or team](https://vercel.com/docs/rest-api/integrations/get-configurations-for-the-authenticated-user-or-team) `GET /v1/integrations/configurations` — Allows to retrieve all configurations for an authenticated integration. When the `project` view is u...
+- [Retrieve an integration configuration](https://vercel.com/docs/rest-api/integrations/retrieve-an-integration-configuration) `GET /v1/integrations/configuration/{id}` — Allows to retrieve a the configuration with the provided id in case it exists. The authenticated use...
+- [Delete an integration configuration](https://vercel.com/docs/rest-api/integrations/delete-an-integration-configuration) `DELETE /v1/integrations/configuration/{id}` — Allows to remove the configuration with the `id` provided in the parameters. The configuration and a...
+- [List products for integration configuration](https://vercel.com/docs/rest-api/integrations/list-products-for-integration-configuration) `GET /v1/integrations/configuration/{id}/products` — Returns products available for an integration configuration. Each product includes a `metadataSchema...
+- [Create integration store (free and paid plans)](https://vercel.com/docs/rest-api/integrations/create-integration-store-free-and-paid-plans) `POST /v1/storage/stores/integration/direct` — Creates an integration store with automatic billing plan handling. For free resources, omit `billing...
+
+### logDrains
+
+- [Retrieves a Configurable Log Drain (deprecated)](https://vercel.com/docs/rest-api/logDrains/retrieves-a-configurable-log-drain-deprecated) `GET /v1/log-drains/{id}` — Retrieves a Configurable Log Drain. This endpoint must be called with a team AccessToken (integratio...
+- [Deletes a Configurable Log Drain (deprecated)](https://vercel.com/docs/rest-api/logDrains/deletes-a-configurable-log-drain-deprecated) `DELETE /v1/log-drains/{id}` — Deletes a Configurable Log Drain. This endpoint must be called with a team AccessToken (integration ...
+- [Retrieves a list of all the Log Drains (deprecated)](https://vercel.com/docs/rest-api/logDrains/retrieves-a-list-of-all-the-log-drains-deprecated) `GET /v1/log-drains` — Retrieves a list of all the Log Drains owned by the account. This endpoint must be called with an ac...
+- [Creates a Configurable Log Drain (deprecated)](https://vercel.com/docs/rest-api/logDrains/creates-a-configurable-log-drain-deprecated) `POST /v1/log-drains` — Creates a configurable log drain. This endpoint must be called with a team AccessToken (integration ...
+- [Retrieves a list of Integration log drains (deprecated)](https://vercel.com/docs/rest-api/logDrains/retrieves-a-list-of-integration-log-drains-deprecated) `GET /v2/integrations/log-drains` — Retrieves a list of all Integration log drains that are defined for the authenticated user or team. ...
+- [Creates a new Integration Log Drain (deprecated)](https://vercel.com/docs/rest-api/logDrains/creates-a-new-integration-log-drain-deprecated) `POST /v2/integrations/log-drains` — Creates an Integration log drain. This endpoint must be called with an OAuth2 client (integration), ...
+- [Deletes the Integration log drain with the provided `id` (deprecated)](https://vercel.com/docs/rest-api/logDrains/deletes-the-integration-log-drain-with-the-provided-id-deprecated) `DELETE /v1/integrations/log-drains/{id}` — Deletes the Integration log drain with the provided `id`. When using an OAuth2 Token, the log drain ...
+
+### logs
+
+- [Get logs for a deployment](https://vercel.com/docs/rest-api/logs/get-logs-for-a-deployment) `GET /v1/projects/{projectId}/deployments/{deploymentId}/runtime-logs` — Returns a stream of logs for a given deployment.
+
+### marketplace
+
+- [Update Installation](https://vercel.com/docs/rest-api/marketplace/update-installation) `PATCH /v1/installations/{integrationConfigurationId}` — This endpoint updates an integration installation.
+- [Get Account Information](https://vercel.com/docs/rest-api/marketplace/get-account-information) `GET /v1/installations/{integrationConfigurationId}/account` — Fetches the best account or user’s contact info
+- [Get Member Information](https://vercel.com/docs/rest-api/marketplace/get-member-information) `GET /v1/installations/{integrationConfigurationId}/member/{memberId}` — Returns the member role and other information for a given member ID ("user_id" claim in the SSO OIDC...
+- [Create Event](https://vercel.com/docs/rest-api/marketplace/create-event) `POST /v1/installations/{integrationConfigurationId}/events` — Partner notifies Vercel of any changes made to an Installation or a Resource. Vercel is expected to ...
+- [Get Integration Resources](https://vercel.com/docs/rest-api/marketplace/get-integration-resources) `GET /v1/installations/{integrationConfigurationId}/resources` — Get all resources for a given installation ID.
+- [Get Integration Resource](https://vercel.com/docs/rest-api/marketplace/get-integration-resource) `GET /v1/installations/{integrationConfigurationId}/resources/{resourceId}` — Get a resource by its partner ID.
+- [Delete Integration Resource](https://vercel.com/docs/rest-api/marketplace/delete-integration-resource) `DELETE /v1/installations/{integrationConfigurationId}/resources/{resourceId}` — Delete a resource owned by the selected installation ID.
+- [Import Resource](https://vercel.com/docs/rest-api/marketplace/import-resource) `PUT /v1/installations/{integrationConfigurationId}/resources/{resourceId}` — This endpoint imports (upserts) a resource to Vercel's installation. This may be needed if resources...
+- [Update Resource](https://vercel.com/docs/rest-api/marketplace/update-resource) `PATCH /v1/installations/{integrationConfigurationId}/resources/{resourceId}` — This endpoint updates an existing resource in the installation. All parameters are optional, allowin...
+- [Submit Billing Data](https://vercel.com/docs/rest-api/marketplace/submit-billing-data) `POST /v1/installations/{integrationConfigurationId}/billing` — Sends the billing and usage data. The partner should do this at least once a day and ideally once pe...
+- [Submit Invoice](https://vercel.com/docs/rest-api/marketplace/submit-invoice) `POST /v1/installations/{integrationConfigurationId}/billing/invoices` — This endpoint allows the partner to submit an invoice to Vercel. The invoice is created in Vercel's ...
+- [Finalize Installation](https://vercel.com/docs/rest-api/marketplace/finalize-installation) `POST /v1/installations/{integrationConfigurationId}/billing/finalize` — This endpoint allows the partner to mark an installation as finalized. This means you will not send ...
+- [Get Invoice](https://vercel.com/docs/rest-api/marketplace/get-invoice) `GET /v1/installations/{integrationConfigurationId}/billing/invoices/{invoiceId}` — Get Invoice details and status for a given invoice ID.<br/> <br/> See [Billing Events with Webhooks ...
+- [Invoice Actions](https://vercel.com/docs/rest-api/marketplace/invoice-actions) `POST /v1/installations/{integrationConfigurationId}/billing/invoices/{invoiceId}/actions` — This endpoint allows the partner to request a refund for an invoice to Vercel. The invoice is create...
+- [Submit Prepayment Balances](https://vercel.com/docs/rest-api/marketplace/submit-prepayment-balances) `POST /v1/installations/{integrationConfigurationId}/billing/balance` — Sends the prepayment balances. The partner should do this at least once a day and ideally once per h...
+- [Deprecated: true. Update Resource Secrets (Deprecated)](https://vercel.com/docs/rest-api/marketplace/deprecated-true-update-resource-secrets-deprecated) `PUT /v1/installations/{integrationConfigurationId}/products/{integrationProductIdOrSlug}/resources/{resourceId}/secrets` — This endpoint is deprecated and replaced with the endpoint [Update Resource Secrets](#update-resourc...
+- [Update Resource Secrets](https://vercel.com/docs/rest-api/marketplace/update-resource-secrets) `PUT /v1/installations/{integrationConfigurationId}/resources/{resourceId}/secrets` — This endpoint updates the secrets of a resource. If a resource has projects connected, the connected...
+- [Create one or multiple experimentation items](https://vercel.com/docs/rest-api/marketplace/create-one-or-multiple-experimentation-items) `POST /v1/installations/{integrationConfigurationId}/resources/{resourceId}/experimentation/items` — Create one or multiple experimentation items
+- [Patch an existing experimentation item](https://vercel.com/docs/rest-api/marketplace/patch-an-existing-experimentation-item) `PATCH /v1/installations/{integrationConfigurationId}/resources/{resourceId}/experimentation/items/{itemId}` — Patch an existing experimentation item
+- [Delete an existing experimentation item](https://vercel.com/docs/rest-api/marketplace/delete-an-existing-experimentation-item) `DELETE /v1/installations/{integrationConfigurationId}/resources/{resourceId}/experimentation/items/{itemId}` — Delete an existing experimentation item
+- [Get the data of a user-provided Edge Config](https://vercel.com/docs/rest-api/marketplace/get-the-data-of-a-user-provided-edge-config) `HEAD /v1/installations/{integrationConfigurationId}/resources/{resourceId}/experimentation/edge-config` — When the user enabled Edge Config syncing, then this endpoint can be used by the partner to fetch th...
+- [Get the data of a user-provided Edge Config](https://vercel.com/docs/rest-api/marketplace/get-the-data-of-a-user-provided-edge-config) `GET /v1/installations/{integrationConfigurationId}/resources/{resourceId}/experimentation/edge-config` — When the user enabled Edge Config syncing, then this endpoint can be used by the partner to fetch th...
+- [Push data into a user-provided Edge Config](https://vercel.com/docs/rest-api/marketplace/push-data-into-a-user-provided-edge-config) `PUT /v1/installations/{integrationConfigurationId}/resources/{resourceId}/experimentation/edge-config` — When the user enabled Edge Config syncing, then this endpoint can be used by the partner to push the...
+
+### microfrontends
+
+- [List microfrontends groups](https://vercel.com/docs/rest-api/microfrontends/list-microfrontends-groups) `GET /v1/microfrontends/groups` — Get the microfrontends group IDs for a team.
+- [List projects in a microfrontends group](https://vercel.com/docs/rest-api/microfrontends/list-projects-in-a-microfrontends-group) `GET /v1/microfrontends/groups/{groupId}/projects` — Get the microfrontends for a given group ID.
+- [Get microfrontends config for a deployment](https://vercel.com/docs/rest-api/microfrontends/get-microfrontends-config-for-a-deployment) `GET /v1/microfrontends/{deploymentId}/config` — Get the microfrontends config for a deployment.
+- [Get microfrontends config for a project](https://vercel.com/docs/rest-api/microfrontends/get-microfrontends-config-for-a-project) `GET /v1/microfrontends/projects/{projectIdOrName}/production-mfe-config` — Get the microfrontends config for a project by ID or name.
+- [Create a microfrontends group with applications](https://vercel.com/docs/rest-api/microfrontends/create-a-microfrontends-group-with-applications) `POST /v1/microfrontends/group` — Creates a microfrontends group and attaches multiple projects in a single request.
+
+### project-routes
+
+- [Get project routing rules](https://vercel.com/docs/rest-api/project-routes/get-project-routing-rules) `GET /v1/projects/{projectId}/routes` — Get the routing rules for a project. Supports searching by name/ID/pattern, filtering by route type,...
+- [Stage routing rules](https://vercel.com/docs/rest-api/project-routes/stage-routing-rules) `PUT /v1/projects/{projectId}/routes` — Stage routing rules for a project. Set `overwrite` to true to replace all existing rules, or omit it...
+- [Add a routing rule](https://vercel.com/docs/rest-api/project-routes/add-a-routing-rule) `POST /v1/projects/{projectId}/routes` — Add a single routing rule to a project at a specified position. Defaults to the end of the list if n...
+- [Delete routing rules](https://vercel.com/docs/rest-api/project-routes/delete-routing-rules) `DELETE /v1/projects/{projectId}/routes` — Delete one or more routing rules from a project by ID. Stages a new version with the routes removed.
+- [Edit a routing rule](https://vercel.com/docs/rest-api/project-routes/edit-a-routing-rule) `PATCH /v1/projects/{projectId}/routes/{routeId}` — Replace a routing rule identified by its ID, or restore it from the current production version. Stag...
+- [Generate a routing rule from natural language](https://vercel.com/docs/rest-api/project-routes/generate-a-routing-rule-from-natural-language) `POST /v1/projects/{projectId}/routes/generate` — Generate a routing rule configuration from a natural language description. Returns a suggested route...
+- [Get routing rule version history](https://vercel.com/docs/rest-api/project-routes/get-routing-rule-version-history) `GET /v1/projects/{projectId}/routes/versions` — Get the version history for a project's routing rules. Returns the staging version (if one exists) f...
+- [Promote, restore, or discard a routing rule version](https://vercel.com/docs/rest-api/project-routes/promote-restore-or-discard-a-routing-rule-version) `POST /v1/projects/{projectId}/routes/versions` — Promote staged routing rules to production, restore a previous production version, or discard staged...
+
+### projectMembers
+
+- [List project members](https://vercel.com/docs/rest-api/projectMembers/list-project-members) `GET /v1/projects/{idOrName}/members` — Lists all members of a project.
+- [Adds a new member to a project.](https://vercel.com/docs/rest-api/projectMembers/adds-a-new-member-to-a-project) `POST /v1/projects/{idOrName}/members` — Adds a new member to the project.
+- [Remove a Project Member](https://vercel.com/docs/rest-api/projectMembers/remove-a-project-member) `DELETE /v1/projects/{idOrName}/members/{uid}` — Remove a member from a specific project
+
+### projects
+
+- [Retrieve a list of projects](https://vercel.com/docs/rest-api/projects/retrieve-a-list-of-projects) `GET /v10/projects` — Allows to retrieve the list of projects of the authenticated user or team. The list will be paginate...
+- [Create a new project](https://vercel.com/docs/rest-api/projects/create-a-new-project) `POST /v11/projects` — Allows to create a new project with the provided configuration. It only requires the project `name` ...
+- [Find a project by id or name](https://vercel.com/docs/rest-api/projects/find-a-project-by-id-or-name) `GET /v9/projects/{idOrName}` — Get the information for a specific project by passing either the project `id` or `name` in the URL.
+- [Update an existing project](https://vercel.com/docs/rest-api/projects/update-an-existing-project) `PATCH /v9/projects/{idOrName}` — Update the fields of a project using either its `name` or `id`.
+- [Delete a Project](https://vercel.com/docs/rest-api/projects/delete-a-project) `DELETE /v9/projects/{idOrName}` — Delete a specific project by passing either the project `id` or `name` in the URL.
+- [Retrieve project domains by project by id or name](https://vercel.com/docs/rest-api/projects/retrieve-project-domains-by-project-by-id-or-name) `GET /v9/projects/{idOrName}/domains` — Retrieve the domains associated with a given project by passing either the project `id` or `name` in...
+- [Get a project domain](https://vercel.com/docs/rest-api/projects/get-a-project-domain) `GET /v9/projects/{idOrName}/domains/{domain}` — Get project domain by project id/name and domain name.
+- [Update a project domain](https://vercel.com/docs/rest-api/projects/update-a-project-domain) `PATCH /v9/projects/{idOrName}/domains/{domain}` — Update a project domain's configuration, including the name, git branch and redirect of the domain.
+- [Remove a domain from a project](https://vercel.com/docs/rest-api/projects/remove-a-domain-from-a-project) `DELETE /v9/projects/{idOrName}/domains/{domain}` — Remove a domain from a project by passing the domain name and by specifying the project by either pa...
+- [Add a domain to a project](https://vercel.com/docs/rest-api/projects/add-a-domain-to-a-project) `POST /v10/projects/{idOrName}/domains` — Add a domain to the project by passing its domain name and by specifying the project by either passi...
+- [Move a project domain](https://vercel.com/docs/rest-api/projects/move-a-project-domain) `POST /v1/projects/{idOrName}/domains/{domain}/move` — Move one project's domain to another project. Also allows the move of all redirects pointed to that ...
+- [Verify project domain](https://vercel.com/docs/rest-api/projects/verify-project-domain) `POST /v9/projects/{idOrName}/domains/{domain}/verify` — Attempts to verify a project domain with `verified = false` by checking the correctness of the proje...
+- [Retrieve the environment variables of a project by id or name](https://vercel.com/docs/rest-api/projects/retrieve-the-environment-variables-of-a-project-by-id-or-name) `GET /v10/projects/{idOrName}/env` — Retrieve the environment variables for a given project by passing either the project `id` or `name` ...
+- [Create one or more environment variables](https://vercel.com/docs/rest-api/projects/create-one-or-more-environment-variables) `POST /v10/projects/{idOrName}/env` — Create one or more environment variables for a project by passing its `key`, `value`, `type` and `ta...
+- [Retrieve the decrypted value of an environment variable of a project by id](https://vercel.com/docs/rest-api/projects/retrieve-the-decrypted-value-of-an-environment-variable-of-a-project-by-id) `GET /v1/projects/{idOrName}/env/{id}` — Retrieve the environment variable for a given project.
+- [Remove an environment variable](https://vercel.com/docs/rest-api/projects/remove-an-environment-variable) `DELETE /v9/projects/{idOrName}/env/{id}` — Delete a specific environment variable for a given project by passing the environment variable ident...
+- [Edit an environment variable](https://vercel.com/docs/rest-api/projects/edit-an-environment-variable) `PATCH /v9/projects/{idOrName}/env/{id}` — Edit a specific environment variable for a given project by passing the environment variable identif...
+- [Batch remove environment variables](https://vercel.com/docs/rest-api/projects/batch-remove-environment-variables) `DELETE /v1/projects/{idOrName}/env` — Delete multiple environment variables for a given project in a single batch operation.
+- [Create project transfer request](https://vercel.com/docs/rest-api/projects/create-project-transfer-request) `POST /projects/{idOrName}/transfer-request` — Initiates a project transfer request from one team to another. <br/> Returns a `code` that remains v...
+- [Accept project transfer request](https://vercel.com/docs/rest-api/projects/accept-project-transfer-request) `PUT /projects/transfer-request/{code}` — Accept a project transfer request initated by another team. <br/> The `code` is generated using the ...
+- [Update Protection Bypass for Automation](https://vercel.com/docs/rest-api/projects/update-protection-bypass-for-automation) `PATCH /v1/projects/{idOrName}/protection-bypass` — Update the deployment protection automation bypass for a project
+- [Points all production domains for a project to the given deploy](https://vercel.com/docs/rest-api/projects/points-all-production-domains-for-a-project-to-the-given-deploy) `POST /v1/projects/{projectId}/rollback/{deploymentId}` — Allows users to rollback to a deployment.
+- [Updates the description for a rollback](https://vercel.com/docs/rest-api/projects/updates-the-description-for-a-rollback) `PATCH /v1/projects/{projectId}/rollback/{deploymentId}/update-description` — Updates the reason for a rollback, without changing the rollback status itself.
+- [Update the microfrontends settings](https://vercel.com/docs/rest-api/projects/update-the-microfrontends-settings) `PATCH /v1/projects/{projectId}/microfrontends` — Update the microfrontends settings for a project.
+- [Points all production domains for a project to the given deploy](https://vercel.com/docs/rest-api/projects/points-all-production-domains-for-a-project-to-the-given-deploy) `POST /v10/projects/{projectId}/promote/{deploymentId}` — Allows users to promote a deployment to production. Note: This does NOT rebuild the deployment. If y...
+- [Gets a list of aliases with status for the current promote](https://vercel.com/docs/rest-api/projects/gets-a-list-of-aliases-with-status-for-the-current-promote) `GET /v1/projects/{projectId}/promote/aliases` — Get a list of aliases related to the last promote request with their mapping status
+- [Pause a project](https://vercel.com/docs/rest-api/projects/pause-a-project) `POST /v1/projects/{projectId}/pause` — Pause a project by passing its project `id` in the URL. If the project does not exist given the id t...
+- [Unpause a project](https://vercel.com/docs/rest-api/projects/unpause-a-project) `POST /v1/projects/{projectId}/unpause` — Unpause a project by passing its project `id` in the URL. If the project does not exist given the id...
+
+### rolling-release
+
+- [Get rolling release billing status](https://vercel.com/docs/rest-api/rolling-release/get-rolling-release-billing-status) `GET /v1/projects/{idOrName}/rolling-release/billing` — Get the Rolling Releases billing status for a project. The team level billing status is used to dete...
+- [Get rolling release configuration](https://vercel.com/docs/rest-api/rolling-release/get-rolling-release-configuration) `GET /v1/projects/{idOrName}/rolling-release/config` — Get the Rolling Releases configuration for a project. The project-level config is simply a template ...
+- [Delete rolling release configuration](https://vercel.com/docs/rest-api/rolling-release/delete-rolling-release-configuration) `DELETE /v1/projects/{idOrName}/rolling-release/config` — Disable Rolling Releases for a project means that future deployments will not undergo a rolling rele...
+- [Update the rolling release settings for the project](https://vercel.com/docs/rest-api/rolling-release/update-the-rolling-release-settings-for-the-project) `PATCH /v1/projects/{idOrName}/rolling-release/config` — Update (or disable) Rolling Releases for a project. When disabling with the resolve-on-disable featu...
+- [Get the active rolling release information for a project](https://vercel.com/docs/rest-api/rolling-release/get-the-active-rolling-release-information-for-a-project) `GET /v1/projects/{idOrName}/rolling-release` — Return the Rolling Release for a project, regardless of whether the rollout is active, aborted, or c...
+- [Update the active rolling release to the next stage for a project](https://vercel.com/docs/rest-api/rolling-release/update-the-active-rolling-release-to-the-next-stage-for-a-project) `POST /v1/projects/{idOrName}/rolling-release/approve-stage` — Advance a rollout to the next stage. This is only needed when rolling releases is configured to requ...
+- [Complete the rolling release for the project](https://vercel.com/docs/rest-api/rolling-release/complete-the-rolling-release-for-the-project) `POST /v1/projects/{idOrName}/rolling-release/complete` — Force-complete a Rolling Release. The canary deployment will begin serving 100% of the traffic.
+
+### sandboxes
+
+- [List sandboxes](https://vercel.com/docs/rest-api/sandboxes/list-sandboxes) `GET /v1/sandboxes` — Retrieves a paginated list of sandboxes belonging to a specific project. Results can be filtered by ...
+- [Create a sandbox](https://vercel.com/docs/rest-api/sandboxes/create-a-sandbox) `POST /v1/sandboxes` — Creates a new sandbox environment for executing code in an isolated virtual machine. A sandbox can b...
+- [List snapshots](https://vercel.com/docs/rest-api/sandboxes/list-snapshots) `GET /v1/sandboxes/snapshots` — Retrieves a paginated list of snapshots for a specific project.
+- [Get a sandbox](https://vercel.com/docs/rest-api/sandboxes/get-a-sandbox) `GET /v1/sandboxes/{sandboxId}` — Retrieves detailed information about a specific sandbox, including its current status, resource conf...
+- [List commands](https://vercel.com/docs/rest-api/sandboxes/list-commands) `GET /v1/sandboxes/{sandboxId}/cmd` — Retrieves a list of all commands that have been executed in a sandbox, including their current statu...
+- [Execute a command](https://vercel.com/docs/rest-api/sandboxes/execute-a-command) `POST /v1/sandboxes/{sandboxId}/cmd` — Executes a shell command inside a running sandbox. The command runs asynchronously and returns immed...
+- [Kill a command](https://vercel.com/docs/rest-api/sandboxes/kill-a-command) `POST /v1/sandboxes/{sandboxId}/{cmdId}/kill` — Sends a signal to terminate a running command in a sandbox. The signal can be used to gracefully sto...
+- [Stop a sandbox](https://vercel.com/docs/rest-api/sandboxes/stop-a-sandbox) `POST /v1/sandboxes/{sandboxId}/stop` — Stops a running sandbox and releases its allocated resources. All running processes within the sandb...
+- [Extend sandbox timeout](https://vercel.com/docs/rest-api/sandboxes/extend-sandbox-timeout) `POST /v1/sandboxes/{sandboxId}/extend-timeout` — Extends the maximum execution time of a running sandbox. The sandbox must be active and able to acce...
+- [Update network policy](https://vercel.com/docs/rest-api/sandboxes/update-network-policy) `POST /v1/sandboxes/{sandboxId}/network-policy` — Replaces the network access policy of a running sandbox. Use this to control which external hosts th...
+- [Get a command](https://vercel.com/docs/rest-api/sandboxes/get-a-command) `GET /v1/sandboxes/{sandboxId}/cmd/{cmdId}` — Retrieves the current status and details of a command executed in a sandbox. Use the `wait` paramete...
+- [Stream command logs](https://vercel.com/docs/rest-api/sandboxes/stream-command-logs) `GET /v1/sandboxes/{sandboxId}/cmd/{cmdId}/logs` — Streams the output of a command in real-time using newline-delimited JSON (ND-JSON). Each entry incl...
+- [Read a file](https://vercel.com/docs/rest-api/sandboxes/read-a-file) `POST /v1/sandboxes/{sandboxId}/fs/read` — Downloads the contents of a file from a sandbox's filesystem. The file content is returned as a bina...
+- [Create a directory](https://vercel.com/docs/rest-api/sandboxes/create-a-directory) `POST /v1/sandboxes/{sandboxId}/fs/mkdir` — Creates a new directory in a sandbox's filesystem. By default, parent directories are created recurs...
+- [Write files](https://vercel.com/docs/rest-api/sandboxes/write-files) `POST /v1/sandboxes/{sandboxId}/fs/write` — Uploads and extracts files to a sandbox's filesystem. Files must be uploaded as a gzipped tarball (`...
+- [Get a snapshot](https://vercel.com/docs/rest-api/sandboxes/get-a-snapshot) `GET /v1/sandboxes/snapshots/{snapshotId}` — Retrieves detailed information about a specific snapshot, including its creation time, size, expirat...
+- [Delete a snapshot](https://vercel.com/docs/rest-api/sandboxes/delete-a-snapshot) `DELETE /v1/sandboxes/snapshots/{snapshotId}` — Permanently deletes a snapshot and frees its associated storage. This action cannot be undone. After...
+- [Create a snapshot](https://vercel.com/docs/rest-api/sandboxes/create-a-snapshot) `POST /v1/sandboxes/{sandboxId}/snapshot` — Creates a point-in-time snapshot of a running sandbox's filesystem. Snapshots can be used to quickly...
+
+### sandboxes-v2-beta
+
+- [List sandboxes](https://vercel.com/docs/rest-api/sandboxes-v2-beta/list-sandboxes) `GET /v2/sandboxes` — Retrieves a paginated list of named sandboxes belonging to a specific project. Results can be sorted...
+- [Create a named sandbox](https://vercel.com/docs/rest-api/sandboxes-v2-beta/create-a-named-sandbox) `POST /v2/sandboxes` — Creates a named sandbox environment. Named sandboxes have a unique name within a project and support...
+- [List snapshots](https://vercel.com/docs/rest-api/sandboxes-v2-beta/list-snapshots) `GET /v2/sandboxes/snapshots` — Retrieves a paginated list of snapshots for a specific project.
+- [Get a snapshot](https://vercel.com/docs/rest-api/sandboxes-v2-beta/get-a-snapshot) `GET /v2/sandboxes/snapshots/{snapshotId}` — Retrieves detailed information about a specific snapshot, including its creation time, size, expirat...
+- [Delete a snapshot](https://vercel.com/docs/rest-api/sandboxes-v2-beta/delete-a-snapshot) `DELETE /v2/sandboxes/snapshots/{snapshotId}` — Permanently deletes a snapshot and frees its associated storage. This action cannot be undone. After...
+- [List sessions](https://vercel.com/docs/rest-api/sandboxes-v2-beta/list-sessions) `GET /v2/sandboxes/sessions` — Retrieves a paginated list of sessions belonging to a specific sandbox. Results are sorted by creati...
+- [Get a session](https://vercel.com/docs/rest-api/sandboxes-v2-beta/get-a-session) `GET /v2/sandboxes/sessions/{sessionId}` — Retrieves detailed information about a specific session, including its current status, resource conf...
+- [Get a named sandbox](https://vercel.com/docs/rest-api/sandboxes-v2-beta/get-a-named-sandbox) `GET /v2/sandboxes/{name}` — Retrieves a named sandbox by name, including its current sandbox and routes. If the sandbox is stopp...
+- [Update a sandbox](https://vercel.com/docs/rest-api/sandboxes-v2-beta/update-a-sandbox) `PATCH /v2/sandboxes/{name}` — Updates the configuration of a sandbox. Only the provided fields will be modified; omitted fields re...
+- [Delete a sandbox](https://vercel.com/docs/rest-api/sandboxes-v2-beta/delete-a-sandbox) `DELETE /v2/sandboxes/{name}` — Deletes a sandbox by name. If sandboxes are currently running, they will be stopped first. This oper...
+- [List commands](https://vercel.com/docs/rest-api/sandboxes-v2-beta/list-commands) `GET /v2/sandboxes/sessions/{sessionId}/cmd` — Retrieves a list of all commands that have been executed in a session, including their current statu...
+- [Execute a command](https://vercel.com/docs/rest-api/sandboxes-v2-beta/execute-a-command) `POST /v2/sandboxes/sessions/{sessionId}/cmd` — Executes a shell command inside a running session. The command runs asynchronously and returns immed...
+- [Get a command](https://vercel.com/docs/rest-api/sandboxes-v2-beta/get-a-command) `GET /v2/sandboxes/sessions/{sessionId}/cmd/{cmdId}` — Retrieves the current status and details of a command executed in a session. Use the `wait` paramete...
+- [Kill a command](https://vercel.com/docs/rest-api/sandboxes-v2-beta/kill-a-command) `POST /v2/sandboxes/sessions/{sessionId}/cmd/{cmdId}/kill` — Sends a signal to terminate a running command in a session. The signal can be used to gracefully sto...
+- [Stream command logs](https://vercel.com/docs/rest-api/sandboxes-v2-beta/stream-command-logs) `GET /v2/sandboxes/sessions/{sessionId}/cmd/{cmdId}/logs` — Streams the output of a command in real-time using newline-delimited JSON (ND-JSON). Each entry incl...
+- [Stop a session](https://vercel.com/docs/rest-api/sandboxes-v2-beta/stop-a-session) `POST /v2/sandboxes/sessions/{sessionId}/stop` — Stops a running session and releases its allocated resources. All running processes within the sessi...
+- [Extend session timeout](https://vercel.com/docs/rest-api/sandboxes-v2-beta/extend-session-timeout) `POST /v2/sandboxes/sessions/{sessionId}/extend-timeout` — Extends the maximum execution time of a running session. The session must be active and able to acce...
+- [Update network policy](https://vercel.com/docs/rest-api/sandboxes-v2-beta/update-network-policy) `POST /v2/sandboxes/sessions/{sessionId}/network-policy` — Replaces the network access policy of a running session. Use this to control which external hosts th...
+- [Read a file](https://vercel.com/docs/rest-api/sandboxes-v2-beta/read-a-file) `POST /v2/sandboxes/sessions/{sessionId}/fs/read` — Downloads the contents of a file from a session's filesystem. The file content is returned as a bina...
+- [Create a directory](https://vercel.com/docs/rest-api/sandboxes-v2-beta/create-a-directory) `POST /v2/sandboxes/sessions/{sessionId}/fs/mkdir` — Creates a new directory in a session's filesystem. By default, parent directories are created recurs...
+- [Write files](https://vercel.com/docs/rest-api/sandboxes-v2-beta/write-files) `POST /v2/sandboxes/sessions/{sessionId}/fs/write` — Uploads and extracts files to a session's filesystem. Files must be uploaded as a gzipped tarball (`...
+- [Create a snapshot](https://vercel.com/docs/rest-api/sandboxes-v2-beta/create-a-snapshot) `POST /v2/sandboxes/sessions/{sessionId}/snapshot` — Creates a point-in-time snapshot of a running session's filesystem. Snapshots can be used to quickly...
+
+### security
+
+- [Update Attack Challenge mode](https://vercel.com/docs/rest-api/security/update-attack-challenge-mode) `POST /v1/security/attack-mode` — Update the setting for determining if the project has Attack Challenge mode enabled.
+- [Put Firewall Configuration](https://vercel.com/docs/rest-api/security/put-firewall-configuration) `PUT /v1/security/firewall/config` — Set the firewall configuration to provided rules and settings. Creates or overwrite the existing fir...
+- [Update Firewall Configuration](https://vercel.com/docs/rest-api/security/update-firewall-configuration) `PATCH /v1/security/firewall/config` — Process updates to modify the existing firewall config for a project
+- [Read Firewall Configuration](https://vercel.com/docs/rest-api/security/read-firewall-configuration) `GET /v1/security/firewall/config/{configVersion}` — Retrieve the specified firewall configuration for a project. The deployed configVersion will be `act...
+- [Read active attack data](https://vercel.com/docs/rest-api/security/read-active-attack-data) `GET /v1/security/firewall/attack-status` — Retrieve active attack data within the last N days (default: 1 day)
+- [Read System Bypass](https://vercel.com/docs/rest-api/security/read-system-bypass) `GET /v1/security/firewall/bypass` — Retrieve the system bypass rules configured for the specified project
+- [Create System Bypass Rule](https://vercel.com/docs/rest-api/security/create-system-bypass-rule) `POST /v1/security/firewall/bypass` — Create new system bypass rules
+- [Remove System Bypass Rule](https://vercel.com/docs/rest-api/security/remove-system-bypass-rule) `DELETE /v1/security/firewall/bypass` — Remove system bypass rules
+- [Read Firewall Actions by Project](https://vercel.com/docs/rest-api/security/read-firewall-actions-by-project) `GET /v1/security/firewall/events` — Retrieve firewall actions for a project
+
+### teams
+
+- [List team members](https://vercel.com/docs/rest-api/teams/list-team-members) `GET /v3/teams/{teamId}/members` — Get a paginated list of team members for the provided team.
+- [Invite a user](https://vercel.com/docs/rest-api/teams/invite-a-user) `POST /v2/teams/{teamId}/members` — Invite a user to join the team specified in the URL. The authenticated user needs to be an `OWNER` i...
+- [Request access to a team](https://vercel.com/docs/rest-api/teams/request-access-to-a-team) `POST /v1/teams/{teamId}/request` — Request access to a team as a member. An owner has to approve the request. Only 10 users can request...
+- [Get access request status](https://vercel.com/docs/rest-api/teams/get-access-request-status) `GET /v1/teams/{teamId}/request/{userId}` — Check the status of a join request. It'll respond with a 404 if the request has been declined. If no...
+- [Join a team](https://vercel.com/docs/rest-api/teams/join-a-team) `POST /v1/teams/{teamId}/members/teams/join` — Join a team with a provided invite code or team ID.
+- [Update a Team Member](https://vercel.com/docs/rest-api/teams/update-a-team-member) `PATCH /v1/teams/{teamId}/members/{uid}` — Update the membership of a Team Member on the Team specified by `teamId`, such as changing the _role...
+- [Remove a Team Member](https://vercel.com/docs/rest-api/teams/remove-a-team-member) `DELETE /v1/teams/{teamId}/members/{uid}` — Remove a Team Member from the Team, or dismiss a user that requested access, or leave a team.
+- [Get a Team](https://vercel.com/docs/rest-api/teams/get-a-team) `GET /v2/teams/{teamId}` — Get information for the Team specified by the `teamId` parameter.
+- [Update a Team](https://vercel.com/docs/rest-api/teams/update-a-team) `PATCH /v2/teams/{teamId}` — Update the information of a Team specified by the `teamId` parameter. The request body should contai...
+- [List all teams](https://vercel.com/docs/rest-api/teams/list-all-teams) `GET /v2/teams` — Get a paginated list of all the Teams the authenticated User is a member of.
+- [Create a Team](https://vercel.com/docs/rest-api/teams/create-a-team) `POST /v1/teams` — Create a new Team under your account. You need to send a POST request with the desired Team slug, an...
+- [Update Team Directory Sync Role Mappings](https://vercel.com/docs/rest-api/teams/update-team-directory-sync-role-mappings) `POST /v1/teams/{teamId}/dsync-roles` — Update the Directory Sync role mappings for a Team. This endpoint allows updating the mapping betwee...
+- [Delete a Team](https://vercel.com/docs/rest-api/teams/delete-a-team) `DELETE /v1/teams/{teamId}` — Delete a team under your account. You need to send a `DELETE` request with the desired team `id`. An...
+- [Delete a Team invite code](https://vercel.com/docs/rest-api/teams/delete-a-team-invite-code) `DELETE /v1/teams/{teamId}/invites/{inviteId}` — Delete an active Team invite code.
+- [Update a microfrontends group](https://vercel.com/docs/rest-api/teams/update-a-microfrontends-group) `PATCH /v1/teams/{teamId}/microfrontends/{groupId}` — Updates the name (and slug) of a microfrontends group.
+- [Delete a microfrontends group](https://vercel.com/docs/rest-api/teams/delete-a-microfrontends-group) `DELETE /v1/teams/{teamId}/microfrontends/{groupId}` — Deletes a microfrontends group from the team associated with the group ID.
+
+### user
+
+- [List User Events](https://vercel.com/docs/rest-api/user/list-user-events) `GET /v3/events` — Retrieves a list of "events" generated by the User on Vercel. Events are generated when the User per...
+- [List Event Types](https://vercel.com/docs/rest-api/user/list-event-types) `GET /v1/events/types` — Returns the list of user-facing event types with descriptions.
+- [Get the User](https://vercel.com/docs/rest-api/user/get-the-user) `GET /v2/user` — Retrieves information related to the currently authenticated User.
+- [Delete User Account](https://vercel.com/docs/rest-api/user/delete-user-account) `DELETE /v1/user` — Initiates the deletion process for the currently authenticated User, by sending a deletion confirmat...
+
+### webhooks
+
+- [Creates a webhook](https://vercel.com/docs/rest-api/webhooks/creates-a-webhook) `POST /v1/webhooks` — Creates a webhook
+- [Get a list of webhooks](https://vercel.com/docs/rest-api/webhooks/get-a-list-of-webhooks) `GET /v1/webhooks` — Get a list of webhooks
+- [Get a webhook](https://vercel.com/docs/rest-api/webhooks/get-a-webhook) `GET /v1/webhooks/{id}` — Get a webhook
+- [Deletes a webhook](https://vercel.com/docs/rest-api/webhooks/deletes-a-webhook) `DELETE /v1/webhooks/{id}` — Deletes a webhook
+
+
+# Vercel SDK Reference
+
+The @vercel/sdk is a type-safe TypeScript SDK for the Vercel REST API.
+Install: npm i @vercel/sdk
+
+## Examples
+
+- [Deployment Automation](https://vercel.com/docs/rest-api/sdk/examples/deployments-automation)
+- [Domain Management](https://vercel.com/docs/rest-api/sdk/examples/domain-management)
+- [Environment Variables](https://vercel.com/docs/rest-api/sdk/examples/environment-variables)
+- [Vercel WAF Management](https://vercel.com/docs/rest-api/sdk/examples/firewall-management)
+- [Integrations](https://vercel.com/docs/rest-api/sdk/examples/integrations)
+- [Logs and Monitoring](https://vercel.com/docs/rest-api/sdk/examples/logs-monitoring)
+- [Managing Redirects](https://vercel.com/docs/rest-api/sdk/examples/managing-redirects)
+- [Project Management](https://vercel.com/docs/rest-api/sdk/examples/project-management)
+- [Rolling Releases Management](https://vercel.com/docs/rest-api/sdk/examples/rolling-releases)
+- [Team and User Management](https://vercel.com/docs/rest-api/sdk/examples/team-management)
+
+## Endpoints
+
+### access-groups
+
+- [Reads an access group](https://vercel.com/docs/rest-api/sdk/access-groups/reads-an-access-group) `GET /v1/access-groups/{idOrName}` — Allows to read an access group
+- [Update an access group](https://vercel.com/docs/rest-api/sdk/access-groups/update-an-access-group) `POST /v1/access-groups/{idOrName}` — Allows to update an access group metadata
+- [Deletes an access group](https://vercel.com/docs/rest-api/sdk/access-groups/deletes-an-access-group) `DELETE /v1/access-groups/{idOrName}` — Allows to delete an access group
+- [List members of an access group](https://vercel.com/docs/rest-api/sdk/access-groups/list-members-of-an-access-group) `GET /v1/access-groups/{idOrName}/members` — List members of an access group
+- [List access groups for a team, project or member](https://vercel.com/docs/rest-api/sdk/access-groups/list-access-groups-for-a-team-project-or-member) `GET /v1/access-groups` — List access groups
+- [Creates an access group](https://vercel.com/docs/rest-api/sdk/access-groups/creates-an-access-group) `POST /v1/access-groups` — Allows to create an access group
+- [List projects of an access group](https://vercel.com/docs/rest-api/sdk/access-groups/list-projects-of-an-access-group) `GET /v1/access-groups/{idOrName}/projects` — List projects of an access group
+- [Create an access group project](https://vercel.com/docs/rest-api/sdk/access-groups/create-an-access-group-project) `POST /v1/access-groups/{accessGroupIdOrName}/projects` — Allows creation of an access group project
+- [Reads an access group project](https://vercel.com/docs/rest-api/sdk/access-groups/reads-an-access-group-project) `GET /v1/access-groups/{accessGroupIdOrName}/projects/{projectId}` — Allows reading an access group project
+- [Update an access group project](https://vercel.com/docs/rest-api/sdk/access-groups/update-an-access-group-project) `PATCH /v1/access-groups/{accessGroupIdOrName}/projects/{projectId}` — Allows update of an access group project
+- [Delete an access group project](https://vercel.com/docs/rest-api/sdk/access-groups/delete-an-access-group-project) `DELETE /v1/access-groups/{accessGroupIdOrName}/projects/{projectId}` — Allows deletion of an access group project
+
+### aliases
+
+- [List Deployment Aliases](https://vercel.com/docs/rest-api/sdk/aliases/list-deployment-aliases) `GET /v2/deployments/{id}/aliases` — Retrieves all Aliases for the Deployment with the given ID. The authenticated user or team must own ...
+- [Assign an Alias](https://vercel.com/docs/rest-api/sdk/aliases/assign-an-alias) `POST /v2/deployments/{id}/aliases` — Creates a new alias for the deployment with the given deployment ID. The authenticated user or team ...
+- [List aliases](https://vercel.com/docs/rest-api/sdk/aliases/list-aliases) `GET /v4/aliases` — Retrieves a list of aliases for the authenticated User or Team. When `domain` is provided, only alia...
+- [Get an Alias](https://vercel.com/docs/rest-api/sdk/aliases/get-an-alias) `GET /v4/aliases/{idOrAlias}` — Retrieves an Alias for the given host name or alias ID.
+- [Delete an Alias](https://vercel.com/docs/rest-api/sdk/aliases/delete-an-alias) `DELETE /v2/aliases/{aliasId}` — Delete an Alias with the specified ID.
+- [Update the protection bypass for a URL](https://vercel.com/docs/rest-api/sdk/aliases/update-the-protection-bypass-for-a-url) `PATCH /aliases/{id}/protection-bypass` — Update the protection bypass for the alias or deployment URL (used for user access & comment access ...
+
+### api-observability
+
+- [Lists disabled Observability Plus projects](https://vercel.com/docs/rest-api/sdk/api-observability/lists-disabled-observability-plus-projects) `GET /v1/observability/manage/configuration/projects` — Lists the projects that are currently configured as disabled for Observability Plus on a team.
+- [Updates a disabled Observability Plus project setting](https://vercel.com/docs/rest-api/sdk/api-observability/updates-a-disabled-observability-plus-project-setting) `PUT /v1/observability/manage/configuration/projects/{projectIdOrName}` — Updates whether Observability Plus is disabled for a single project.
+
+### artifacts
+
+- [Record an artifacts cache usage event](https://vercel.com/docs/rest-api/sdk/artifacts/record-an-artifacts-cache-usage-event) `POST /v8/artifacts/events` — Records an artifacts cache usage event. The body of this request is an array of cache usage events. ...
+- [Get status of Remote Caching for this principal](https://vercel.com/docs/rest-api/sdk/artifacts/get-status-of-remote-caching-for-this-principal) `GET /v8/artifacts/status` — Check the status of Remote Caching for this principal. Returns a JSON-encoded status indicating if R...
+- [Upload a cache artifact](https://vercel.com/docs/rest-api/sdk/artifacts/upload-a-cache-artifact) `PUT /v8/artifacts/{hash}` — Uploads a cache artifact identified by the `hash` specified on the path. The cache artifact can then...
+- [Download a cache artifact](https://vercel.com/docs/rest-api/sdk/artifacts/download-a-cache-artifact) `GET /v8/artifacts/{hash}` — Downloads a cache artifact indentified by its `hash` specified on the request path. The artifact is ...
+- [Check if a cache artifact exists](https://vercel.com/docs/rest-api/sdk/artifacts/check-if-a-cache-artifact-exists) `HEAD /v8/artifacts/{hash}` — Check that a cache artifact with the given `hash` exists. This request returns response headers only...
+- [Query information about an artifact](https://vercel.com/docs/rest-api/sdk/artifacts/query-information-about-an-artifact) `POST /v8/artifacts` — Query information about an array of artifacts.
+
+### authentication
+
+- [SSO Token Exchange](https://vercel.com/docs/rest-api/sdk/authentication/sso-token-exchange) `POST /v1/integrations/sso/token` — During the autorization process, Vercel sends the user to the provider [redirectLoginUrl](https://ve...
+- [List Auth Tokens](https://vercel.com/docs/rest-api/sdk/authentication/list-auth-tokens) `GET /v6/user/tokens` — Retrieve a list of the current User's authentication tokens.
+- [Create an Auth Token](https://vercel.com/docs/rest-api/sdk/authentication/create-an-auth-token) `POST /v3/user/tokens` — Creates and returns a new authentication token for the currently authenticated User. The `bearerToke...
+- [Get Auth Token Metadata](https://vercel.com/docs/rest-api/sdk/authentication/get-auth-token-metadata) `GET /v5/user/tokens/{tokenId}` — Retrieve metadata about an authentication token belonging to the currently authenticated User.
+- [Delete an authentication token](https://vercel.com/docs/rest-api/sdk/authentication/delete-an-authentication-token) `DELETE /v3/user/tokens/{tokenId}` — Invalidate an authentication token, such that it will no longer be valid for future HTTP requests.
+
+### billing
+
+- [List FOCUS billing charges](https://vercel.com/docs/rest-api/sdk/billing/list-focus-billing-charges) `GET /v1/billing/charges` — Returns the billing charge data in FOCUS v1.3 JSONL format for a specified Vercel team, within a dat...
+- [List FOCUS contract commitments](https://vercel.com/docs/rest-api/sdk/billing/list-focus-contract-commitments) `GET /v1/billing/contract-commitments` — Returns commitment allocations per contract period in FOCUS v1.3 JSONL format for a specified Vercel...
+- [Purchase credits](https://vercel.com/docs/rest-api/sdk/billing/purchase-credits) `POST /v1/billing/buy` — Purchases credits for a Vercel team using the default payment method on file. The purchase is charge...
+
+### bulk-redirects
+
+- [Stages new redirects for a project.](https://vercel.com/docs/rest-api/sdk/bulk-redirects/stages-new-redirects-for-a-project) `PUT /v1/bulk-redirects` — Stages new redirects for a project and returns the new version.
+- [Gets project-level redirects.](https://vercel.com/docs/rest-api/sdk/bulk-redirects/gets-project-level-redirects) `GET /v1/bulk-redirects` — Get the version history for a project's bulk redirects
+- [Delete project-level redirects.](https://vercel.com/docs/rest-api/sdk/bulk-redirects/delete-project-level-redirects) `DELETE /v1/bulk-redirects` — Deletes the provided redirects from the latest version of the projects' bulk redirects. Stages a new...
+- [Edit a project-level redirect.](https://vercel.com/docs/rest-api/sdk/bulk-redirects/edit-a-project-level-redirect) `PATCH /v1/bulk-redirects` — Edits a single redirect identified by its source path. Stages a new change with the modified redirec...
+- [Restore staged project-level redirects to their production version.](https://vercel.com/docs/rest-api/sdk/bulk-redirects/restore-staged-project-level-redirects-to-their-production-version) `POST /v1/bulk-redirects/restore` — Restores the provided redirects in the staging version to the value in the production version. If no...
+- [Get the version history for a project's redirects.](https://vercel.com/docs/rest-api/sdk/bulk-redirects/get-the-version-history-for-a-project-s-redirects) `GET /v1/bulk-redirects/versions` — Get the version history for a project's bulk redirects
+- [Promote a staging version to production or restore a previous production version.](https://vercel.com/docs/rest-api/sdk/bulk-redirects/promote-a-staging-version-to-production-or-restore-a-previous-production-version) `POST /v1/bulk-redirects/versions` — Update a version by promoting staging to production or restoring a previous production version
+
+### certs
+
+- [Get cert by id](https://vercel.com/docs/rest-api/sdk/certs/get-cert-by-id) `GET /v8/certs/{id}` — Get cert by id
+- [Remove cert](https://vercel.com/docs/rest-api/sdk/certs/remove-cert) `DELETE /v8/certs/{id}` — Remove cert
+- [Issue a new cert](https://vercel.com/docs/rest-api/sdk/certs/issue-a-new-cert) `POST /v8/certs` — Issue a new cert
+- [Upload a cert](https://vercel.com/docs/rest-api/sdk/certs/upload-a-cert) `PUT /v8/certs` — Upload a cert
+
+### checks
+
+- [Creates a new Check](https://vercel.com/docs/rest-api/sdk/checks/creates-a-new-check) `POST /v1/deployments/{deploymentId}/checks` — Creates a new check. This endpoint must be called with an OAuth2 or it will produce a 400 error.
+- [Retrieve a list of all checks](https://vercel.com/docs/rest-api/sdk/checks/retrieve-a-list-of-all-checks) `GET /v1/deployments/{deploymentId}/checks` — List all of the checks created for a deployment.
+- [Get a single check](https://vercel.com/docs/rest-api/sdk/checks/get-a-single-check) `GET /v1/deployments/{deploymentId}/checks/{checkId}` — Return a detailed response for a single check.
+- [Update a check](https://vercel.com/docs/rest-api/sdk/checks/update-a-check) `PATCH /v1/deployments/{deploymentId}/checks/{checkId}` — Update an existing check. This endpoint must be called with an OAuth2 or it will produce a 400 error...
+- [Rerequest a check](https://vercel.com/docs/rest-api/sdk/checks/rerequest-a-check) `POST /v1/deployments/{deploymentId}/checks/{checkId}/rerequest` — Rerequest a selected check that has failed.
+
+### checks-v2
+
+- [List all checks for a project](https://vercel.com/docs/rest-api/sdk/checks-v2/list-all-checks-for-a-project) `GET /v2/projects/{projectIdOrName}/checks` — List all checks for a project, optionally filtered by target.
+- [Create a check](https://vercel.com/docs/rest-api/sdk/checks-v2/create-a-check) `POST /v2/projects/{projectIdOrName}/checks` — Creates a new check for a project.
+- [Get a check](https://vercel.com/docs/rest-api/sdk/checks-v2/get-a-check) `GET /v2/projects/{projectIdOrName}/checks/{checkId}` — Return a detailed response for a single check.
+- [Update a check](https://vercel.com/docs/rest-api/sdk/checks-v2/update-a-check) `PATCH /v2/projects/{projectIdOrName}/checks/{checkId}` — Update an existing check.
+- [Delete a check](https://vercel.com/docs/rest-api/sdk/checks-v2/delete-a-check) `DELETE /v2/projects/{projectIdOrName}/checks/{checkId}` — Delete an existing check and all of its runs.
+- [List runs for a check](https://vercel.com/docs/rest-api/sdk/checks-v2/list-runs-for-a-check) `GET /v2/projects/{projectIdOrName}/checks/{checkId}/runs` — List all runs associated with a given check.
+- [List check runs for a deployment](https://vercel.com/docs/rest-api/sdk/checks-v2/list-check-runs-for-a-deployment) `GET /v2/deployments/{deploymentId}/check-runs` — List all check runs for a deployment.
+- [Create a check run](https://vercel.com/docs/rest-api/sdk/checks-v2/create-a-check-run) `POST /v2/deployments/{deploymentId}/check-runs` — Creates a new check run for a deployment.
+- [Get a check run](https://vercel.com/docs/rest-api/sdk/checks-v2/get-a-check-run) `GET /v2/deployments/{deploymentId}/check-runs/{checkRunId}` — Return a detailed response for a single check run.
+- [Update a check run](https://vercel.com/docs/rest-api/sdk/checks-v2/update-a-check-run) `PATCH /v2/deployments/{deploymentId}/check-runs/{checkRunId}` — Update an existing check run for a deployment.
+
+### connect
+
+- [List Secure Compute networks](https://vercel.com/docs/rest-api/sdk/connect/list-secure-compute-networks) `GET /v1/connect/networks` — Allows to list Secure Compute networks.
+- [Create a Secure Compute network](https://vercel.com/docs/rest-api/sdk/connect/create-a-secure-compute-network) `POST /v1/connect/networks` — Allows to create a Secure Compute network.
+- [Delete a Secure Compute network](https://vercel.com/docs/rest-api/sdk/connect/delete-a-secure-compute-network) `DELETE /v1/connect/networks/{networkId}` — Allows to delete a Secure Compute network.
+- [Update a Secure Compute network](https://vercel.com/docs/rest-api/sdk/connect/update-a-secure-compute-network) `PATCH /v1/connect/networks/{networkId}` — Allows to update a Secure Compute network.
+- [Read a Secure Compute network](https://vercel.com/docs/rest-api/sdk/connect/read-a-secure-compute-network) `GET /v1/connect/networks/{networkId}` — Allows to read a Secure Compute network.
+- [Configures Static IPs for a project](https://vercel.com/docs/rest-api/sdk/connect/configures-static-ip-s-for-a-project) `PATCH /v1/projects/{idOrName}/shared-connect-links` — Allows configuring Static IPs for a project
+
+### deployments
+
+- [Get deployment events](https://vercel.com/docs/rest-api/sdk/deployments/get-deployment-events) `GET /v3/deployments/{idOrUrl}/events` — Get the build logs of a deployment by deployment ID and build ID. It can work as an infinite stream ...
+- [Update deployment integration action](https://vercel.com/docs/rest-api/sdk/deployments/update-deployment-integration-action) `PATCH /v1/deployments/{deploymentId}/integrations/{integrationConfigurationId}/resources/{resourceId}/actions/{action}` — Updates the deployment integration action for the specified integration installation
+- [Get a deployment by ID or URL](https://vercel.com/docs/rest-api/sdk/deployments/get-a-deployment-by-id-or-url) `GET /v13/deployments/{idOrUrl}` — Retrieves information for a deployment either by supplying its ID (`id` property) or Hostname (`url`...
+- [Create a new deployment](https://vercel.com/docs/rest-api/sdk/deployments/create-a-new-deployment) `POST /v13/deployments` — Create a new deployment with all the required and intended data. If the deployment is not a git depl...
+- [Cancel a deployment](https://vercel.com/docs/rest-api/sdk/deployments/cancel-a-deployment) `PATCH /v12/deployments/{id}/cancel` — This endpoint allows you to cancel a deployment which is currently building, by supplying its `id` i...
+- [Upload Deployment Files](https://vercel.com/docs/rest-api/sdk/deployments/upload-deployment-files) `POST /v2/files` — Before you create a deployment you need to upload the required files for that deployment. To do it, ...
+- [List Deployment Files](https://vercel.com/docs/rest-api/sdk/deployments/list-deployment-files) `GET /v6/deployments/{id}/files` — Allows to retrieve the file structure of the source code of a deployment by supplying the deployment...
+- [Get Deployment File Contents](https://vercel.com/docs/rest-api/sdk/deployments/get-deployment-file-contents) `GET /v8/deployments/{id}/files/{fileId}` — Allows to retrieve the content of a file by supplying the file identifier and the deployment unique ...
+- [List deployments](https://vercel.com/docs/rest-api/sdk/deployments/list-deployments) `GET /v6/deployments` — List deployments under the authenticated user or team. If a deployment hasn't finished uploading (is...
+- [Delete a Deployment](https://vercel.com/docs/rest-api/sdk/deployments/delete-a-deployment) `DELETE /v13/deployments/{id}` — This API allows you to delete a deployment, either by supplying its `id` in the URL or the `url` of ...
+
+### dns
+
+- [List existing DNS records](https://vercel.com/docs/rest-api/sdk/dns/list-existing-dns-records) `GET /v5/domains/{domain}/records` — Retrieves a list of DNS records created for a domain name. By default it returns 20 records if no li...
+- [Create a DNS record](https://vercel.com/docs/rest-api/sdk/dns/create-a-dns-record) `POST /v2/domains/{domain}/records` — Creates a DNS record for a domain.
+- [Update an existing DNS record](https://vercel.com/docs/rest-api/sdk/dns/update-an-existing-dns-record) `PATCH /v1/domains/records/{recordId}` — Updates an existing DNS record for a domain name.
+- [Delete a DNS record](https://vercel.com/docs/rest-api/sdk/dns/delete-a-dns-record) `DELETE /v2/domains/{domain}/records/{recordId}` — Removes an existing DNS record from a domain name.
+
+### domains
+
+- [Get a Domain's configuration](https://vercel.com/docs/rest-api/sdk/domains/get-a-domain-s-configuration) `GET /v6/domains/{domain}/config` — Get a Domain's configuration.
+- [Get Information for a Single Domain](https://vercel.com/docs/rest-api/sdk/domains/get-information-for-a-single-domain) `GET /v5/domains/{domain}` — Get information for a single domain in an account or team.
+- [List all the domains](https://vercel.com/docs/rest-api/sdk/domains/list-all-the-domains) `GET /v5/domains` — Retrieves a list of domains registered for the authenticated user or team. By default it returns the...
+- [Add an existing domain to the Vercel platform](https://vercel.com/docs/rest-api/sdk/domains/add-an-existing-domain-to-the-vercel-platform) `POST /v7/domains` — This endpoint is used for adding a new apex domain name with Vercel for the authenticating user. Not...
+- [Update or move apex domain](https://vercel.com/docs/rest-api/sdk/domains/update-or-move-apex-domain) `PATCH /v3/domains/{domain}` — Update or move apex domain. Note: This endpoint is no longer used for updating auto-renew or nameser...
+- [Remove a domain by name](https://vercel.com/docs/rest-api/sdk/domains/remove-a-domain-by-name) `DELETE /v6/domains/{domain}` — Delete a previously registered domain name from Vercel. Deleting a domain will automatically remove ...
+
+### domains-registrar
+
+- [Get supported TLDs](https://vercel.com/docs/rest-api/sdk/domains-registrar/get-supported-tld-s) `GET /v1/registrar/tlds/supported` — Get a list of TLDs supported by Vercel
+- [Get TLD](https://vercel.com/docs/rest-api/sdk/domains-registrar/get-tld) `GET /v1/registrar/tlds/{tld}` — Get the metadata for a specific TLD.
+- [Get TLD price data](https://vercel.com/docs/rest-api/sdk/domains-registrar/get-tld-price-data) `GET /v1/registrar/tlds/{tld}/price` — Get price data for a specific TLD. This only reflects base prices for the given TLD. Premium domains...
+- [Get availability for a domain](https://vercel.com/docs/rest-api/sdk/domains-registrar/get-availability-for-a-domain) `GET /v1/registrar/domains/{domain}/availability` — Get availability for a specific domain. If the domain is available, it can be purchased using the [B...
+- [Get price data for a domain](https://vercel.com/docs/rest-api/sdk/domains-registrar/get-price-data-for-a-domain) `GET /v1/registrar/domains/{domain}/price` — Get price data for a specific domain
+- [Get availability for multiple domains](https://vercel.com/docs/rest-api/sdk/domains-registrar/get-availability-for-multiple-domains) `POST /v1/registrar/domains/availability` — Get availability for multiple domains. If the domains are available, they can be purchased using the...
+- [Get the auth code for a domain](https://vercel.com/docs/rest-api/sdk/domains-registrar/get-the-auth-code-for-a-domain) `GET /v1/registrar/domains/{domain}/auth-code` — Get the auth code for a domain. This is required to transfer a domain from Vercel to another registr...
+- [Buy a domain](https://vercel.com/docs/rest-api/sdk/domains-registrar/buy-a-domain) `POST /v1/registrar/domains/{domain}/buy` — Buy a domain
+- [Buy multiple domains](https://vercel.com/docs/rest-api/sdk/domains-registrar/buy-multiple-domains) `POST /v1/registrar/domains/buy` — Buy multiple domains at once
+- [Transfer-in a domain](https://vercel.com/docs/rest-api/sdk/domains-registrar/transfer-in-a-domain) `POST /v1/registrar/domains/{domain}/transfer` — Transfer a domain in from another registrar
+- [Get a domain's transfer status](https://vercel.com/docs/rest-api/sdk/domains-registrar/get-a-domain-s-transfer-status) `GET /v1/registrar/domains/{domain}/transfer` — Get the transfer status for a domain
+- [Renew a domain](https://vercel.com/docs/rest-api/sdk/domains-registrar/renew-a-domain) `POST /v1/registrar/domains/{domain}/renew` — Renew a domain
+- [Update auto-renew for a domain](https://vercel.com/docs/rest-api/sdk/domains-registrar/update-auto-renew-for-a-domain) `PATCH /v1/registrar/domains/{domain}/auto-renew` — Update the auto-renew setting for a domain
+- [Update nameservers for a domain](https://vercel.com/docs/rest-api/sdk/domains-registrar/update-nameservers-for-a-domain) `PATCH /v1/registrar/domains/{domain}/nameservers` — Update the nameservers for a domain. Pass an empty array to use Vercel's default nameservers.
+- [Get contact info schema](https://vercel.com/docs/rest-api/sdk/domains-registrar/get-contact-info-schema) `GET /v1/registrar/domains/{domain}/contact-info/schema` — Some TLDs require additional contact information. Use this endpoint to get the schema for the tld-sp...
+- [Get a domain order](https://vercel.com/docs/rest-api/sdk/domains-registrar/get-a-domain-order) `GET /v1/registrar/orders/{orderId}` — Get information about a domain order by its ID
+
+### drains
+
+- [Create a new Drain](https://vercel.com/docs/rest-api/sdk/drains/create-a-new-drain) `POST /v1/drains` — Create a new Drain with the provided configuration.
+- [Retrieve a list of all Drains](https://vercel.com/docs/rest-api/sdk/drains/retrieve-a-list-of-all-drains) `GET /v1/drains` — Allows to retrieve the list of Drains of the authenticated team.
+- [Delete a drain](https://vercel.com/docs/rest-api/sdk/drains/delete-a-drain) `DELETE /v1/drains/{id}` — Delete a specific Drain by passing the drain id in the URL.
+- [Find a Drain by id](https://vercel.com/docs/rest-api/sdk/drains/find-a-drain-by-id) `GET /v1/drains/{id}` — Get the information for a specific Drain by passing the drain id in the URL.
+- [Update an existing Drain](https://vercel.com/docs/rest-api/sdk/drains/update-an-existing-drain) `PATCH /v1/drains/{id}` — Update the configuration of an existing drain.
+- [Validate Drain delivery configuration](https://vercel.com/docs/rest-api/sdk/drains/validate-drain-delivery-configuration) `POST /v1/drains/test` — Validate the delivery configuration of a Drain using sample events.
+
+### edge-cache
+
+- [Invalidate by tag](https://vercel.com/docs/rest-api/sdk/edge-cache/invalidate-by-tag) `POST /v1/edge-cache/invalidate-by-tags` — Marks a cache tag as stale, causing cache entries associated with that tag to be revalidated in the ...
+- [Dangerously delete by tag](https://vercel.com/docs/rest-api/sdk/edge-cache/dangerously-delete-by-tag) `POST /v1/edge-cache/dangerously-delete-by-tags` — Marks a cache tag as deleted, causing cache entries associated with that tag to be revalidated in th...
+- [Invalidate by source image](https://vercel.com/docs/rest-api/sdk/edge-cache/invalidate-by-source-image) `POST /v1/edge-cache/invalidate-by-src-images` — Marks a source image as stale, causing its corresponding transformed images to be revalidated in the...
+- [Dangerously delete by source image](https://vercel.com/docs/rest-api/sdk/edge-cache/dangerously-delete-by-source-image) `POST /v1/edge-cache/dangerously-delete-by-src-images` — Marks a source image as deleted, causing cache entries associated with that source image to be reval...
+
+### edge-config
+
+- [Get Edge Configs](https://vercel.com/docs/rest-api/sdk/edge-config/get-edge-configs) `GET /v1/edge-config` — Returns all Edge Configs.
+- [Create an Edge Config](https://vercel.com/docs/rest-api/sdk/edge-config/create-an-edge-config) `POST /v1/edge-config` — Creates an Edge Config.
+- [Get an Edge Config](https://vercel.com/docs/rest-api/sdk/edge-config/get-an-edge-config) `GET /v1/edge-config/{edgeConfigId}` — Returns an Edge Config.
+- [Update an Edge Config](https://vercel.com/docs/rest-api/sdk/edge-config/update-an-edge-config) `PUT /v1/edge-config/{edgeConfigId}` — Updates an Edge Config.
+- [Delete an Edge Config](https://vercel.com/docs/rest-api/sdk/edge-config/delete-an-edge-config) `DELETE /v1/edge-config/{edgeConfigId}` — Delete an Edge Config by id.
+- [Get Edge Config items](https://vercel.com/docs/rest-api/sdk/edge-config/get-edge-config-items) `GET /v1/edge-config/{edgeConfigId}/items` — Returns all items of an Edge Config.
+- [Update Edge Config items in batch](https://vercel.com/docs/rest-api/sdk/edge-config/update-edge-config-items-in-batch) `PATCH /v1/edge-config/{edgeConfigId}/items` — Update multiple Edge Config Items in batch.
+- [Get Edge Config schema](https://vercel.com/docs/rest-api/sdk/edge-config/get-edge-config-schema) `GET /v1/edge-config/{edgeConfigId}/schema` — Returns the schema of an Edge Config.
+- [Update Edge Config schema](https://vercel.com/docs/rest-api/sdk/edge-config/update-edge-config-schema) `POST /v1/edge-config/{edgeConfigId}/schema` — Update an Edge Config's schema.
+- [Delete an Edge Config's schema](https://vercel.com/docs/rest-api/sdk/edge-config/delete-an-edge-config-s-schema) `DELETE /v1/edge-config/{edgeConfigId}/schema` — Deletes the schema of existing Edge Config.
+- [Get an Edge Config item](https://vercel.com/docs/rest-api/sdk/edge-config/get-an-edge-config-item) `GET /v1/edge-config/{edgeConfigId}/item/{edgeConfigItemKey}` — Returns a specific Edge Config Item.
+- [Get all tokens of an Edge Config](https://vercel.com/docs/rest-api/sdk/edge-config/get-all-tokens-of-an-edge-config) `GET /v1/edge-config/{edgeConfigId}/tokens` — Returns all tokens of an Edge Config.
+- [Delete one or more Edge Config tokens](https://vercel.com/docs/rest-api/sdk/edge-config/delete-one-or-more-edge-config-tokens) `DELETE /v1/edge-config/{edgeConfigId}/tokens` — Deletes one or more tokens of an existing Edge Config.
+- [Get Edge Config token meta data](https://vercel.com/docs/rest-api/sdk/edge-config/get-edge-config-token-meta-data) `GET /v1/edge-config/{edgeConfigId}/token/{token}` — Return meta data about an Edge Config token.
+- [Create an Edge Config token](https://vercel.com/docs/rest-api/sdk/edge-config/create-an-edge-config-token) `POST /v1/edge-config/{edgeConfigId}/token` — Adds a token to an existing Edge Config.
+- [Get Edge Config backup](https://vercel.com/docs/rest-api/sdk/edge-config/get-edge-config-backup) `GET /v1/edge-config/{edgeConfigId}/backups/{edgeConfigBackupVersionId}` — Retrieves a specific version of an Edge Config from backup storage.
+- [Get Edge Config backups](https://vercel.com/docs/rest-api/sdk/edge-config/get-edge-config-backups) `GET /v1/edge-config/{edgeConfigId}/backups` — Returns backups of an Edge Config.
+
+### environment
+
+- [Create one or more shared environment variables](https://vercel.com/docs/rest-api/sdk/environment/create-one-or-more-shared-environment-variables) `POST /v1/env` — Creates shared environment variable(s) for a team.
+- [Lists all Shared Environment Variables for a team](https://vercel.com/docs/rest-api/sdk/environment/lists-all-shared-environment-variables-for-a-team) `GET /v1/env` — Lists all Shared Environment Variables for a team, taking into account optional filters.
+- [Updates one or more shared environment variables](https://vercel.com/docs/rest-api/sdk/environment/updates-one-or-more-shared-environment-variables) `PATCH /v1/env` — Updates a given Shared Environment Variable for a Team.
+- [Delete one or more Env Var](https://vercel.com/docs/rest-api/sdk/environment/delete-one-or-more-env-var) `DELETE /v1/env` — Deletes one or many Shared Environment Variables for a given team.
+- [Retrieve the decrypted value of a Shared Environment Variable by id.](https://vercel.com/docs/rest-api/sdk/environment/retrieve-the-decrypted-value-of-a-shared-environment-variable-by-id) `GET /v1/env/{id}` — Retrieve the decrypted value of a Shared Environment Variable by id.
+- [Disconnects a shared environment variable for a given project](https://vercel.com/docs/rest-api/sdk/environment/disconnects-a-shared-environment-variable-for-a-given-project) `PATCH /v1/env/{id}/unlink/{projectId}` — Disconnects a shared environment variable for a given project
+- [Create a custom environment for the current project.](https://vercel.com/docs/rest-api/sdk/environment/create-a-custom-environment-for-the-current-project) `POST /v9/projects/{idOrName}/custom-environments` — Creates a custom environment for the current project. Cannot be named 'Production' or 'Preview'.
+- [Retrieve custom environments](https://vercel.com/docs/rest-api/sdk/environment/retrieve-custom-environments) `GET /v9/projects/{idOrName}/custom-environments` — Retrieve custom environments for the project. Must not be named 'Production' or 'Preview'.
+- [Retrieve a custom environment](https://vercel.com/docs/rest-api/sdk/environment/retrieve-a-custom-environment) `GET /v9/projects/{idOrName}/custom-environments/{environmentSlugOrId}` — Retrieve a custom environment for the project. Must not be named 'Production' or 'Preview'.
+- [Update a custom environment](https://vercel.com/docs/rest-api/sdk/environment/update-a-custom-environment) `PATCH /v9/projects/{idOrName}/custom-environments/{environmentSlugOrId}` — Update a custom environment for the project. Must not be named 'Production' or 'Preview'.
+- [Remove a custom environment](https://vercel.com/docs/rest-api/sdk/environment/remove-a-custom-environment) `DELETE /v9/projects/{idOrName}/custom-environments/{environmentSlugOrId}` — Remove a custom environment for the project. Must not be named 'Production' or 'Preview'.
+
+### feature-flags
+
+- [List flags](https://vercel.com/docs/rest-api/sdk/feature-flags/list-flags) `GET /v1/projects/{projectIdOrName}/feature-flags/flags` — Retrieve feature flags for a project. The list can be filtered by state and supports pagination.
+- [Create a flag](https://vercel.com/docs/rest-api/sdk/feature-flags/create-a-flag) `PUT /v1/projects/{projectIdOrName}/feature-flags/flags` — Create a new feature flag for a project. The flag must have a unique slug within the project and spe...
+- [Get a flag](https://vercel.com/docs/rest-api/sdk/feature-flags/get-a-flag) `GET /v1/projects/{projectIdOrName}/feature-flags/flags/{flagIdOrSlug}` — Retrieve a specific feature flag by its ID or slug.
+- [Update a flag](https://vercel.com/docs/rest-api/sdk/feature-flags/update-a-flag) `PATCH /v1/projects/{projectIdOrName}/feature-flags/flags/{flagIdOrSlug}` — Update an existing feature flag. This endpoint supports partial updates, allowing you to modify spec...
+- [Delete a flag](https://vercel.com/docs/rest-api/sdk/feature-flags/delete-a-flag) `DELETE /v1/projects/{projectIdOrName}/feature-flags/flags/{flagIdOrSlug}` — Permanently delete a feature flag from the project. This action cannot be undone. Consider archiving...
+- [List flag versions](https://vercel.com/docs/rest-api/sdk/feature-flags/list-flag-versions) `GET /v1/projects/{projectIdOrName}/feature-flags/flags/{flagIdOrSlug}/versions` — Lists flag versions for a given flag.
+- [Get project flag settings](https://vercel.com/docs/rest-api/sdk/feature-flags/get-project-flag-settings) `GET /v1/projects/{projectIdOrName}/feature-flags/settings` — Retrieve feature flag settings for a project.
+- [Update project flag settings](https://vercel.com/docs/rest-api/sdk/feature-flags/update-project-flag-settings) `PATCH /v1/projects/{projectIdOrName}/feature-flags/settings` — Update feature flag settings for a project.
+- [List team project flag settings](https://vercel.com/docs/rest-api/sdk/feature-flags/list-team-project-flag-settings) `GET /v1/teams/{teamId}/feature-flags/settings` — Retrieve feature flag settings for projects in a team.
+- [List all flags for a team](https://vercel.com/docs/rest-api/sdk/feature-flags/list-all-flags-for-a-team) `GET /v1/teams/{teamId}/feature-flags/flags` — Retrieve all feature flags for a team across all projects. The list can be filtered by state and sup...
+- [Create a segment](https://vercel.com/docs/rest-api/sdk/feature-flags/create-a-segment) `PUT /v1/projects/{projectIdOrName}/feature-flags/segments` — Create a new feature flag segment.
+- [List segments](https://vercel.com/docs/rest-api/sdk/feature-flags/list-segments) `GET /v1/projects/{projectIdOrName}/feature-flags/segments` — List all feature flag segments for a project.
+- [Get a segment](https://vercel.com/docs/rest-api/sdk/feature-flags/get-a-segment) `GET /v1/projects/{projectIdOrName}/feature-flags/segments/{segmentIdOrSlug}` — Retrieve a feature flag segment by ID or slug.
+- [Delete a segment](https://vercel.com/docs/rest-api/sdk/feature-flags/delete-a-segment) `DELETE /v1/projects/{projectIdOrName}/feature-flags/segments/{segmentIdOrSlug}` — Delete a feature flag segment.
+- [Update a segment](https://vercel.com/docs/rest-api/sdk/feature-flags/update-a-segment) `PATCH /v1/projects/{projectIdOrName}/feature-flags/segments/{segmentIdOrSlug}` — Update an existing feature flag segment.
+- [Retrieve the feature flags of a deployment](https://vercel.com/docs/rest-api/sdk/feature-flags/retrieve-the-feature-flags-of-a-deployment) `GET /v1/deployments/{deploymentId}/feature-flags` — Retrieve the feature flags of a deployment.
+- [Get all SDK keys](https://vercel.com/docs/rest-api/sdk/feature-flags/get-all-sdk-keys) `GET /v1/projects/{projectIdOrName}/feature-flags/sdk-keys` — Gets all SDK keys for a project.
+- [Create an SDK key](https://vercel.com/docs/rest-api/sdk/feature-flags/create-an-sdk-key) `PUT /v1/projects/{projectIdOrName}/feature-flags/sdk-keys` — Creates an SDK key.
+- [Delete an SDK key](https://vercel.com/docs/rest-api/sdk/feature-flags/delete-an-sdk-key) `DELETE /v1/projects/{projectIdOrName}/feature-flags/sdk-keys/{hashKey}` — Deletes an SDK key.
+
+### integrations
+
+- [List git namespaces by provider](https://vercel.com/docs/rest-api/sdk/integrations/list-git-namespaces-by-provider) `GET /v1/integrations/git-namespaces` — Lists git namespaces for a supported provider. Supported providers are `github`, `gitlab` and `bitbu...
+- [List git repositories linked to namespace by provider](https://vercel.com/docs/rest-api/sdk/integrations/list-git-repositories-linked-to-namespace-by-provider) `GET /v1/integrations/search-repo` — Lists git repositories linked to a namespace `id` for a supported provider. A specific namespace `id...
+- [List integration billing plans](https://vercel.com/docs/rest-api/sdk/integrations/list-integration-billing-plans) `GET /v1/integrations/integration/{integrationIdOrSlug}/products/{productIdOrSlug}/plans` — Get a list of billing plans for an integration and product.
+- [Connect integration resource to project](https://vercel.com/docs/rest-api/sdk/integrations/connect-integration-resource-to-project) `POST /v1/integrations/installations/{integrationConfigurationId}/resources/{resourceId}/connections` — Connects an integration resource to a Vercel project. This endpoint establishes a connection between...
+- [Get configurations for the authenticated user or team](https://vercel.com/docs/rest-api/sdk/integrations/get-configurations-for-the-authenticated-user-or-team) `GET /v1/integrations/configurations` — Allows to retrieve all configurations for an authenticated integration. When the `project` view is u...
+- [Retrieve an integration configuration](https://vercel.com/docs/rest-api/sdk/integrations/retrieve-an-integration-configuration) `GET /v1/integrations/configuration/{id}` — Allows to retrieve a the configuration with the provided id in case it exists. The authenticated use...
+- [Delete an integration configuration](https://vercel.com/docs/rest-api/sdk/integrations/delete-an-integration-configuration) `DELETE /v1/integrations/configuration/{id}` — Allows to remove the configuration with the `id` provided in the parameters. The configuration and a...
+- [List products for integration configuration](https://vercel.com/docs/rest-api/sdk/integrations/list-products-for-integration-configuration) `GET /v1/integrations/configuration/{id}/products` — Returns products available for an integration configuration. Each product includes a `metadataSchema...
+- [Create integration store (free and paid plans)](https://vercel.com/docs/rest-api/sdk/integrations/create-integration-store-free-and-paid-plans) `POST /v1/storage/stores/integration/direct` — Creates an integration store with automatic billing plan handling. For free resources, omit `billing...
+
+### logDrains
+
+- [Retrieves a Configurable Log Drain (deprecated)](https://vercel.com/docs/rest-api/sdk/logDrains/retrieves-a-configurable-log-drain-deprecated) `GET /v1/log-drains/{id}` — Retrieves a Configurable Log Drain. This endpoint must be called with a team AccessToken (integratio...
+- [Deletes a Configurable Log Drain (deprecated)](https://vercel.com/docs/rest-api/sdk/logDrains/deletes-a-configurable-log-drain-deprecated) `DELETE /v1/log-drains/{id}` — Deletes a Configurable Log Drain. This endpoint must be called with a team AccessToken (integration ...
+- [Retrieves a list of all the Log Drains (deprecated)](https://vercel.com/docs/rest-api/sdk/logDrains/retrieves-a-list-of-all-the-log-drains-deprecated) `GET /v1/log-drains` — Retrieves a list of all the Log Drains owned by the account. This endpoint must be called with an ac...
+- [Creates a Configurable Log Drain (deprecated)](https://vercel.com/docs/rest-api/sdk/logDrains/creates-a-configurable-log-drain-deprecated) `POST /v1/log-drains` — Creates a configurable log drain. This endpoint must be called with a team AccessToken (integration ...
+- [Retrieves a list of Integration log drains (deprecated)](https://vercel.com/docs/rest-api/sdk/logDrains/retrieves-a-list-of-integration-log-drains-deprecated) `GET /v2/integrations/log-drains` — Retrieves a list of all Integration log drains that are defined for the authenticated user or team. ...
+- [Creates a new Integration Log Drain (deprecated)](https://vercel.com/docs/rest-api/sdk/logDrains/creates-a-new-integration-log-drain-deprecated) `POST /v2/integrations/log-drains` — Creates an Integration log drain. This endpoint must be called with an OAuth2 client (integration), ...
+- [Deletes the Integration log drain with the provided `id` (deprecated)](https://vercel.com/docs/rest-api/sdk/logDrains/deletes-the-integration-log-drain-with-the-provided-id-deprecated) `DELETE /v1/integrations/log-drains/{id}` — Deletes the Integration log drain with the provided `id`. When using an OAuth2 Token, the log drain ...
+
+### logs
+
+- [Get logs for a deployment](https://vercel.com/docs/rest-api/sdk/logs/get-logs-for-a-deployment) `GET /v1/projects/{projectId}/deployments/{deploymentId}/runtime-logs` — Returns a stream of logs for a given deployment.
+
+### marketplace
+
+- [Update Installation](https://vercel.com/docs/rest-api/sdk/marketplace/update-installation) `PATCH /v1/installations/{integrationConfigurationId}` — This endpoint updates an integration installation.
+- [Get Account Information](https://vercel.com/docs/rest-api/sdk/marketplace/get-account-information) `GET /v1/installations/{integrationConfigurationId}/account` — Fetches the best account or user’s contact info
+- [Get Member Information](https://vercel.com/docs/rest-api/sdk/marketplace/get-member-information) `GET /v1/installations/{integrationConfigurationId}/member/{memberId}` — Returns the member role and other information for a given member ID ("user_id" claim in the SSO OIDC...
+- [Create Event](https://vercel.com/docs/rest-api/sdk/marketplace/create-event) `POST /v1/installations/{integrationConfigurationId}/events` — Partner notifies Vercel of any changes made to an Installation or a Resource. Vercel is expected to ...
+- [Get Integration Resources](https://vercel.com/docs/rest-api/sdk/marketplace/get-integration-resources) `GET /v1/installations/{integrationConfigurationId}/resources` — Get all resources for a given installation ID.
+- [Get Integration Resource](https://vercel.com/docs/rest-api/sdk/marketplace/get-integration-resource) `GET /v1/installations/{integrationConfigurationId}/resources/{resourceId}` — Get a resource by its partner ID.
+- [Delete Integration Resource](https://vercel.com/docs/rest-api/sdk/marketplace/delete-integration-resource) `DELETE /v1/installations/{integrationConfigurationId}/resources/{resourceId}` — Delete a resource owned by the selected installation ID.
+- [Import Resource](https://vercel.com/docs/rest-api/sdk/marketplace/import-resource) `PUT /v1/installations/{integrationConfigurationId}/resources/{resourceId}` — This endpoint imports (upserts) a resource to Vercel's installation. This may be needed if resources...
+- [Update Resource](https://vercel.com/docs/rest-api/sdk/marketplace/update-resource) `PATCH /v1/installations/{integrationConfigurationId}/resources/{resourceId}` — This endpoint updates an existing resource in the installation. All parameters are optional, allowin...
+- [Submit Billing Data](https://vercel.com/docs/rest-api/sdk/marketplace/submit-billing-data) `POST /v1/installations/{integrationConfigurationId}/billing` — Sends the billing and usage data. The partner should do this at least once a day and ideally once pe...
+- [Submit Invoice](https://vercel.com/docs/rest-api/sdk/marketplace/submit-invoice) `POST /v1/installations/{integrationConfigurationId}/billing/invoices` — This endpoint allows the partner to submit an invoice to Vercel. The invoice is created in Vercel's ...
+- [Finalize Installation](https://vercel.com/docs/rest-api/sdk/marketplace/finalize-installation) `POST /v1/installations/{integrationConfigurationId}/billing/finalize` — This endpoint allows the partner to mark an installation as finalized. This means you will not send ...
+- [Get Invoice](https://vercel.com/docs/rest-api/sdk/marketplace/get-invoice) `GET /v1/installations/{integrationConfigurationId}/billing/invoices/{invoiceId}` — Get Invoice details and status for a given invoice ID.<br/> <br/> See [Billing Events with Webhooks ...
+- [Invoice Actions](https://vercel.com/docs/rest-api/sdk/marketplace/invoice-actions) `POST /v1/installations/{integrationConfigurationId}/billing/invoices/{invoiceId}/actions` — This endpoint allows the partner to request a refund for an invoice to Vercel. The invoice is create...
+- [Submit Prepayment Balances](https://vercel.com/docs/rest-api/sdk/marketplace/submit-prepayment-balances) `POST /v1/installations/{integrationConfigurationId}/billing/balance` — Sends the prepayment balances. The partner should do this at least once a day and ideally once per h...
+- [Deprecated: true. Update Resource Secrets (Deprecated)](https://vercel.com/docs/rest-api/sdk/marketplace/deprecated-true-update-resource-secrets-deprecated) `PUT /v1/installations/{integrationConfigurationId}/products/{integrationProductIdOrSlug}/resources/{resourceId}/secrets` — This endpoint is deprecated and replaced with the endpoint [Update Resource Secrets](#update-resourc...
+- [Update Resource Secrets](https://vercel.com/docs/rest-api/sdk/marketplace/update-resource-secrets) `PUT /v1/installations/{integrationConfigurationId}/resources/{resourceId}/secrets` — This endpoint updates the secrets of a resource. If a resource has projects connected, the connected...
+- [Create one or multiple experimentation items](https://vercel.com/docs/rest-api/sdk/marketplace/create-one-or-multiple-experimentation-items) `POST /v1/installations/{integrationConfigurationId}/resources/{resourceId}/experimentation/items` — Create one or multiple experimentation items
+- [Patch an existing experimentation item](https://vercel.com/docs/rest-api/sdk/marketplace/patch-an-existing-experimentation-item) `PATCH /v1/installations/{integrationConfigurationId}/resources/{resourceId}/experimentation/items/{itemId}` — Patch an existing experimentation item
+- [Delete an existing experimentation item](https://vercel.com/docs/rest-api/sdk/marketplace/delete-an-existing-experimentation-item) `DELETE /v1/installations/{integrationConfigurationId}/resources/{resourceId}/experimentation/items/{itemId}` — Delete an existing experimentation item
+- [Get the data of a user-provided Edge Config](https://vercel.com/docs/rest-api/sdk/marketplace/get-the-data-of-a-user-provided-edge-config) `HEAD /v1/installations/{integrationConfigurationId}/resources/{resourceId}/experimentation/edge-config` — When the user enabled Edge Config syncing, then this endpoint can be used by the partner to fetch th...
+- [Get the data of a user-provided Edge Config](https://vercel.com/docs/rest-api/sdk/marketplace/get-the-data-of-a-user-provided-edge-config) `GET /v1/installations/{integrationConfigurationId}/resources/{resourceId}/experimentation/edge-config` — When the user enabled Edge Config syncing, then this endpoint can be used by the partner to fetch th...
+- [Push data into a user-provided Edge Config](https://vercel.com/docs/rest-api/sdk/marketplace/push-data-into-a-user-provided-edge-config) `PUT /v1/installations/{integrationConfigurationId}/resources/{resourceId}/experimentation/edge-config` — When the user enabled Edge Config syncing, then this endpoint can be used by the partner to push the...
+
+### microfrontends
+
+- [List microfrontends groups](https://vercel.com/docs/rest-api/sdk/microfrontends/list-microfrontends-groups) `GET /v1/microfrontends/groups` — Get the microfrontends group IDs for a team.
+- [List projects in a microfrontends group](https://vercel.com/docs/rest-api/sdk/microfrontends/list-projects-in-a-microfrontends-group) `GET /v1/microfrontends/groups/{groupId}/projects` — Get the microfrontends for a given group ID.
+- [Get microfrontends config for a deployment](https://vercel.com/docs/rest-api/sdk/microfrontends/get-microfrontends-config-for-a-deployment) `GET /v1/microfrontends/{deploymentId}/config` — Get the microfrontends config for a deployment.
+- [Get microfrontends config for a project](https://vercel.com/docs/rest-api/sdk/microfrontends/get-microfrontends-config-for-a-project) `GET /v1/microfrontends/projects/{projectIdOrName}/production-mfe-config` — Get the microfrontends config for a project by ID or name.
+- [Create a microfrontends group with applications](https://vercel.com/docs/rest-api/sdk/microfrontends/create-a-microfrontends-group-with-applications) `POST /v1/microfrontends/group` — Creates a microfrontends group and attaches multiple projects in a single request.
+
+### project-routes
+
+- [Get project routing rules](https://vercel.com/docs/rest-api/sdk/project-routes/get-project-routing-rules) `GET /v1/projects/{projectId}/routes` — Get the routing rules for a project. Supports searching by name/ID/pattern, filtering by route type,...
+- [Stage routing rules](https://vercel.com/docs/rest-api/sdk/project-routes/stage-routing-rules) `PUT /v1/projects/{projectId}/routes` — Stage routing rules for a project. Set `overwrite` to true to replace all existing rules, or omit it...
+- [Add a routing rule](https://vercel.com/docs/rest-api/sdk/project-routes/add-a-routing-rule) `POST /v1/projects/{projectId}/routes` — Add a single routing rule to a project at a specified position. Defaults to the end of the list if n...
+- [Delete routing rules](https://vercel.com/docs/rest-api/sdk/project-routes/delete-routing-rules) `DELETE /v1/projects/{projectId}/routes` — Delete one or more routing rules from a project by ID. Stages a new version with the routes removed.
+- [Edit a routing rule](https://vercel.com/docs/rest-api/sdk/project-routes/edit-a-routing-rule) `PATCH /v1/projects/{projectId}/routes/{routeId}` — Replace a routing rule identified by its ID, or restore it from the current production version. Stag...
+- [Generate a routing rule from natural language](https://vercel.com/docs/rest-api/sdk/project-routes/generate-a-routing-rule-from-natural-language) `POST /v1/projects/{projectId}/routes/generate` — Generate a routing rule configuration from a natural language description. Returns a suggested route...
+- [Get routing rule version history](https://vercel.com/docs/rest-api/sdk/project-routes/get-routing-rule-version-history) `GET /v1/projects/{projectId}/routes/versions` — Get the version history for a project's routing rules. Returns the staging version (if one exists) f...
+- [Promote, restore, or discard a routing rule version](https://vercel.com/docs/rest-api/sdk/project-routes/promote-restore-or-discard-a-routing-rule-version) `POST /v1/projects/{projectId}/routes/versions` — Promote staged routing rules to production, restore a previous production version, or discard staged...
+
+### projectMembers
+
+- [List project members](https://vercel.com/docs/rest-api/sdk/projectMembers/list-project-members) `GET /v1/projects/{idOrName}/members` — Lists all members of a project.
+- [Adds a new member to a project.](https://vercel.com/docs/rest-api/sdk/projectMembers/adds-a-new-member-to-a-project) `POST /v1/projects/{idOrName}/members` — Adds a new member to the project.
+- [Remove a Project Member](https://vercel.com/docs/rest-api/sdk/projectMembers/remove-a-project-member) `DELETE /v1/projects/{idOrName}/members/{uid}` — Remove a member from a specific project
+
+### projects
+
+- [Retrieve a list of projects](https://vercel.com/docs/rest-api/sdk/projects/retrieve-a-list-of-projects) `GET /v10/projects` — Allows to retrieve the list of projects of the authenticated user or team. The list will be paginate...
+- [Create a new project](https://vercel.com/docs/rest-api/sdk/projects/create-a-new-project) `POST /v11/projects` — Allows to create a new project with the provided configuration. It only requires the project `name` ...
+- [Find a project by id or name](https://vercel.com/docs/rest-api/sdk/projects/find-a-project-by-id-or-name) `GET /v9/projects/{idOrName}` — Get the information for a specific project by passing either the project `id` or `name` in the URL.
+- [Update an existing project](https://vercel.com/docs/rest-api/sdk/projects/update-an-existing-project) `PATCH /v9/projects/{idOrName}` — Update the fields of a project using either its `name` or `id`.
+- [Delete a Project](https://vercel.com/docs/rest-api/sdk/projects/delete-a-project) `DELETE /v9/projects/{idOrName}` — Delete a specific project by passing either the project `id` or `name` in the URL.
+- [Retrieve project domains by project by id or name](https://vercel.com/docs/rest-api/sdk/projects/retrieve-project-domains-by-project-by-id-or-name) `GET /v9/projects/{idOrName}/domains` — Retrieve the domains associated with a given project by passing either the project `id` or `name` in...
+- [Get a project domain](https://vercel.com/docs/rest-api/sdk/projects/get-a-project-domain) `GET /v9/projects/{idOrName}/domains/{domain}` — Get project domain by project id/name and domain name.
+- [Update a project domain](https://vercel.com/docs/rest-api/sdk/projects/update-a-project-domain) `PATCH /v9/projects/{idOrName}/domains/{domain}` — Update a project domain's configuration, including the name, git branch and redirect of the domain.
+- [Remove a domain from a project](https://vercel.com/docs/rest-api/sdk/projects/remove-a-domain-from-a-project) `DELETE /v9/projects/{idOrName}/domains/{domain}` — Remove a domain from a project by passing the domain name and by specifying the project by either pa...
+- [Add a domain to a project](https://vercel.com/docs/rest-api/sdk/projects/add-a-domain-to-a-project) `POST /v10/projects/{idOrName}/domains` — Add a domain to the project by passing its domain name and by specifying the project by either passi...
+- [Move a project domain](https://vercel.com/docs/rest-api/sdk/projects/move-a-project-domain) `POST /v1/projects/{idOrName}/domains/{domain}/move` — Move one project's domain to another project. Also allows the move of all redirects pointed to that ...
+- [Verify project domain](https://vercel.com/docs/rest-api/sdk/projects/verify-project-domain) `POST /v9/projects/{idOrName}/domains/{domain}/verify` — Attempts to verify a project domain with `verified = false` by checking the correctness of the proje...
+- [Retrieve the environment variables of a project by id or name](https://vercel.com/docs/rest-api/sdk/projects/retrieve-the-environment-variables-of-a-project-by-id-or-name) `GET /v10/projects/{idOrName}/env` — Retrieve the environment variables for a given project by passing either the project `id` or `name` ...
+- [Create one or more environment variables](https://vercel.com/docs/rest-api/sdk/projects/create-one-or-more-environment-variables) `POST /v10/projects/{idOrName}/env` — Create one or more environment variables for a project by passing its `key`, `value`, `type` and `ta...
+- [Retrieve the decrypted value of an environment variable of a project by id](https://vercel.com/docs/rest-api/sdk/projects/retrieve-the-decrypted-value-of-an-environment-variable-of-a-project-by-id) `GET /v1/projects/{idOrName}/env/{id}` — Retrieve the environment variable for a given project.
+- [Remove an environment variable](https://vercel.com/docs/rest-api/sdk/projects/remove-an-environment-variable) `DELETE /v9/projects/{idOrName}/env/{id}` — Delete a specific environment variable for a given project by passing the environment variable ident...
+- [Edit an environment variable](https://vercel.com/docs/rest-api/sdk/projects/edit-an-environment-variable) `PATCH /v9/projects/{idOrName}/env/{id}` — Edit a specific environment variable for a given project by passing the environment variable identif...
+- [Batch remove environment variables](https://vercel.com/docs/rest-api/sdk/projects/batch-remove-environment-variables) `DELETE /v1/projects/{idOrName}/env` — Delete multiple environment variables for a given project in a single batch operation.
+- [Create project transfer request](https://vercel.com/docs/rest-api/sdk/projects/create-project-transfer-request) `POST /projects/{idOrName}/transfer-request` — Initiates a project transfer request from one team to another. <br/> Returns a `code` that remains v...
+- [Accept project transfer request](https://vercel.com/docs/rest-api/sdk/projects/accept-project-transfer-request) `PUT /projects/transfer-request/{code}` — Accept a project transfer request initated by another team. <br/> The `code` is generated using the ...
+- [Update Protection Bypass for Automation](https://vercel.com/docs/rest-api/sdk/projects/update-protection-bypass-for-automation) `PATCH /v1/projects/{idOrName}/protection-bypass` — Update the deployment protection automation bypass for a project
+- [Points all production domains for a project to the given deploy](https://vercel.com/docs/rest-api/sdk/projects/points-all-production-domains-for-a-project-to-the-given-deploy) `POST /v1/projects/{projectId}/rollback/{deploymentId}` — Allows users to rollback to a deployment.
+- [Updates the description for a rollback](https://vercel.com/docs/rest-api/sdk/projects/updates-the-description-for-a-rollback) `PATCH /v1/projects/{projectId}/rollback/{deploymentId}/update-description` — Updates the reason for a rollback, without changing the rollback status itself.
+- [Update the microfrontends settings](https://vercel.com/docs/rest-api/sdk/projects/update-the-microfrontends-settings) `PATCH /v1/projects/{projectId}/microfrontends` — Update the microfrontends settings for a project.
+- [Points all production domains for a project to the given deploy](https://vercel.com/docs/rest-api/sdk/projects/points-all-production-domains-for-a-project-to-the-given-deploy) `POST /v10/projects/{projectId}/promote/{deploymentId}` — Allows users to promote a deployment to production. Note: This does NOT rebuild the deployment. If y...
+- [Gets a list of aliases with status for the current promote](https://vercel.com/docs/rest-api/sdk/projects/gets-a-list-of-aliases-with-status-for-the-current-promote) `GET /v1/projects/{projectId}/promote/aliases` — Get a list of aliases related to the last promote request with their mapping status
+- [Pause a project](https://vercel.com/docs/rest-api/sdk/projects/pause-a-project) `POST /v1/projects/{projectId}/pause` — Pause a project by passing its project `id` in the URL. If the project does not exist given the id t...
+- [Unpause a project](https://vercel.com/docs/rest-api/sdk/projects/unpause-a-project) `POST /v1/projects/{projectId}/unpause` — Unpause a project by passing its project `id` in the URL. If the project does not exist given the id...
+
+### rolling-release
+
+- [Get rolling release billing status](https://vercel.com/docs/rest-api/sdk/rolling-release/get-rolling-release-billing-status) `GET /v1/projects/{idOrName}/rolling-release/billing` — Get the Rolling Releases billing status for a project. The team level billing status is used to dete...
+- [Get rolling release configuration](https://vercel.com/docs/rest-api/sdk/rolling-release/get-rolling-release-configuration) `GET /v1/projects/{idOrName}/rolling-release/config` — Get the Rolling Releases configuration for a project. The project-level config is simply a template ...
+- [Delete rolling release configuration](https://vercel.com/docs/rest-api/sdk/rolling-release/delete-rolling-release-configuration) `DELETE /v1/projects/{idOrName}/rolling-release/config` — Disable Rolling Releases for a project means that future deployments will not undergo a rolling rele...
+- [Update the rolling release settings for the project](https://vercel.com/docs/rest-api/sdk/rolling-release/update-the-rolling-release-settings-for-the-project) `PATCH /v1/projects/{idOrName}/rolling-release/config` — Update (or disable) Rolling Releases for a project. When disabling with the resolve-on-disable featu...
+- [Get the active rolling release information for a project](https://vercel.com/docs/rest-api/sdk/rolling-release/get-the-active-rolling-release-information-for-a-project) `GET /v1/projects/{idOrName}/rolling-release` — Return the Rolling Release for a project, regardless of whether the rollout is active, aborted, or c...
+- [Update the active rolling release to the next stage for a project](https://vercel.com/docs/rest-api/sdk/rolling-release/update-the-active-rolling-release-to-the-next-stage-for-a-project) `POST /v1/projects/{idOrName}/rolling-release/approve-stage` — Advance a rollout to the next stage. This is only needed when rolling releases is configured to requ...
+- [Complete the rolling release for the project](https://vercel.com/docs/rest-api/sdk/rolling-release/complete-the-rolling-release-for-the-project) `POST /v1/projects/{idOrName}/rolling-release/complete` — Force-complete a Rolling Release. The canary deployment will begin serving 100% of the traffic.
+
+### sandboxes
+
+- [List sandboxes](https://vercel.com/docs/rest-api/sdk/sandboxes/list-sandboxes) `GET /v1/sandboxes` — Retrieves a paginated list of sandboxes belonging to a specific project. Results can be filtered by ...
+- [Create a sandbox](https://vercel.com/docs/rest-api/sdk/sandboxes/create-a-sandbox) `POST /v1/sandboxes` — Creates a new sandbox environment for executing code in an isolated virtual machine. A sandbox can b...
+- [List snapshots](https://vercel.com/docs/rest-api/sdk/sandboxes/list-snapshots) `GET /v1/sandboxes/snapshots` — Retrieves a paginated list of snapshots for a specific project.
+- [Get a sandbox](https://vercel.com/docs/rest-api/sdk/sandboxes/get-a-sandbox) `GET /v1/sandboxes/{sandboxId}` — Retrieves detailed information about a specific sandbox, including its current status, resource conf...
+- [List commands](https://vercel.com/docs/rest-api/sdk/sandboxes/list-commands) `GET /v1/sandboxes/{sandboxId}/cmd` — Retrieves a list of all commands that have been executed in a sandbox, including their current statu...
+- [Execute a command](https://vercel.com/docs/rest-api/sdk/sandboxes/execute-a-command) `POST /v1/sandboxes/{sandboxId}/cmd` — Executes a shell command inside a running sandbox. The command runs asynchronously and returns immed...
+- [Kill a command](https://vercel.com/docs/rest-api/sdk/sandboxes/kill-a-command) `POST /v1/sandboxes/{sandboxId}/{cmdId}/kill` — Sends a signal to terminate a running command in a sandbox. The signal can be used to gracefully sto...
+- [Stop a sandbox](https://vercel.com/docs/rest-api/sdk/sandboxes/stop-a-sandbox) `POST /v1/sandboxes/{sandboxId}/stop` — Stops a running sandbox and releases its allocated resources. All running processes within the sandb...
+- [Extend sandbox timeout](https://vercel.com/docs/rest-api/sdk/sandboxes/extend-sandbox-timeout) `POST /v1/sandboxes/{sandboxId}/extend-timeout` — Extends the maximum execution time of a running sandbox. The sandbox must be active and able to acce...
+- [Update network policy](https://vercel.com/docs/rest-api/sdk/sandboxes/update-network-policy) `POST /v1/sandboxes/{sandboxId}/network-policy` — Replaces the network access policy of a running sandbox. Use this to control which external hosts th...
+- [Get a command](https://vercel.com/docs/rest-api/sdk/sandboxes/get-a-command) `GET /v1/sandboxes/{sandboxId}/cmd/{cmdId}` — Retrieves the current status and details of a command executed in a sandbox. Use the `wait` paramete...
+- [Stream command logs](https://vercel.com/docs/rest-api/sdk/sandboxes/stream-command-logs) `GET /v1/sandboxes/{sandboxId}/cmd/{cmdId}/logs` — Streams the output of a command in real-time using newline-delimited JSON (ND-JSON). Each entry incl...
+- [Read a file](https://vercel.com/docs/rest-api/sdk/sandboxes/read-a-file) `POST /v1/sandboxes/{sandboxId}/fs/read` — Downloads the contents of a file from a sandbox's filesystem. The file content is returned as a bina...
+- [Create a directory](https://vercel.com/docs/rest-api/sdk/sandboxes/create-a-directory) `POST /v1/sandboxes/{sandboxId}/fs/mkdir` — Creates a new directory in a sandbox's filesystem. By default, parent directories are created recurs...
+- [Write files](https://vercel.com/docs/rest-api/sdk/sandboxes/write-files) `POST /v1/sandboxes/{sandboxId}/fs/write` — Uploads and extracts files to a sandbox's filesystem. Files must be uploaded as a gzipped tarball (`...
+- [Get a snapshot](https://vercel.com/docs/rest-api/sdk/sandboxes/get-a-snapshot) `GET /v1/sandboxes/snapshots/{snapshotId}` — Retrieves detailed information about a specific snapshot, including its creation time, size, expirat...
+- [Delete a snapshot](https://vercel.com/docs/rest-api/sdk/sandboxes/delete-a-snapshot) `DELETE /v1/sandboxes/snapshots/{snapshotId}` — Permanently deletes a snapshot and frees its associated storage. This action cannot be undone. After...
+- [Create a snapshot](https://vercel.com/docs/rest-api/sdk/sandboxes/create-a-snapshot) `POST /v1/sandboxes/{sandboxId}/snapshot` — Creates a point-in-time snapshot of a running sandbox's filesystem. Snapshots can be used to quickly...
+
+### sandboxes-v2-beta
+
+- [List sandboxes](https://vercel.com/docs/rest-api/sdk/sandboxes-v2-beta/list-sandboxes) `GET /v2/sandboxes` — Retrieves a paginated list of named sandboxes belonging to a specific project. Results can be sorted...
+- [Create a named sandbox](https://vercel.com/docs/rest-api/sdk/sandboxes-v2-beta/create-a-named-sandbox) `POST /v2/sandboxes` — Creates a named sandbox environment. Named sandboxes have a unique name within a project and support...
+- [List snapshots](https://vercel.com/docs/rest-api/sdk/sandboxes-v2-beta/list-snapshots) `GET /v2/sandboxes/snapshots` — Retrieves a paginated list of snapshots for a specific project.
+- [Get a snapshot](https://vercel.com/docs/rest-api/sdk/sandboxes-v2-beta/get-a-snapshot) `GET /v2/sandboxes/snapshots/{snapshotId}` — Retrieves detailed information about a specific snapshot, including its creation time, size, expirat...
+- [Delete a snapshot](https://vercel.com/docs/rest-api/sdk/sandboxes-v2-beta/delete-a-snapshot) `DELETE /v2/sandboxes/snapshots/{snapshotId}` — Permanently deletes a snapshot and frees its associated storage. This action cannot be undone. After...
+- [List sessions](https://vercel.com/docs/rest-api/sdk/sandboxes-v2-beta/list-sessions) `GET /v2/sandboxes/sessions` — Retrieves a paginated list of sessions belonging to a specific sandbox. Results are sorted by creati...
+- [Get a session](https://vercel.com/docs/rest-api/sdk/sandboxes-v2-beta/get-a-session) `GET /v2/sandboxes/sessions/{sessionId}` — Retrieves detailed information about a specific session, including its current status, resource conf...
+- [Get a named sandbox](https://vercel.com/docs/rest-api/sdk/sandboxes-v2-beta/get-a-named-sandbox) `GET /v2/sandboxes/{name}` — Retrieves a named sandbox by name, including its current sandbox and routes. If the sandbox is stopp...
+- [Update a sandbox](https://vercel.com/docs/rest-api/sdk/sandboxes-v2-beta/update-a-sandbox) `PATCH /v2/sandboxes/{name}` — Updates the configuration of a sandbox. Only the provided fields will be modified; omitted fields re...
+- [Delete a sandbox](https://vercel.com/docs/rest-api/sdk/sandboxes-v2-beta/delete-a-sandbox) `DELETE /v2/sandboxes/{name}` — Deletes a sandbox by name. If sandboxes are currently running, they will be stopped first. This oper...
+- [List commands](https://vercel.com/docs/rest-api/sdk/sandboxes-v2-beta/list-commands) `GET /v2/sandboxes/sessions/{sessionId}/cmd` — Retrieves a list of all commands that have been executed in a session, including their current statu...
+- [Execute a command](https://vercel.com/docs/rest-api/sdk/sandboxes-v2-beta/execute-a-command) `POST /v2/sandboxes/sessions/{sessionId}/cmd` — Executes a shell command inside a running session. The command runs asynchronously and returns immed...
+- [Get a command](https://vercel.com/docs/rest-api/sdk/sandboxes-v2-beta/get-a-command) `GET /v2/sandboxes/sessions/{sessionId}/cmd/{cmdId}` — Retrieves the current status and details of a command executed in a session. Use the `wait` paramete...
+- [Kill a command](https://vercel.com/docs/rest-api/sdk/sandboxes-v2-beta/kill-a-command) `POST /v2/sandboxes/sessions/{sessionId}/cmd/{cmdId}/kill` — Sends a signal to terminate a running command in a session. The signal can be used to gracefully sto...
+- [Stream command logs](https://vercel.com/docs/rest-api/sdk/sandboxes-v2-beta/stream-command-logs) `GET /v2/sandboxes/sessions/{sessionId}/cmd/{cmdId}/logs` — Streams the output of a command in real-time using newline-delimited JSON (ND-JSON). Each entry incl...
+- [Stop a session](https://vercel.com/docs/rest-api/sdk/sandboxes-v2-beta/stop-a-session) `POST /v2/sandboxes/sessions/{sessionId}/stop` — Stops a running session and releases its allocated resources. All running processes within the sessi...
+- [Extend session timeout](https://vercel.com/docs/rest-api/sdk/sandboxes-v2-beta/extend-session-timeout) `POST /v2/sandboxes/sessions/{sessionId}/extend-timeout` — Extends the maximum execution time of a running session. The session must be active and able to acce...
+- [Update network policy](https://vercel.com/docs/rest-api/sdk/sandboxes-v2-beta/update-network-policy) `POST /v2/sandboxes/sessions/{sessionId}/network-policy` — Replaces the network access policy of a running session. Use this to control which external hosts th...
+- [Read a file](https://vercel.com/docs/rest-api/sdk/sandboxes-v2-beta/read-a-file) `POST /v2/sandboxes/sessions/{sessionId}/fs/read` — Downloads the contents of a file from a session's filesystem. The file content is returned as a bina...
+- [Create a directory](https://vercel.com/docs/rest-api/sdk/sandboxes-v2-beta/create-a-directory) `POST /v2/sandboxes/sessions/{sessionId}/fs/mkdir` — Creates a new directory in a session's filesystem. By default, parent directories are created recurs...
+- [Write files](https://vercel.com/docs/rest-api/sdk/sandboxes-v2-beta/write-files) `POST /v2/sandboxes/sessions/{sessionId}/fs/write` — Uploads and extracts files to a session's filesystem. Files must be uploaded as a gzipped tarball (`...
+- [Create a snapshot](https://vercel.com/docs/rest-api/sdk/sandboxes-v2-beta/create-a-snapshot) `POST /v2/sandboxes/sessions/{sessionId}/snapshot` — Creates a point-in-time snapshot of a running session's filesystem. Snapshots can be used to quickly...
+
+### security
+
+- [Update Attack Challenge mode](https://vercel.com/docs/rest-api/sdk/security/update-attack-challenge-mode) `POST /v1/security/attack-mode` — Update the setting for determining if the project has Attack Challenge mode enabled.
+- [Put Firewall Configuration](https://vercel.com/docs/rest-api/sdk/security/put-firewall-configuration) `PUT /v1/security/firewall/config` — Set the firewall configuration to provided rules and settings. Creates or overwrite the existing fir...
+- [Update Firewall Configuration](https://vercel.com/docs/rest-api/sdk/security/update-firewall-configuration) `PATCH /v1/security/firewall/config` — Process updates to modify the existing firewall config for a project
+- [Read Firewall Configuration](https://vercel.com/docs/rest-api/sdk/security/read-firewall-configuration) `GET /v1/security/firewall/config/{configVersion}` — Retrieve the specified firewall configuration for a project. The deployed configVersion will be `act...
+- [Read active attack data](https://vercel.com/docs/rest-api/sdk/security/read-active-attack-data) `GET /v1/security/firewall/attack-status` — Retrieve active attack data within the last N days (default: 1 day)
+- [Read System Bypass](https://vercel.com/docs/rest-api/sdk/security/read-system-bypass) `GET /v1/security/firewall/bypass` — Retrieve the system bypass rules configured for the specified project
+- [Create System Bypass Rule](https://vercel.com/docs/rest-api/sdk/security/create-system-bypass-rule) `POST /v1/security/firewall/bypass` — Create new system bypass rules
+- [Remove System Bypass Rule](https://vercel.com/docs/rest-api/sdk/security/remove-system-bypass-rule) `DELETE /v1/security/firewall/bypass` — Remove system bypass rules
+- [Read Firewall Actions by Project](https://vercel.com/docs/rest-api/sdk/security/read-firewall-actions-by-project) `GET /v1/security/firewall/events` — Retrieve firewall actions for a project
+
+### teams
+
+- [List team members](https://vercel.com/docs/rest-api/sdk/teams/list-team-members) `GET /v3/teams/{teamId}/members` — Get a paginated list of team members for the provided team.
+- [Invite a user](https://vercel.com/docs/rest-api/sdk/teams/invite-a-user) `POST /v2/teams/{teamId}/members` — Invite a user to join the team specified in the URL. The authenticated user needs to be an `OWNER` i...
+- [Request access to a team](https://vercel.com/docs/rest-api/sdk/teams/request-access-to-a-team) `POST /v1/teams/{teamId}/request` — Request access to a team as a member. An owner has to approve the request. Only 10 users can request...
+- [Get access request status](https://vercel.com/docs/rest-api/sdk/teams/get-access-request-status) `GET /v1/teams/{teamId}/request/{userId}` — Check the status of a join request. It'll respond with a 404 if the request has been declined. If no...
+- [Join a team](https://vercel.com/docs/rest-api/sdk/teams/join-a-team) `POST /v1/teams/{teamId}/members/teams/join` — Join a team with a provided invite code or team ID.
+- [Update a Team Member](https://vercel.com/docs/rest-api/sdk/teams/update-a-team-member) `PATCH /v1/teams/{teamId}/members/{uid}` — Update the membership of a Team Member on the Team specified by `teamId`, such as changing the _role...
+- [Remove a Team Member](https://vercel.com/docs/rest-api/sdk/teams/remove-a-team-member) `DELETE /v1/teams/{teamId}/members/{uid}` — Remove a Team Member from the Team, or dismiss a user that requested access, or leave a team.
+- [Get a Team](https://vercel.com/docs/rest-api/sdk/teams/get-a-team) `GET /v2/teams/{teamId}` — Get information for the Team specified by the `teamId` parameter.
+- [Update a Team](https://vercel.com/docs/rest-api/sdk/teams/update-a-team) `PATCH /v2/teams/{teamId}` — Update the information of a Team specified by the `teamId` parameter. The request body should contai...
+- [List all teams](https://vercel.com/docs/rest-api/sdk/teams/list-all-teams) `GET /v2/teams` — Get a paginated list of all the Teams the authenticated User is a member of.
+- [Create a Team](https://vercel.com/docs/rest-api/sdk/teams/create-a-team) `POST /v1/teams` — Create a new Team under your account. You need to send a POST request with the desired Team slug, an...
+- [Update Team Directory Sync Role Mappings](https://vercel.com/docs/rest-api/sdk/teams/update-team-directory-sync-role-mappings) `POST /v1/teams/{teamId}/dsync-roles` — Update the Directory Sync role mappings for a Team. This endpoint allows updating the mapping betwee...
+- [Delete a Team](https://vercel.com/docs/rest-api/sdk/teams/delete-a-team) `DELETE /v1/teams/{teamId}` — Delete a team under your account. You need to send a `DELETE` request with the desired team `id`. An...
+- [Delete a Team invite code](https://vercel.com/docs/rest-api/sdk/teams/delete-a-team-invite-code) `DELETE /v1/teams/{teamId}/invites/{inviteId}` — Delete an active Team invite code.
+- [Update a microfrontends group](https://vercel.com/docs/rest-api/sdk/teams/update-a-microfrontends-group) `PATCH /v1/teams/{teamId}/microfrontends/{groupId}` — Updates the name (and slug) of a microfrontends group.
+- [Delete a microfrontends group](https://vercel.com/docs/rest-api/sdk/teams/delete-a-microfrontends-group) `DELETE /v1/teams/{teamId}/microfrontends/{groupId}` — Deletes a microfrontends group from the team associated with the group ID.
+
+### user
+
+- [List User Events](https://vercel.com/docs/rest-api/sdk/user/list-user-events) `GET /v3/events` — Retrieves a list of "events" generated by the User on Vercel. Events are generated when the User per...
+- [List Event Types](https://vercel.com/docs/rest-api/sdk/user/list-event-types) `GET /v1/events/types` — Returns the list of user-facing event types with descriptions.
+- [Get the User](https://vercel.com/docs/rest-api/sdk/user/get-the-user) `GET /v2/user` — Retrieves information related to the currently authenticated User.
+- [Delete User Account](https://vercel.com/docs/rest-api/sdk/user/delete-user-account) `DELETE /v1/user` — Initiates the deletion process for the currently authenticated User, by sending a deletion confirmat...
+
+### webhooks
+
+- [Creates a webhook](https://vercel.com/docs/rest-api/sdk/webhooks/creates-a-webhook) `POST /v1/webhooks` — Creates a webhook
+- [Get a list of webhooks](https://vercel.com/docs/rest-api/sdk/webhooks/get-a-list-of-webhooks) `GET /v1/webhooks` — Get a list of webhooks
+- [Get a webhook](https://vercel.com/docs/rest-api/sdk/webhooks/get-a-webhook) `GET /v1/webhooks/{id}` — Get a webhook
+- [Deletes a webhook](https://vercel.com/docs/rest-api/sdk/webhooks/deletes-a-webhook) `DELETE /v1/webhooks/{id}` — Deletes a webhook
+
+
+# Knowledge Base
+
+## Topics
+
+- [Account](https://vercel.com/kb/account): Manage your Vercel account, teams, projects, and configure access control.
+- [AI](https://vercel.com/kb/ai): Build AI-powered applications using Vercel's AI Cloud features and SDKs.
+- [Architecture](https://vercel.com/kb/architecture): Scale your application using best practices for microfrontends, monorepos, and multi-tenant setups.
+- [Backend](https://vercel.com/kb/backend): Build and host APIs and other backend functionality on Vercel.
+- [Build and Deploy](https://vercel.com/kb/build-and-deploy): Build, preview, and deploy with Vercel's CI/CD pipeline, git integration, rollbacks, and more.
+- [CDN](https://vercel.com/kb/cdn): Vercel's CDN is a globally distributed platform that stores content near your customers and runs compute in regions close to your data, reducing latency and improving end-user performance.
+- [Collaboration](https://vercel.com/kb/collaboration): Collaborate across teams using Preview deployments, comments, toolbar, and more.
+- [Frameworks](https://vercel.com/kb/framework): Deploy your preferred framework on Vercel, including Next.js, Sveltekit, Nuxt, and more.
+- [Frontend](https://vercel.com/kb/frontend): Optimize your frontend with ISR, Streaming, Image Optimization, and OG generations.
+- [Infrastructure and Compute](https://vercel.com/kb/infrastructure-and-compute): Scale and deliver applications efficiently across regions using Vercel's Fluid Compute and CDN.
+- [Integrations](https://vercel.com/kb/integrations): Integrate third-party tools across observability, AI, storage, and more.
+- [Limits and Pricing](https://vercel.com/kb/limits-and-pricing): Learn about Vercel usage limits, billing, quotas, and how pricing scales across plans.
+- [Observability](https://vercel.com/kb/observability): Monitor and analyze performance with Speed Insights, Web Analytics, Logs, and more.
+- [Security](https://vercel.com/kb/security): Secure your applications with Vercel's Firewall, Bot Management, deployment protection, and more.
+- [Storage and Caching](https://vercel.com/kb/storage): Store and manage data using Vercel Cache, Edge Config and Database integrations.
+
+## Guides
+
+- [“Cannot Find Matching Keyid” Errors or “Corepack/PNPM Not Found” on GitHub Actions](https://vercel.com/kb/guide/corepack-errors-github-actions): How to debug and address this corepack issue with GitHub Actions.
+- [A/B Testing on Vercel](https://vercel.com/kb/guide/ab-testing-on-vercel): Learn best practices for A/B testing on Vercel
+- [Accessing Vercel-hosted sites from mainland China](https://vercel.com/kb/guide/accessing-vercel-hosted-sites-from-mainland-china): Understand why Vercel-hosted sites may be slow or inaccessible in mainland China, and explore steps to improve performance for users in the region
+- [Add Auth to a Next.js Site with Magic.link](https://vercel.com/kb/guide/add-auth-to-nextjs-with-magic): Learn how to add user authentication to a Next.js site using Magic.link.
+- [Add Rate Limiting with Vercel](https://vercel.com/kb/guide/add-rate-limiting-vercel): Learn how to implement rate limiting with Vercel
+- [Adding a response header](https://vercel.com/kb/guide/add-response-header): Learn how to add a response header in your Middleware.
+- [Agent Readability: A Specification for AI-Optimized Websites](https://vercel.com/kb/guide/agent-readability-spec): When an agent visits your site, it needs to quickly find, read, and understand your pages. Sites that are easy for agents to navigate get cited more often, surface in more answers, and reach a wider audience.
+- [Agent Skills: Creating, Installing, and Sharing Reusable Agent Context](https://vercel.com/kb/guide/agent-skills-creating-installing-and-sharing-reusable-agent-context): This guide will cover what skills are, how to create custom skills for yourself and your team, and how to publish them to the community.
+- [AI Agents on Vercel](https://vercel.com/kb/guide/ai-agents): This guide provides an overview of how to build and deploy AI agents on Vercel.
+- [An Introduction to Evals](https://vercel.com/kb/guide/an-introduction-to-evals): Evaluations test model and agent outputs to ensure they meet the standards and requirements you specify.
+- [Application Authentication on Vercel](https://vercel.com/kb/guide/application-authentication-on-vercel): Learn best practices for application authentication Vercel
+- [Are Vercel Preview Deployments indexed by search engines?](https://vercel.com/kb/guide/are-vercel-preview-deployment-indexed-by-search-engines): Information on whether a Vercel Deployment will be indexed by search engines.
+- [Avoiding duplicate-content SEO with vercel.app URLs and custom domains](https://vercel.com/kb/guide/avoiding-duplicate-content-with-vercel-app-urls): Discover why search engines may treat your vercel.app URL and custom domain as separate pages, and how to consolidate ranking signals and protect your SEO.
+- [Block PHP requests](https://vercel.com/kb/guide/block-php-requests): Learn how to block traffic looking for .php vulnerabilies.
+- [Blocking traffic from a specific IP address.](https://vercel.com/kb/guide/traffic-spikes): Learn how to block traffic from a specific IP address.
+- [Build a ChatGPT Connector (MCP server)](https://vercel.com/kb/guide/mcp-server-chatgpt-connector): Create an MCP server to bring your tools and data to ChatGPT
+- [Build a Claude Managed Agent on Vercel](https://vercel.com/kb/guide/claude-managed-agent-vercel): Learn how to build a Claude Managed Agent on Vercel with auth, credential vaults, durable polling, and a chat UI.
+- [Build a multi-tenant app with Next.js and Vercel](https://vercel.com/kb/guide/nextjs-multi-tenant-application): Create a Next.js application with multi-tenancy and custom domain support on Vercel.
+- [Build an AI Chat Agent with Weather API Tool Calling](https://vercel.com/kb/guide/build-ai-agent-weather-api): Build an intelligent conversational agent that fetches real-time weather data using the AI SDK, tool calling, and a backend weather API powered by Express, FastAPI or Nitro
+- [Build an MCP Server with Weather tools using Express and Vercel](https://vercel.com/kb/guide/mcp-server-with-weather-tool-express): Make your Express weather API accessible to AI assistants through the Model Context Protocol.
+- [Build commission-free iOS checkouts with Vercel and Paddle](https://vercel.com/kb/guide/build-commission-free-ios-checkouts-with-vercel-and-paddle): A new ruling allows iOS apps to use external checkouts. Learn how to deploy a secure, high-performance external checkout on Vercel with Paddle and Next.js, avoiding Apple’s 30% cut while supporting Apple Pay and owning pricing and customer relationships.
+- [Building a Slack agent with durable workflows](https://vercel.com/kb/guide/building-a-slack-agent-with-durable-workflows): Build an AI-powered Slack bot that gathers team data, drafts a summary, and refines it through conversation.
+- [Building AI apps on Vercel: an overview](https://vercel.com/kb/guide/how-to-build-ai-app): Learn the key AI concepts and tools for building and scaling AI apps.
+- [Building AI-powered Article Embeddings with Chroma and GPT-4](https://vercel.com/kb/guide/ai-powered-article-embeddings-with-chroma-and-gpt-4): This guide provides step-by-step instructions on using Chroma and GPT-4 to build AI-powered article embeddings for tasks like similarity-based search and recommendation systems.
+- [Building an agent with OpenAI Agents SDK and Vercel Sandbox](https://vercel.com/kb/guide/building-an-agent-with-openai-agents-sdk-and-vercel-sandbox): Learn how to build an agent with with OpenAI Agents SDK and Vercel Sandbox
+- [Building an AI Chatbot with Cohere, Next.js, and the Vercel AI SDK](https://vercel.com/kb/guide/cohere-nextjs-vercel-ai-sdk): Learn how to build a generative AI application using Cohere, Next.js, and Vercel.
+- [Building an AI chatbot with Next.js, Langchain, and OpenAI](https://vercel.com/kb/guide/nextjs-langchain-vercel-ai): Dive into the world of LangChain.js and Next.js with our detailed guide. Learn how to set up a chatbot, structure outputs, integrate agents, and more. Perfect for developers looking to harness the power of AI in their web applications.
+- [Building Ecommerce Sites with Next.js and Shopify](https://vercel.com/kb/guide/building-ecommerce-sites-with-next-js-and-shopify): Learn how to integrate Next.js and Shopify together for the fastest storefronts using the Storefront GraphQL API.
+- [Building Next.js Apps with GraphQL Fragment Colocation and Sanity CMS](https://vercel.com/kb/guide/building-nextjs-apps-with-graphql-fragment-colocation-and-sanity-cms): Build a content-heavy Next.js app with Sanity using GraphQL fragment colocation. Compose component fragments into one type-safe query for faster ISR, fewer requests, and scalable performance.
+- [Building stateful Slack bots with Vercel Workflow](https://vercel.com/kb/guide/stateful-slack-bots-with-vercel-workflow): Learn how to build Slack bots that maintain state and handle long-running processes without managing queues, databases, or background job infra.
+- [Can a CAA record be added to a Subdomain Configured with CNAME?](https://vercel.com/kb/guide/can-a-caa-record-be-added-to-a-subdomain-configured-with-cname): This guide is for any users with requirements on customization of CAA records on subdomains.
+- [Can I connect a Pro team to a personal Git account?](https://vercel.com/kb/guide/connecting-teams-with-personal-git-accounts): Information on connecting personal Git accounts to a Vercel team.
+- [Can I deploy a locally built Next.js app to Vercel?](https://vercel.com/kb/guide/deploying-locally-built-nextjs): Learn how to deploy a locally built Next.js application to Vercel.
+- [Can I deploy Discord bots to Vercel?](https://vercel.com/kb/guide/can-i-deploy-discord-bots-to-vercel): Learn about whether it's possible to deploy Discord Bots to Vercel.
+- [Can I disable auto renewals for a domain registered with Vercel?](https://vercel.com/kb/guide/how-can-i-disable-auto-renewals-for-a-domain-registered-with-vercel): Learn about disabling auto-renewal of domains registered with Vercel.
+- [Can I get a fixed IP address for my Vercel deployments?](https://vercel.com/kb/guide/can-i-get-a-fixed-ip-address): You can allowlist IP addresses with Vercel Secure Compute and Static IPs
+- [Can I get a refund for a domain purchased or renewed with Vercel?](https://vercel.com/kb/guide/can-i-get-a-refund-for-a-domain-purchased-or-renewed-with-vercel): Information on getting a refund for a domain purchased or renewed with Vercel.
+- [Can I redirect from a subdomain to a subpath?](https://vercel.com/kb/guide/can-i-redirect-from-a-subdomain-to-a-subpath): Learn how to redirect from your subdomain to a subpath on Vercel with a vercel.json file or with Next.js
+- [Can I route based on letter casing on Vercel?](https://vercel.com/kb/guide/can-i-route-based-on-letter-casing-on-vercel): Information on whether or not it is possible to route based on letting casing with Vercel.
+- [Can I Set a Cookie from My Vercel Project Subdomain to Vercel.app?](https://vercel.com/kb/guide/can-i-set-a-cookie-from-my-vercel-project-subdomain-to-vercel-app): If you set a cookie at the level of `vercel.app` in your Vercel project, will the cookie be applied to `vercel.app`?
+- [Can I use a proxy on top of my Vercel Deployment?](https://vercel.com/kb/guide/can-i-use-a-proxy-on-top-of-my-vercel-deployment): General information about using an external proxy to serve a Vercel Deployment.
+- [Can I use Bitbucket Data Center with Vercel?](https://vercel.com/kb/guide/can-i-use-bitbucket-data-center-with-vercel): You can use Bitbucket Data Center and Bitbucket Pipelines to deploy your application to Vercel.
+- [Can I use GitHub Enterprise Server with Vercel?](https://vercel.com/kb/guide/can-i-use-github-enterprise-server-with-vercel): You can use GitHub Enterprise Server and GitHub Actions to deploy your application to Vercel.
+- [Can I use my domain on Vercel with A records?](https://vercel.com/kb/guide/a-record-and-caa-with-vercel): Information on how to use A records with Vercel to verify a domain.
+- [Can I use Preview Deployment Suffix without switching to Vercel Nameservers?](https://vercel.com/kb/guide/preview-deployment-suffix-without-vercel-nameservers): Information on how to use Preview Deployment Suffix without Vercel Nameservers
+- [Can I use self-managed GitLab with Vercel?](https://vercel.com/kb/guide/can-i-use-self-managed-gitlab-with-vercel): You can use self-managed GitLab and GitHub Pipelines to deploy your application to Vercel.
+- [Can I use SMTP with Vercel?](https://vercel.com/kb/guide/serverless-functions-and-smtp): Information on SMTP and email usage in Serverless Functions.
+- [Can I use Vercel as a reverse proxy?](https://vercel.com/kb/guide/vercel-reverse-proxy-rewrites-external): Learn how to use rewrites to proxy requests from Vercel to other deployments.
+- [Can I use Vercel to deploy to a private cloud?](https://vercel.com/kb/guide/can-i-use-vercel-to-deploy-to-a-private-cloud): Learn about if it's possible to deploy to a private cloud with Vercel.
+- [Can I use wildcard domains without switching to Vercel Nameservers?](https://vercel.com/kb/guide/wildcard-domain-without-vercel-nameservers): Information on how to use wildcard domains without Vercel Nameservers
+- [Can Vercel sponsor my open source project?](https://vercel.com/kb/guide/can-vercel-sponsor-my-open-source-project): Information on how Vercel can sponsor your open source project and how to apply.
+- [Can you deploy based on tags/releases on Vercel?](https://vercel.com/kb/guide/can-you-deploy-based-on-tags-releases-on-vercel): Learn how to deploy based on tags/releases on Vercel.
+- [Challenge cookie-less requests on a specific path](https://vercel.com/kb/guide/challenge-cookieless-requests-on-a-specific-path): Learn how to challenge specific requests with the Vercel WAF API.
+- [Challenge cURL requests](https://vercel.com/kb/guide/challenge-curl-requests): Learn how to challenge curl requests with the Vercel WAF API.
+- [Comparing MySQL, PostgreSQL, and MongoDB ](https://vercel.com/kb/guide/mysql-vs-postgresql-vs-mongodb): Explore database selection for optimal performance, focusing on SQL options like MySQL, PostgreSQL, and NoSQL's MongoDB. Consider data types, indexing, concurrency, scalability, replication, and ACID compliance for your application's needs.
+- [Connect Next.js to Amazon Aurora PostgreSQL using Vercel Marketplace](https://vercel.com/kb/guide/connect-next-js-to-amazon-aurora-postgresql-using-vercel-marketplace): Learn how to connect your Next.js application to Amazon Aurora PostgreSQL securely using the Vercel Marketplace AWS integration
+- [Connection Pooling with Vercel Functions](https://vercel.com/kb/guide/connection-pooling-with-functions): Learn best practices for connecting to relational databases with Vercel Functions and Fluid compute
+- [Create a Discord support bot with Nuxt and Redis](https://vercel.com/kb/guide/create-a-discord-support-bot-with-nuxt-and-redis): This guide walks through building a Discord support bot with Nuxt, covering project setup, Discord app configuration, Gateway forwarding, AI-powered responses, and deployment.
+- [Create and Deploy a Crystallize E-commerce Site with Vercel](https://vercel.com/kb/guide/deploying-crystallize-with-vercel): How to launch an e-commerce site using Next.js and Crystallize on Vercel in minutes.
+- [Creating a Session Store with Redis and Next.js](https://vercel.com/kb/guide/session-store-nextjs-redis-vercel-kv): Learn how to durably store sessions with Redis and Next.js.
+- [Custom 404 Page](https://vercel.com/kb/guide/custom-404-page): Create a custom 404 page and deploy with Vercel.
+- [Debug and Troubleshoot Logs with Vercel and Sematext](https://vercel.com/kb/guide/debugging-and-troubleshooting-vercel-logs-with-sematext): Automatically send all Vercel logs to Sematext to understand how your application is running.
+- [Debug routing on Vercel](https://vercel.com/kb/guide/debug-routing-on-vercel): Learn how to debug how Vercel decides where to route your request
+- [Deny non-browser traffic or blocklisted ASNs](https://vercel.com/kb/guide/deny-non-browser-traffic-or-blocklisted-asns): Learn how to block traffic from known threats with the Vercel WAF API.
+- [Deny traffic from a set of IP addresses](https://vercel.com/kb/guide/deny-traffic-from-a-set-of-ip-addresses): Learn how to block specific IP addresses with the Vercel WAF API.
+- [Dependencies from package.json are missing after install](https://vercel.com/kb/guide/dependencies-from-package-json-missing-after-install): Understand why dependencies may not being installed during a build and how to fix.
+- [Deploy a headless BigCommerce storefront with Vercel](https://vercel.com/kb/guide/deploy-headless-bigcommerce-storefront-with-vercel): Deploy a headless BigCommerce storefront using Catalyst and Next.js on Vercel
+- [Deploy a headless Shopify storefront with Vercel](https://vercel.com/kb/guide/deploy-headless-shopify-storefront-with-vercel): Deploy a headless Shopify storefront using the Next.js Commerce template on Vercel
+- [Deploy Foundation with Vercel](https://vercel.com/kb/guide/deploying-foundation-with-vercel): Create a Foundation app and deploy it live with Vercel.
+- [Deploy Next.js and Userbase with Vercel](https://vercel.com/kb/guide/deploying-next-and-userbase-with-vercel): Create a Todo app with Next.js and Userbase and deploy it live with Vercel.
+- [Deploying a Monorepo Using Yarn Workspaces to Vercel](https://vercel.com/kb/guide/deploying-yarn-monorepos-to-vercel): In this guide, you will deploy a monorepo that includes two frontend applications and one shared library with Yarn workspaces.
+- [Deploying and testing BotID](https://vercel.com/kb/guide/deploying-and-testing-botid): This guide gives an overview on Vercel BotID and how to deploy and test it in production
+- [Deploying Chained OpenAI LLM Calls to Vercel with the Inngest SDK](https://vercel.com/kb/guide/chained-openai-llm-calls-vercel-inngest): Discover how to deploy chained OpenAI LLMs (GPT-4) to Vercel using Inngest SDK for improved conversational AI, multi-turn interactions, and error correction.
+- [Deploying Puppeteer with Next.js on Vercel](https://vercel.com/kb/guide/deploying-puppeteer-with-nextjs-on-vercel): This guide covers setting up Puppeteer with Next.js on Vercel for headless browser automation, featuring a practical example for generating web page screenshots efficiently.
+- [Deploying React Forms Using Formspree with Vercel](https://vercel.com/kb/guide/deploying-react-forms-using-formspree-with-vercel): Create and deploy a React form with the help of Formspree and Vercel.
+- [Deploying Real-Time Apps with Pusher Channels and Vercel](https://vercel.com/kb/guide/deploying-pusher-channels-with-vercel): How to get started building and deploying real-time apps with Channels on Vercel.
+- [Deploying Storybook with Vercel](https://vercel.com/kb/guide/storybook-with-vercel): Learn how to deploy Storybook applications to Vercel in minutes.
+- [Displaying headlines in social previews with Vercel OG](https://vercel.com/kb/guide/displaying-article-headlines-in-social-previews): Twitter/X is planning to remove headlines from social previews. To get around this limitation, Vercel OG offers a way to display article titles directly inside OG images.
+- [Do Vercel Serverless Functions support WebSocket connections?](https://vercel.com/kb/guide/do-vercel-serverless-functions-support-websocket-connections): Information on Vercel's support for WebSocket connections with Vercel Functions.
+- [Does streaming affect SEO and can streamed content be indexed?](https://vercel.com/kb/guide/does-streaming-affect-seo): Streamed content does not affect SEO and will still be indexed by Google. Learn more in this guide.
+- [Does using Vercel's Nameserver's lock you in?](https://vercel.com/kb/guide/does-using-vercel-s-nameserver-s-lock-you-in): Learn about how using Vercel's Nameservers doesn't lock you to anything.
+- [Does Vercel have a SOC 2 Type 2 attestation?](https://vercel.com/kb/guide/is-vercel-soc-2-compliant): Learn about Vercel and SOC 2 Type 2 attestation.
+- [Does Vercel support .htaccess files?](https://vercel.com/kb/guide/does-vercel-support-htaccess-files): Information on Vercel's support for .htaccess files.
+- [Does Vercel support Docker deployments?](https://vercel.com/kb/guide/does-vercel-support-docker-deployments): While Vercel does not support deploying Docker images directly, you can use Docker as part of your development toolchain when building for Vercel.
+- [Does Vercel support HIPAA compliance?](https://vercel.com/kb/guide/is-vercel-hipaa-compliant): Learn about Vercel and HIPAA compliance.
+- [Does Vercel support PCI compliance?](https://vercel.com/kb/guide/is-vercel-pci-compliant): Learn about Vercel and PCI compliance.
+- [Does Vercel support permanent redirects?](https://vercel.com/kb/guide/does-vercel-support-permanent-redirects): Information on Vercel's support for permanent redirects.
+- [Does Vercel support Ruby on Rails applications?](https://vercel.com/kb/guide/does-vercel-support-ruby-on-rails-applications): Learn how you can use Ruby on Rails with your frontend on Vercel.
+- [Does Vercel support Yarn 2?](https://vercel.com/kb/guide/does-vercel-support-yarn-2): Information on Vercel's support for Yarn 2.
+- [Does Vercel support Yarn 3?](https://vercel.com/kb/guide/does-vercel-support-yarn-3): Information on Vercel's support for Yarn 3.
+- [Does Vercel support Yarn 4?](https://vercel.com/kb/guide/does-vercel-support-yarn-4): Information on Vercel's support for Yarn 4.
+- [Domain Linked to Another Account](https://vercel.com/kb/guide/domain-linked-to-another-account): This guide explains how to claim a domain already linked to another Vercel account and add it to your team using the domain claim flow.
+- [Dynamic redirects with Edge Config and Next.js proxy](https://vercel.com/kb/guide/dynamic-redirects-with-edge-config-and-next-js-proxy): Learn how to create redirects that update instantly without redeploying by storing rules in Edge Config and reading them from your Next.js proxy.
+- [Dynamically run build commands](https://vercel.com/kb/guide/dynamic-build-commands): Learn how to run different scripts based on the environment or branch.
+- [Efficiently manage database connection pools with Fluid compute](https://vercel.com/kb/guide/efficiently-manage-database-connection-pools-with-fluid-compute): How to create high-performance database connection pools without leaking connections
+- [Emergency Redirect](https://vercel.com/kb/guide/emergency-redirect): Learn how to implement an emergency redirect without re-deploying your site.
+- [Encrypting parameters](https://vercel.com/kb/guide/encrypting-parameters): Learn how to encrypt parameters so that only certain values can be passed to generate your image.
+- [Enhancing Security for Redirects and Rewrites](https://vercel.com/kb/guide/enhancing-security-for-redirects-and-rewrites): Learn how security measures in URI handling can prevent semantic attacks, where malicious hosts exploit redirects and rewrites to mimic trusted sites, leading to phishing and data breaches.
+- [Ensuring safe and effective infrastructure testing](https://vercel.com/kb/guide/ensuring-safe-and-effective-infrastructure-testing): We conduct regular penetration testing through certified third-party assessors to secure the Vercel platform. This guide explains why we handle infrastructure testing centrally and what security resources are available to customers.
+- [Error Reports for Your Projects with URIports and Vercel](https://vercel.com/kb/guide/client-side-error-reports-with-uriports-vercel): Enable error reporting for your websites deployed with Vercel and act fast on issues.
+- [Filtering query parameters](https://vercel.com/kb/guide/filter-query-parameters): Learn how to filter query parameters in your Middleware.
+- [Fine-tuning GPT with OpenAI, Next.js, and Vercel AI SDK](https://vercel.com/kb/guide/fine-tuning-openai-nextjs): In this guide, we will build Shooketh – an AI bot fine-tuned on Shakespeare's literary works with OpenAI GPT-4o and the Vercel AI SDK.
+- [Firewall Terraform Configuration](https://vercel.com/kb/guide/firewall-terraform-configuration): Learn how to create scalable firewall configurations with Terraform
+- [First Input Delay (FID) vs. Interaction to Next Paint (INP)](https://vercel.com/kb/guide/first-input-delay-vs-interaction-to-next-paint): Learn about the differences between FID and INP and how to optimize your website's INP score.
+- [Getting started with Next.js, TypeScript, and Stripe Checkout](https://vercel.com/kb/guide/getting-started-with-nextjs-typescript-stripe): Add payments functionality to your Next.js applications with Stripe and deploy to Vercel.
+- [Handling Backpressure](https://vercel.com/kb/guide/handling-backpressure): Learn how to handle backpressure by pushing data into a steam as it's needed, rather than as it's ready.
+- [Handling Node.js Request Bodies with Vercel](https://vercel.com/kb/guide/handling-node-request-body): Parse Node.js request bodies for use inside Serverless Functions deployed with Vercel.
+- [HIPAA Compliance on Vercel](https://vercel.com/kb/guide/hipaa-compliance-guide-vercel): Deploy HIPAA-compliant healthcare apps on Vercel with built-in security, BAAs, and scalable serverless infrastructure.
+- [Hosting your API on Vercel](https://vercel.com/kb/guide/hosting-backend-apis): Learn how to build and scale performant APIs on Vercel.
+- [How can I add a custom build step to my project? ](https://vercel.com/kb/guide/how-can-i-add-a-custom-build-step-to-my-project): Learn how to add a custom build step for your project.
+- [How can I allowlist IP addresses for a deployment?](https://vercel.com/kb/guide/how-to-allowlist-deployment-ip-address): You can securely connect a deployment to external services by using a stable set of IP addresses.
+- [How can I do a "Zero Downtime" DNS migration to Vercel?](https://vercel.com/kb/guide/zero-downtime-migration-for-dns): Information about how to migrate your DNS records to Vercel without downtime.
+- [How can I enable CORS on Vercel?](https://vercel.com/kb/guide/how-to-enable-cors): Learn how to add CORS headers to your application on Vercel.
+- [How can I fix SharedArrayBuffer is not defined?](https://vercel.com/kb/guide/fix-shared-array-buffer-not-defined-nextjs-react): Learn how to enable cross-origin isolation to fix SharedArrayBuffer not being defined.
+- [How can I improve function cold start performance on Vercel?](https://vercel.com/kb/guide/how-can-i-improve-serverless-function-lambda-cold-start-performance-on-vercel): This guide will help you improve the performance of your Vercel Functions and understand how to determine if the latency increase is from a cold start.
+- [How can I increase the limit of redirects or use dynamic redirects on Vercel?](https://vercel.com/kb/guide/how-can-i-increase-the-limit-of-redirects-or-use-dynamic-redirects-on-vercel): Instructions on how to use Serverless Functions to handle redirects on Vercel.
+- [How can I make my library compatible with the Vercel Edge Functions runtime?](https://vercel.com/kb/guide/library-sdk-compatible-with-vercel-edge-runtime-and-functions): Learn how to make your library or SDK compatible with Vercel Edge Functions and Vercel Edge Middleware.
+- [How can I manage my Vercel DNS records?](https://vercel.com/kb/guide/how-to-manage-vercel-dns-records): Information on how to view, add, and remove Vercel DNS records.
+- [How can I migrate a site to Vercel without downtime?](https://vercel.com/kb/guide/zero-downtime-migration): Information about how to assign a Vercel deployment to a domain without downtime.
+- [How can I move a domain to a Vercel team?](https://vercel.com/kb/guide/how-can-i-move-a-domain-to-a-team): Information on how to move domains between accounts on Vercel.
+- [How can I prerender my application on Vercel?](https://vercel.com/kb/guide/how-can-i-prerender-my-application-on-vercel): Learn how to enable prerendering with your frontend framework on Vercel for better performance and SEO.
+- [How can I reduce my Serverless Execution usage on Vercel?](https://vercel.com/kb/guide/how-can-i-reduce-my-serverless-execution-usage-on-vercel): Information about how to reduce the usage of Serverless Functions on Vercel.
+- [How can I run end-to-end tests after my Vercel Preview Deployment?](https://vercel.com/kb/guide/how-can-i-run-end-to-end-tests-after-my-vercel-preview-deployment): Learn how to use the Vercel CLI in combination with your CI/CD provider to run end-to-end tests for every code change.
+- [How can I run Next.js on localhost through HTTPS?](https://vercel.com/kb/guide/access-nextjs-localhost-https-certificate-self-signed): Learn how to create a self-signed certificate for use with local Next.js development.
+- [How can I serve multiple projects under a single domain?](https://vercel.com/kb/guide/how-can-i-serve-multiple-projects-under-a-single-domain): Learn how to serve multiple Vercel projects from a single domain.
+- [How can I set a custom build timeout?](https://vercel.com/kb/guide/custom-build-timeout): Wrap your Vercel build command with the timeout command to ensure builds terminate gracefully before exceeding Vercel’s maximum build duration.
+- [How can I share my Vercel cache across deployments?](https://vercel.com/kb/guide/share-vercel-cache-across-deployments-nextjs): Learn how to reuse cached responses across deployments with the Next.js App Router and the Vercel Data Cache.
+- [How can I use AWS S3 with Vercel?](https://vercel.com/kb/guide/how-can-i-use-aws-s3-with-vercel): Example how to use AWS S3 library on Vercel
+- [How can I use AWS SDK Environment Variables on Vercel?](https://vercel.com/kb/guide/how-can-i-use-aws-sdk-environment-variables-on-vercel): How to use AWS SDK Environment Variables on Vercel
+- [How can I use Bitbucket Pipelines with Vercel?](https://vercel.com/kb/guide/how-can-i-use-bitbucket-pipelines-with-vercel): Learn how to use Bitbucket Pipelines to deploy to Vercel including support for Bitbucket Data Center.
+- [How can I use CircleCI with Vercel?](https://vercel.com/kb/guide/how-can-i-use-circleci-with-vercel): Learn how to use CircleCI to deploy to Vercel with custom CI/CD.
+- [How can I use files in Vercel Functions?](https://vercel.com/kb/guide/how-can-i-use-files-in-serverless-functions): Learn how to import files inside Serverless Functions on Vercel.
+- [How can I use geolocation IP headers?](https://vercel.com/kb/guide/geo-ip-headers-geolocation-vercel-functions): Learn how to read geolocation headers on Vercel with Next.js or any frontend framework.
+- [How can I use GitHub Actions with Vercel?](https://vercel.com/kb/guide/how-can-i-use-github-actions-with-vercel): Learn how to use GitHub Actions to deploy to Vercel including support for GitHub Enterprise Server.
+- [How can I use GitLab Pipelines with Vercel?](https://vercel.com/kb/guide/how-can-i-use-gitlab-pipelines-with-vercel): Learn how to use GitLab Pipelines to deploy to Vercel including support for self-managed GitLab.
+- [How can I use Python and JavaScript in the same application?](https://vercel.com/kb/guide/how-to-use-python-and-javascript-in-the-same-application): Unlock the power of Python and JavaScript in your apps. Learn to integrate Flask and Next.js for dynamic frontends with AI-capable backends. Perfect for developers keen on hybrid programming.
+- [How can I use special characters in my custom domain on Vercel?](https://vercel.com/kb/guide/how-can-i-use-special-characters-in-my-custom-domain): How to resolve error 'The specified value "yöur-domaín.com" is not a fully qualified domain name' when using special characters for a custom domain in Vercel.
+- [How can I use the Vercel CLI for custom workflows?](https://vercel.com/kb/guide/using-vercel-cli-for-custom-workflows): You can use the Vercel CLI to deploy any application, including custom git providers and restricted source code.
+- [How do I add a custom domain to my Vercel project?](https://vercel.com/kb/guide/how-do-i-add-a-custom-domain-to-my-vercel-project): Learn how to add a custom domain to your Vercel project. 
+- [How do I add a domain using the Vercel API?](https://vercel.com/kb/guide/how-do-i-add-a-domain-using-the-vercel-api): Information on adding a domain using the Vercel API.
+- [How do I add environment variables to my Vercel project?](https://vercel.com/kb/guide/how-to-add-vercel-environment-variables): Learn how to add Environment Variables to your Vercel project.
+- [How do I add password protection to my Vercel deployment?](https://vercel.com/kb/guide/how-do-i-add-password-protection-to-my-vercel-deployment): Learn about how to add password protection to your websites.
+- [How do I bypass the 4.5MB body size limit of Vercel Serverless Functions?](https://vercel.com/kb/guide/how-to-bypass-vercel-body-size-limit-serverless-functions): Learn how to deal with the body size limit of Serverless Functions on Vercel.
+- [How do I change CAA records when using the Vercel CNAME record?](https://vercel.com/kb/guide/change-caa-records-with-vercel-cname): Information on how to change CAA records when using the Vercel CNAME record.
+- [How do I change my Nameservers on Vercel?](https://vercel.com/kb/guide/how-do-i-change-my-nameservers-on-vercel): Learn about how to change Nameservers for domains registered with Vercel.
+- [How do I change my Vercel avatar?](https://vercel.com/kb/guide/how-do-i-change-my-vercel-avatar): Information on changing your Vercel avatar.
+- [How do I change my Vercel username?](https://vercel.com/kb/guide/how-do-i-change-my-vercel-username): Information on changing your Vercel username.
+- [How do I change the name of my Vercel Project?](https://vercel.com/kb/guide/how-do-i-change-the-name-of-my-vercel-project): Information on changing the name of a Vercel Project.
+- [How do I create a minimal reproducible example for Vercel Support?](https://vercel.com/kb/guide/creating-a-minimal-reproducible-example): Information on how to create a minimal reproducible example for Vercel Support.
+- [How do I debug a 502 error from a Vercel Serverless Function?](https://vercel.com/kb/guide/how-to-debug-a-502-error): Information on how to debug a 502 error from a Vercel Serverless Function.
+- [How do I delete a Vercel team?](https://vercel.com/kb/guide/how-do-i-delete-a-vercel-team): Information on deleting a Vercel team.
+- [How do I delete an individual deployment?](https://vercel.com/kb/guide/how-do-i-delete-an-individual-deployment): Information on deleting an individual deployment.
+- [How do I delete my Vercel account?](https://vercel.com/kb/guide/how-do-i-delete-my-vercel-account): This guide covers how to delete your personal or team account on Vercel.
+- [How do I disable Git Notifications from Deployments?](https://vercel.com/kb/guide/how-do-i-disable-git-notifications-from-deployments): If your project is connected via a Git account to your deployment, you will receive email notifications whenever the deployment has completed. How can you disable these notifications?
+- [How do I generate a “sitemap.xml” for my Next.js app on Vercel?](https://vercel.com/kb/guide/how-do-i-generate-a-sitemap-for-my-nextjs-app-on-vercel): Guidance on how to generate a "sitemap.xml" at build time and runtime.
+- [How do I generate an SHA for uploading a file to the Vercel API?](https://vercel.com/kb/guide/how-do-i-generate-an-sha-for-uploading-a-file-to-the-vercel-api): When using the Vercel API to create a deployment, you first need to upload your files. An SHA is required to upload these files.
+- [How do I get notified when my Vercel deployment fails?](https://vercel.com/kb/guide/how-do-i-get-notified-when-my-vercel-deployment-fails): When your Vercel deployment fails, both a web notification and an email notification are sent to the creator of the deployment.
+- [How do I get the raw body of a Serverless Function?](https://vercel.com/kb/guide/how-do-i-get-the-raw-body-of-a-serverless-function): Learn how to disable body parsing for Vercel Serverless Functions to enable reading the raw data from a POST request.
+- [How do I lower my Vercel Function execution time?](https://vercel.com/kb/guide/how-do-i-lower-my-serverless-function-execution-time): Learn how to lower your Serverless Function execution time.
+- [How do I migrate away from `vercel.json` env and build.env?](https://vercel.com/kb/guide/how-do-i-migrate-away-from-vercel-json-env-and-build-env): Information on how to migrate your `vercel.json` environment variables to the Environment Variables UI.
+- [How do I perform Vercel redirects based on query strings?](https://vercel.com/kb/guide/how-do-i-perform-vercel-redirects-based-on-query-strings): When using redirects with the `vercel.json` or `next.config.js` configuration file, your URL may contain query parameters that you would like to use in your re-direction, this is possible with 2 different methods.
+- [How do I point a subdomain to a service outside of Vercel?](https://vercel.com/kb/guide/pointing-subdomains-to-external-services): Information on how to make a subdomain available to a service outside of Vercel.
+- [How do I prevent the Vercel for GitHub integration comments?](https://vercel.com/kb/guide/how-to-prevent-vercel-github-comments): Information on how to prevent the Vercel for GitHub integration from adding comments.
+- [How do I reduce my build time with Next.js on Vercel?](https://vercel.com/kb/guide/how-do-i-reduce-my-build-time-with-next-js-on-vercel): When building a Next.js project with thousands of static pages, you may hit the maximum build time per deployment limit of 45 minutes. Learn some strategies for reducing your build times by reducing computation during each build.
+- [How do I remove a domain from my Vercel account?](https://vercel.com/kb/guide/how-do-i-remove-a-domain-from-my-vercel-account): Learn how to completely remove a domain from your Vercel account?
+- [How do I resolve "ERR_SSL_PROTOCOL_ERROR" with Vercel?](https://vercel.com/kb/guide/resolve-err-ssl-protocol-error-with-vercel): Information about how to resolve the "ERR_SSL_PROTOCOL_ERROR" error with Vercel.
+- [How do I resolve "err_too_many_redirects" when using a Cloudflare proxy with Vercel?](https://vercel.com/kb/guide/resolve-err-too-many-redirects-when-using-cloudflare-proxy-with-vercel): Information about how to resolve the "err_too_many_redirects" error when using a Cloudflare proxy with Vercel.
+- [How do I resolve a 'module not found' error?](https://vercel.com/kb/guide/how-do-i-resolve-a-module-not-found-error): Information on resolving a 'module not found' error.
+- [How do I resolve a 'process.env.CI = true' error?](https://vercel.com/kb/guide/how-do-i-resolve-a-process-env-ci-true-error): Information on resolving a 'process.env.CI = true' error.
+- [How do I resolve alias related errors on Vercel?](https://vercel.com/kb/guide/how-to-resolve-alias-errors-on-vercel): Information on resolving alias related errors on Vercel.
+- [How do I select a team on Vercel?](https://vercel.com/kb/guide/how-do-i-select-a-team-on-vercel): Information on selecting a team on Vercel.
+- [How do I send and receive emails with my Vercel purchased domain?](https://vercel.com/kb/guide/using-email-with-your-vercel-domain): Information on how to send and receive emails with a domain purchased from Vercel.
+- [How do I set up a staging environment on Vercel?](https://vercel.com/kb/guide/set-up-a-staging-environment-on-vercel): Information on how to set up a staging environment on Vercel.
+- [How do I store logs on Vercel?](https://vercel.com/kb/guide/how-do-i-store-logs-on-vercel): Learn how to store logs on Vercel.
+- [How do I transfer my domain out of Vercel?](https://vercel.com/kb/guide/how-do-i-transfer-my-domain-out-of-vercel): Information on how to transfer a domain out of Vercel.
+- [How do I transfer my domain to Vercel?](https://vercel.com/kb/guide/how-do-i-transfer-my-domain-to-vercel): Information on how to transfer a domain to Vercel.
+- [How do I transfer ownership of a Vercel team?](https://vercel.com/kb/guide/how-do-i-transfer-ownership-of-a-vercel-team): Information on how to transfer ownership of a Vercel team.
+- [How do I use a Vercel API Access Token?](https://vercel.com/kb/guide/how-do-i-use-a-vercel-api-access-token): An Access Token is required in order to use the Vercel API. Tokens can be created and managed at the level of your account.
+- [How do I use private dependencies with Vercel?](https://vercel.com/kb/guide/using-private-dependencies-with-vercel): Information on how to use private dependencies with a Vercel deployment.
+- [How do I use the "Ignored Build Step" field on Vercel?](https://vercel.com/kb/guide/how-do-i-use-the-ignored-build-step-field-on-vercel): Instructions on how to use the "Ignored Build Step" field to programmatically prevent a new deployment from being built.
+- [How do I use the latest npm version for my Vercel Deployment?](https://vercel.com/kb/guide/how-do-i-use-the-latest-npm-version-for-my-vercel-deployment): Learn how to use the latest npm version for Vercel deployments.
+- [How do I view and update my domain's ICANN registrant information on Vercel? ](https://vercel.com/kb/guide/update-icann-domain-information-for-vercel-domain): Learn how to view and update the registrant information for a domain registered with Vercel.
+- [How does Vercel handle copyright infringement claims?](https://vercel.com/kb/guide/how-does-vercel-handle-copyright-infringement-claims): Information on the process Vercel will follow when receiving a copyright infringement claim.
+- [How I use OpenCode with Vercel AI Gateway to build features fast](https://vercel.com/kb/guide/how-i-use-opencode-with-vercel-ai-gateway-to-build-features-fast): How to route different AI models to different coding tasks automatically, cutting token costs by ~70% without losing quality on the work that matters.
+- [How long does it take to get a response from Vercel Support?](https://vercel.com/kb/guide/vercel-support-queue-time): Information on how long it might take Vercel Support to respond to your request.
+- [How long will it take for my Vercel DNS records to update?](https://vercel.com/kb/guide/how-long-to-update-dns-records): Information on the length of time it may take for Vercel DNS changes to take place.
+- [How to alias a preview deployment using the CLI](https://vercel.com/kb/guide/how-to-alias-a-preview-deployment-using-the-cli): Learn how to automatically alias a Vercel preview deployment.
+- [How to allow the Vercel Support team to access your deployments' source code?](https://vercel.com/kb/guide/how-to-allow-the-vercel-support-team-to-access-your-deployment-source-code): To help troubleshoot problems, you can allow the Vercel Support team to access your Deployments' source code.
+- [How to block bots from OpenAI GPTBot](https://vercel.com/kb/guide/how-to-block-bots-openai-gptbot): Learn how to use the Vercel WAF to block, rate limit, or challenge traffic from OpenAI GPTBot.
+- [How to Build a Fullstack App with Next.js, Prisma, and Postgres](https://vercel.com/kb/guide/nextjs-prisma-postgres): Create a fullstack application with Next.js, Prisma, Postgres, and deploy to Vercel.
+- [How to build a Slack bot with Next.js and Redis](https://vercel.com/kb/guide/how-to-build-a-slack-bot-with-next-js-and-redis): This guide walks through building a Slack bot with Next.js, covering project setup, Slack app configuration, event handling, interactive features, and deployment.
+- [How to Build a Weather API with Express and Vercel](https://vercel.com/kb/guide/weather-api-with-express): Provide real-time weather data to apps and websites with a single Express route.
+- [How to Build a Weather API with FastAPI and Vercel](https://vercel.com/kb/guide/weather-api-with-fastapi): Provide real-time weather data to apps and websites with a single FastAPI route.
+- [How to Build a Weather API with Nitro and Vercel](https://vercel.com/kb/guide/weather-api-with-nitro): Provide real-time weather data to apps and websites with a single Nitro route, Vercel cache storage, and Observability.
+- [How to build AI Agents with Vercel and the AI SDK](https://vercel.com/kb/guide/how-to-build-ai-agents-with-vercel-and-the-ai-sdk): Learn how to build, deploy, and scale AI agents on Vercel using the AI SDK. This guide covers calling LLMs, defining tools, creating multi-step agents, and monitoring performance.
+- [How to build an AI agent for Slack with Chat SDK and AI SDK](https://vercel.com/kb/guide/how-to-build-an-ai-agent-for-slack-with-chat-sdk-and-ai-sdk): Build a Slack AI agent using Chat SDK, AI SDK's ToolLoopAgent, and Vercel AI Gateway. Covers project setup, tool definitions, streaming responses, deployment to Vercel, and scaling tool selection with toolpick.
+- [How to build an MCP server with Nuxt](https://vercel.com/kb/guide/how-to-build-an-mcp-server-with-nuxt): Add an MCP server to your Nuxt app with the Nuxt MCP Toolkit. Create tools, resources, and prompt templates that AI assistants like Cursor and VS Code can connect to.
+- [How to build an on-demand voice agent with Vercel Sandbox](https://vercel.com/kb/guide/how-to-build-an-on-demand-voice-agent-with-vercel-sandbox): Build a voice AI application that creates isolated LiveKit agent environments using Vercel Sandbox, enabling real-time conversations without maintaining persistent infrastructure.
+- [How to conduct PCI scans on Vercel: A complete guide to IP safelisting](https://vercel.com/kb/guide/how-to-conduct-pci-scans-on-vercel-guide): Scan and verify your Vercel deployments for secure, PCI-compliant payment processing.
+- [How to Configure the Cache-Control Response Header in Vercel Projects](https://vercel.com/kb/guide/how-to-configure-the-cache-control-response-header-in-vercel-projects): After reviewing this guide, you will be able to set a cache-control header of any value to be returned when a specific page of your deployment is requested.
+- [How to contribute to the Vercel Community](https://vercel.com/kb/guide/how-to-contribute-to-the-vercel-community): Discover the ways you can participate, share, and grow with us
+- [How to create a HAR file for Vercel Support](https://vercel.com/kb/guide/create-a-har-file-for-vercel-support): Learn how to generate a HAR file on macOS and Windows across all major browsers.
+- [How to debug 404 errors](https://vercel.com/kb/guide/how-to-debug-404-errors): Learn the systematic steps to identify and resolve 404 issues.
+- [How to Deploy a Brunch App with Vercel](https://vercel.com/kb/guide/deploying-brunch-with-vercel): Create a Brunch app and deploy it live with Vercel.
+- [How to Deploy a Charge App with Vercel](https://vercel.com/kb/guide/deploying-charge-with-vercel): Create a Charge App and deploy it live with Vercel.
+- [How to Deploy a Docusaurus Site with Vercel](https://vercel.com/kb/guide/deploying-docusaurus-with-vercel): Create a Docusaurus documentation site and deploy it live with Vercel.
+- [How to Deploy a Dojo App with Vercel](https://vercel.com/kb/guide/deploying-dojo-with-vercel): Create a Dojo app and deploy it live with Vercel.
+- [How to Deploy a Hexo Blog with Vercel](https://vercel.com/kb/guide/deploying-hexo-with-vercel): Create a Hexo blog and deploy it live with Vercel.
+- [How to Deploy a Hugo Site with Vercel](https://vercel.com/kb/guide/deploying-hugo-with-vercel): Create a Hugo website and deploy it live with Vercel.
+- [How to Deploy a Jekyll Site with Vercel](https://vercel.com/kb/guide/deploying-jekyll-with-vercel): Create a Jekyll website and deploy it live with Vercel.
+- [How to Deploy a Middleman App with Vercel](https://vercel.com/kb/guide/deploying-middleman-with-vercel): Create a Middleman app and deploy it live with Vercel.
+- [How to deploy a Next.js online store with Stripe](https://vercel.com/kb/guide/how-to-deploy-a-next-js-online-store-with-stripe): Learn how to build and deploy a Next.js e-commerce store with Stripe payments on Vercel. This step-by-step guide covers setup, local development, and going live with your online store.
+- [How to Deploy a Polymer App with Vercel](https://vercel.com/kb/guide/deploying-polymer-with-vercel): Create a Polymer app and deploy it live with Vercel.
+- [How to Deploy a Preact Site with Vercel](https://vercel.com/kb/guide/deploying-preact-with-vercel): Create your Preact app and deploy it with Vercel.
+- [How to Deploy a React Site with Vercel](https://vercel.com/kb/guide/deploying-react-with-vercel): Create your React app and deploy it with Vercel.
+- [How to Deploy a Redwood Site with Vercel](https://vercel.com/kb/guide/deploying-redwood-with-vercel): Create your Redwood app and deploy it with Vercel.
+- [How to Deploy a Remix Site with Vercel](https://vercel.com/kb/guide/deploying-remix-with-vercel): Create your Remix app and deploy it with Vercel.
+- [How to Deploy a Solid App with Vercel](https://vercel.com/kb/guide/deploying-solid-with-vercel): Create a Solidjs app and deploy it live with Vercel.
+- [How to Deploy a Stencil app with Vercel](https://vercel.com/kb/guide/deploying-stencil-with-vercel): Create a Stencil app and deploy it live with Vercel.
+- [How to Deploy a Vue.js Site with Vercel](https://vercel.com/kb/guide/deploying-vuejs-to-vercel): Create your Vue.js app and deploy it with Vercel.
+- [How to Deploy an Angular Site with Vercel](https://vercel.com/kb/guide/deploying-angular-with-vercel): Create your Angular app and deploy it with Vercel.
+- [How to Deploy an Aurelia App with Vercel](https://vercel.com/kb/guide/deploying-aurelia-with-vercel): Create an Aurelia app and deploy it live with Vercel.
+- [How to Deploy an Eleventy Site with Vercel](https://vercel.com/kb/guide/deploying-eleventy-with-vercel): Create an Eleventy website and deploy it live with Vercel.
+- [How to Deploy an Ember App with Vercel](https://vercel.com/kb/guide/deploying-ember-with-vercel): Create an Ember app and deploy it live with Vercel.
+- [How to Deploy an UmiJS App with Vercel](https://vercel.com/kb/guide/deploying-umijs-with-vercel): Create an UmiJS app and deploy it live with Vercel.
+- [How to Deploy MDX Deck with Vercel](https://vercel.com/kb/guide/deploying-mdx-deck-with-vercel): Create a React based slideshow with MDX Deck and deploy it live with Vercel.
+- [How to detect when user leaves the page and display a confirmation dialog?](https://vercel.com/kb/guide/leave-page-confirmation-dialog-before-unload-nextjs-react): Learn how to use React and Next.js to show an alert asking the user to confirm they want to exit a page using the window beforeunload event listener.
+- [How to determine which Vercel Deployment introduced an issue?](https://vercel.com/kb/guide/how-to-determine-which-vercel-deployment-introduced-an-issue): Process to quickly determine when a deployment issue was introduced using the Vercel CLI
+- [How to Effectively Load Test Your Vercel Application](https://vercel.com/kb/guide/how-to-effectively-load-test-your-vercel-application): Learn how to safely load test your Next.js app on Vercel. This guide covers realistic, policy-compliant testing of routes, caching, middleware, and databases to uncover performance issues without impacting Vercel’s infrastructure.
+- [How to evaluate a rapid AI prototyping tool](https://vercel.com/kb/guide/how-to-evaluate-a-rapid-ai-prototyping-tool): A practical guide on how to evaluate an AI prototyping tool for your team, from thinking through requirements like security and prototype fidelity, to choosing the right pilot metrics, to structuring a two-phase rollout that starts with a small group and expands once the first phase proves out.
+- [How to execute AI-generated code safely with Vercel Sandbox](https://vercel.com/kb/guide/how-to-execute-ai-generated-code-safely): Learn how to run code generated by AI models in an isolated sandbox environment.
+- [How to Export Your Domain's DNS Records from Vercel](https://vercel.com/kb/guide/export-domain-dns-records-via-api): Learn how to utilize our API to export your domain's DNS records from Vercel.
+- [How to Fix Sitecore JSS Middleware Performance](https://vercel.com/kb/guide/how-to-fix-sitecore-jss-middleware-performance): Learn how to troubleshoot and resolve Vercel Middleware timeouts and memory errors in your Sitecore JSS application caused by URLs with many query parameters.
+- [How to get good answers on Vercel Community](https://vercel.com/kb/guide/how-to-get-good-answers-on-vercel-community): Learn the art of asking effective questions and contributing to collaborative problem-solving.
+- [How to gradually roll out new versions of your backend](https://vercel.com/kb/guide/how-to-gradually-roll-out-new-versions-of-your-backend): Incrementally release updates to your backend to minimize impact of mistakes.
+- [How to install system packages in Vercel Sandbox](https://vercel.com/kb/guide/how-to-install-system-packages-in-vercel-sandbox): Learn how to install additional system packages in Vercel Sandbox using dnf, the package manager for Amazon Linux 2023.
+- [How to Integrate Next.js with Prismic's Headless CMS](https://vercel.com/kb/guide/how-to-integrate-nextjs-with-prismic): Learn how to connect Next.js with Prismic's CMS and deploy the integrated website to Vercel
+- [How to Integrate Optimizely Feature Experimentation with Next.js and Vercel](https://vercel.com/kb/guide/how-to-integrate-optimizely-feature-experimentation-next-vercel): This guide covers setting up feature flags, implementing A/B tests, and optimizing performance using React Server Components and streaming.
+- [How to internationalise error pages in Next.js App Router](https://vercel.com/kb/guide/how-to-internationalise-error-pages-in-next-js-app-router):  Learn how to show translated error messages in Next.js App Router when using the app/[lang]/ pattern for internationalisation.
+- [How to Load Data from a File in Next.js](https://vercel.com/kb/guide/loading-static-file-nextjs-api-route): Learn how to display and read the contents of a static json file in your Next.js application.
+- [How to lock down deployments on Vercel and v0](https://vercel.com/kb/guide/locking-down-deployments): Protect who can see your deployments.
+- [How to migrate from Fastly to Vercel with zero downtime](https://vercel.com/kb/guide/how-to-migrate-from-fastly-to-vercel-with-zero-downtime): Consolidate your CDN infrastructure on Vercel to reduce latency, simplify your configuration, and improve your developer experience without interrupting service to your users.
+- [How to move a domain between Vercel projects with "Zero Downtime"?](https://vercel.com/kb/guide/how-to-move-a-domain-between-vercel-projects-with-zero-downtime): Information about how to move your domain between Vercel projects without downtime.
+- [How to Optimize Next.js + Sitecore JSS](https://vercel.com/kb/guide/how-to-optimize-next.js-sitecore-jss): This guide covers performance and usage considerations when building and deploying your Next.js and Sitecore JSS application.
+- [How to Optimize RSC Payload Size](https://vercel.com/kb/guide/how-to-optimize-rsc-payload-size): Learn how to use React Server Components efficiently in Next.js to reduce cost and improve performance
+- [How to optimize your document size in Next.js](https://vercel.com/kb/guide/how-to-optimize-your-document-size-in-next-js): A quick reference checklist to help you optimize your Next.js document size for better performance and lower costs.
+- [How to pin a specific Bun version for Vercel builds?](https://vercel.com/kb/guide/how-to-pin-a-specific-bun-version-for-vercel-builds): Learn how to use a specific Bun version for Vercel builds.
+- [How to protect your AI app from bots](https://vercel.com/kb/guide/how-to-protect-your-ai-app-from-bots): Learn how to protect your AI app from bots, scrapers, and abuse using Firewall, BotID, and more.
+- [How to reconnect to a running Sandbox](https://vercel.com/kb/guide/how-to-reconnect-to-a-running-sandbox):  Learn how to use `Sandbox.get()` to reconnect to an existing sandbox from a different process or after a script restart.
+- [How to resolve IP blocking issues ](https://vercel.com/kb/guide/how-to-resolve-ip-blocking-issues): Learn to troubleshoot IP blocking issues for both shared and personal networks.
+- [How to rotate the secrets of your Clerk integration](https://vercel.com/kb/guide/how-to-reset-the-secrets-of-your-clerk-integration): Rotate Clerk API keys
+- [How to rotate the secrets of your Hypertune integration](https://vercel.com/kb/guide/how-to-reset-the-secrets-of-your-hypertune-integration): Rotate Hypertune API keys with zero-downtime.
+- [How to rotate the secrets of your MongoDB Atlas integration](https://vercel.com/kb/guide/how-to-reset-the-secret-for-your-mongodb-atlas-integration): This will guide you how to update the password for a MongoDB Atlas databse.
+- [How to rotate the secrets of your Neon integration](https://vercel.com/kb/guide/how-to-reset-a-secret-for-a-neon-integration): This will guide you how to update the password for a Neon project.
+- [How to rotate the secrets of your Redis integration](https://vercel.com/kb/guide/how-to-reset-the-secret-for-your-redis-integration): This will guide you how to update the password for a Redis databse.
+- [How to rotate the secrets of your Supabase integration](https://vercel.com/kb/guide/how-to-reset-the-secrets-of-your-supabase-integration): Rotate Supabase API keys, JWT secrets, and database passwords.
+- [How to rotate the secrets of your Upstash integration](https://vercel.com/kb/guide/how-to-reset-the-secrets-of-your-upstash-integration): Rotate Upstash API keys, JWT secrets, and database passwords.
+- [How to serve documentation for agents](https://vercel.com/kb/guide/how-to-serve-documentation-for-agents): Learn how to serve markdown to agents and HTML for humans from the same URL
+- [How to Setup Cron Jobs on Vercel](https://vercel.com/kb/guide/how-to-setup-cron-jobs-on-vercel): Learn how to setup and use cron jobs on Vercel
+- [How to test a Slack bot with your Vercel preview deployment](https://vercel.com/kb/guide/test-slack-bot-with-vercel-preview-deployment): Learn how to build and test a Slack bot using Vercel preview deployments. This guide covers setting up your Slack app, configuring webhook URLs, and bypassing deployment protection using the x-vercel-protection-bypass query parameter.
+- [How to troubleshoot stale content returned from the Edge Network when using an external proxy or CDN](https://vercel.com/kb/guide/how-to-troubleshoot-stale-content-returned-from-the-edge-network-when-using-an-external-proxy-or-cdn): Learn how to diagnose and fix stale content issues when using external proxies or CDNs with Vercel. Understand troubleshooting strategies, and configuration best practices to ensure fresh content delivery.
+- [How to Upload and Store Files with Vercel](https://vercel.com/kb/guide/how-to-upload-and-store-files-with-vercel): Learn how to upload and store files with Vercel
+- [How to use Deploy Hooks with Vercel and a Headless CMS](https://vercel.com/kb/guide/set-up-and-use-deploy-hooks-with-vercel-and-headless-cms): Create your own Deploy Hooks to trigger automatic deployments on Vercel when using a Headless CMS.
+- [How to Use ML Models from Hugging Face in Vercel Functions](https://vercel.com/kb/guide/ml-models-hugging-face): This guide provides step-by-step instructions on how to integrate ML models from Hugging Face into Vercel Functions
+- [How to use OpenAI Function Calling with Next.js and the Vercel AI SDK](https://vercel.com/kb/guide/openai-function-calling): Learn how to use OpenAI Function Calling and Vercel AI SDK in a Next.js Application to build AI-powered user experiences.
+- [How to use snapshots for faster sandbox startup](https://vercel.com/kb/guide/how-to-use-snapshots-for-faster-sandbox-startup): Learn how to save sandbox state with snapshots and skip installation on future runs.
+- [How to Utilize Vercel’s Bot Management Features](https://vercel.com/kb/guide/how-to-utilize-vercels-bot-management-features): A practical, step-by-step guide to identifying unwanted automated traffic and securing your Vercel apps with Bot Protection Managed Rules, AI Bots Managed Rules, BotID, and custom WAF rules. Learn how to enable, monitor, and tune protections to block bad bots, preserve performance for real users, and safely allow good crawlers.
+- [Implementing Blue-Green Deployments on Vercel](https://vercel.com/kb/guide/blue_green_deployments_on_vercel):  This guide outlines how to implement blue-green deployments on Vercel, leveraging GitHub Actions for seamless and controlled application updates with minimal downtime.
+- [Implementing Canary Deployments on Vercel](https://vercel.com/kb/guide/implementing_canary_deployments_on_vercel): This guide explains how to set up canary deployments on Vercel, enabling developers to gradually roll out new versions to a subset of users with minimal risk by leveraging Skew Protection, Edge Config, and Middleware in Next.js.
+- [Incremental Migrations with Microfrontends](https://vercel.com/kb/guide/incremental-migrations-with-microfrontends): Learn how to migrate legacy applications using microfrontends
+- [Integrate Vercel and Contentstack for your Headless CMS](https://vercel.com/kb/guide/integrate-vercel-and-contentstack): Integrate Vercel with Contentstack, a headless CMS, to build and deploy dynamic, high-performance websites.
+- [Integrating AWS Secrets Manager with Vercel Using Terraform](https://vercel.com/kb/guide/integrating_aws_secrets_manager_with_vercel_using_terraform): Learn how to seamlessly integrate AWS Secrets Manager with Vercel for enhanced security and efficiency in your web deployments using Terraform with our comprehensive guide.
+- [Integrating Next.js and Contentful for your Headless CMS](https://vercel.com/kb/guide/integrating-next-js-and-contentful-for-your-headless-cms):  Next.js with Contentful gives you the power to quickly build scalable dynamic static websites with improved search engine optimization (SEO) and enhanced performance.
+- [Integrating Terraform with Vercel](https://vercel.com/kb/guide/integrating-terraform-with-vercel): Understand the benefits of Terraform and how to set up the Integration with Vercel.
+- [Investigate latency issues and slowness on Vercel](https://vercel.com/kb/guide/investigate-latency-issues-and-slowness): Learn how to use Observability to investigate latency issues and slowness on Vercel.
+- [Is SQLite supported in Vercel?](https://vercel.com/kb/guide/is-sqlite-supported-in-vercel): SQLite is a popular and fast database engine. In this article, we discuss whether it can be used in a serverless environment like Vercel.
+- [Is Vercel certified under DPF?](https://vercel.com/kb/guide/is-vercel-certified-under-dpf): The EU-U.S. Data Privacy Framework (DPF) enables secure data transfers from the EU, UK, and Switzerland to the U.S. Vercel is DPF certified, ensuring compliance with data protection laws. Learn more in our Privacy Notice.
+- [Is Vercel ISO 27001 certified?](https://vercel.com/kb/guide/is-vercel-iso-27001-certified): Vercel is ISO 27001:2022 certified. See our certificate here.
+- [ISR Observability: Framework Discrepancies ](https://vercel.com/kb/guide/isr-observability-framework-discrepancies): Understanding ISR Observability with Different Frameworks
+- [Lifecycle of a domain](https://vercel.com/kb/guide/lifecycle-of-a-domain): From active to available: the domain expiration timeline for a .com domain
+- [Limit Abuse with Rate Limiting](https://vercel.com/kb/guide/limit-abuse-with-rate-limiting): Learn how to protect your authentication endpoints against abuse.
+- [Load Google Analytics script based on user location in Next.js](https://vercel.com/kb/guide/geolocation-script): Learn how you can conditionally load a Google Analytics script based on your user's location
+- [Make your documentation readable by AI agents](https://vercel.com/kb/guide/make-your-documentation-readable-by-ai-agents): Serve markdown to AI agents using content negotiation, .md endpoints, agent auto-detection, llms.txt,   sitemap.md, and MCP. Includes a checklist, implementation patterns, and a compliance framework for measuring agent readiness   across content platforms.
+- [Manage cache tags for external origins](https://vercel.com/kb/guide/how-to-manage-cache-tags-for-external-origins): Learn how to use cache tags to optimally serve fresh content on Vercel when content from your external origin changes
+- [Managing Redirects from your CMS using Vercel Bulk Redirects](https://vercel.com/kb/guide/managing-redirects-from-your-cms-using-vercel-bulk-redirects): Learn how to sync redirect rules from your CMS to Vercel at build time with vercel.ts, allowing non-technical teams to manage vanity URLs and product redirects without code changes.
+- [Migrate to Vercel from Cloudflare](https://vercel.com/kb/guide/migrate-to-vercel-from-cloudflare): Migrate your website's configuration from Cloudflare Pages or Workers to Vercel
+- [Migrate to Vercel from Netlify](https://vercel.com/kb/guide/migrate-to-vercel-from-netlify): Migrate your website's configuration from Netlify to Vercel
+- [Missing routes-manifest.json file or No Output Directory when using Turborepo or NX](https://vercel.com/kb/guide/missing-routes-manifest-or-output-turborepo-nx): How to solve the error `The file "/vercel/path0/apps/web/.next/routes-manifest.json" couldn't be found` or `No Output Directory` when using Turborepo or NX.
+- [Modifying request headers](https://vercel.com/kb/guide/modify-request-headers): Learn how to modify request headers in your Middleware.
+- [Monitor Frontend Performance with DebugBear and Vercel](https://vercel.com/kb/guide/monitor-frontend-performance-with-debugbear-and-vercel): Automatically test each Vercel deployment and report performance changes to GitHub.
+- [Monitor Performance with Calibre and Vercel](https://vercel.com/kb/guide/monitoring-performance-with-calibre-and-vercel): Receive performance reports directly in your GitHub Pull Requests, following a Vercel deployment.
+- [Optimizing Core Web Vitals in 2024](https://vercel.com/kb/guide/optimizing-core-web-vitals-in-2024): Learn how to optimize Core Web Vitals for your site, including INP, CLS, LCP, and more.
+- [Optimizing hard navigations](https://vercel.com/kb/guide/optimizing-hard-navigations): Learn how to improve performance for navigations that require a full page reload
+- [Pause your project](https://vercel.com/kb/guide/pause-your-project): Use a webhook to pause your project based on spend management.
+- [Penetration testing on Vercel](https://vercel.com/kb/guide/penetration-testing-on-vercel): Learn how to perform pentesting on Vercel.
+- [Per-environment and per-branch Build Commands on Vercel](https://vercel.com/kb/guide/per-environment-and-per-branch-build-commands): Customize your commands for specific behaviors based on branch, environment, and more.
+- [Processing Data Chunks](https://vercel.com/kb/guide/processing-data-chunks): Learn how to create an API endpoint that processes data chunks.
+- [Publish and Subscribe to Realtime Data on Vercel](https://vercel.com/kb/guide/publish-and-subscribe-to-realtime-data-on-vercel): Learn how to upload and store files with Vercel
+- [Rendering content based on device](https://vercel.com/kb/guide/rendering-content-based-on-device): Learn how to render different content based on the user agent in your Middleware.
+- [Run and track deploys from Slack](https://vercel.com/kb/guide/run-and-track-deploys-from-slack): Build a Slack deploy bot with Chat SDK and Vercel Workflow. Dispatch GitHub Actions from a slash command, gate production behind approval, poll for completion, and notify Linear and GitHub when the run finishes. 
+- [Running OpenClaw in Vercel Sandbox](https://vercel.com/kb/guide/running-openclaw-in-vercel-sandbox): This guide walks you through setting up OpenClaw inside a Vercel Sandbox and configuring the WhatsApp channel.
+- [Running OpenCode securely with the Vercel Sandbox](https://vercel.com/kb/guide/running-opencode-securely-with-the-vercel-sandbox): Run OpenCode in an isolated Vercel Sandbox MicroVM with controlled egress, using the SDK to restrict network access so the AI agent can only reach approved LLM endpoints.
+- [Safely running AI generated code in your Next.js application](https://vercel.com/kb/guide/running-ai-generated-code-sandbox): How to execute untrusted, AI‑generated code from a Next.js app using Vercel Sandbox, an isolated, ephemeral environment.
+- [Securing your AI applications with Rate Limiting](https://vercel.com/kb/guide/securing-ai-app-rate-limiting): Learn how to secure your AI applications with rate limiting using Vercel WAF and Vercel AI SDK
+- [Sending a sample of events to Speed Insights](https://vercel.com/kb/guide/sending-sample-to-speed-insights): Learn how to send a sample of your data to Speed insights.
+- [Sending Emails from an application on Vercel](https://vercel.com/kb/guide/sending-emails-from-an-application-on-vercel): Learn best practices for sending emails from an application on Vercel
+- [Serverless Function contains invalid runtime error](https://vercel.com/kb/guide/serverless-function-contains-invalid-runtime-error): A guide for the "Serverless Function contains invalid runtime" error for Node.js v20 deployments.
+- [Set cache control headers for functions](https://vercel.com/kb/guide/set-cache-control-headers): Learn how to set headers to cache your function's responses.
+- [Ship a GitHub code review bot with Hono and Redis](https://vercel.com/kb/guide/ship-a-github-code-review-bot-with-hono-and-redis): This guide walks through building a GitHub bot that reviews pull requests on demand. When a user @mentions the bot on a PR, Chat SDK picks up the mention, spins up a Vercel Sandbox with the repo cloned, and uses AI SDK to analyze the diff.
+- [Should I use Cloudflare in front of Vercel?](https://vercel.com/kb/guide/cloudflare-with-vercel): Information on using Cloudflare together with Vercel.
+- [SQL vs. NoSQL databases](https://vercel.com/kb/guide/sql-vs-nosql-databases): Learn about the differences between SQL and NoSQL, each with a unique set of benefits suited for particular use cases.
+- [Streaming in web applications](https://vercel.com/kb/guide/what-is-streaming): Learn how streaming works in web applications. Explore benefits, use cases, and implementation details with Vercel Functions and the Web Streams API
+- [Streaming responses from LLMs](https://vercel.com/kb/guide/streaming-from-llm): Learn how to use the AI SDK to stream LLM responses.
+- [Supporting Compliance with Vercel WAF](https://vercel.com/kb/guide/supporting-compliance-with-vercel-waf): Vercel Firewall provides edge-based traffic filtering and monitoring to help teams meet compliance requirements in security and regulatory frameworks, including PCI DSS, ISO 27001, SOC 2, and HIPAA.
+- [Suspicious Traffic in Specific Countries](https://vercel.com/kb/guide/suspicious-traffic-in-specific-countries): Learn how to block traffic in specific geographical regions.
+- [Transferring Domains to Vercel](https://vercel.com/kb/guide/transferring-domains-to-vercel): How to transfer your domain to Vercel.
+- [Triage form submissions with Chat SDK](https://vercel.com/kb/guide/triage-form-submissions-with-chat-sdk): Build a Slack bot that triages form submissions with interactive cards. Forward, edit, or mark as spam without leaving Slack. Built with Chat SDK, Hono, and Resend.
+- [Troubleshooting Build Error: "Build step did not complete within the maximum of 45 minutes"](https://vercel.com/kb/guide/troubleshooting-build-error-build-step-did-not-complete-within-45-minutes): Learn strategies to reduce build times and optimize your Vercel project.
+- [Troubleshooting Build Error: “Serverless Function has exceeded the unzipped maximum size of 250 MB”](https://vercel.com/kb/guide/troubleshooting-function-250mb-limit): Learn how to troubleshoot builds failing due to exceeding the maximum function size limit on Vercel.
+- [Troubleshooting Builds Failing with SIGKILL or Out of Memory Errors](https://vercel.com/kb/guide/troubleshooting-sigkill-out-of-memory-errors): Learn how to troubleshoot builds failing with SIGKILL or Out of Memory errors on a Vercel Deployment. 
+- [Troubleshooting connectivity issues to Vercel Deployments](https://vercel.com/kb/guide/troubleshooting-connectivity-issues): Learn how to troubleshoot network connectivity issues to your Vercel deployment.
+- [Troubleshooting Content Link](https://vercel.com/kb/guide/troubleshooting-content-link): This guide provides troubleshooting information for common issues when using Content Link
+- [Troubleshooting Cross-Origin Errors (net::ERR_BLOCKED_BY_ORB) with Deployment Protection](https://vercel.com/kb/guide/troubleshooting-cross-origin-errors-neterr-blocked-by-orb-with-deployment-protection): Learn to resolve `net::ERR_BLOCKED_BY_ORB` errors on protected Vercel deployments. This guide explains how cross-origin asset requests conflict with Vercel Authentication and shows the fix for Sitecore JSS apps using the `PUBLIC_URL` environment variable.
+- [Troubleshooting Inconsistent Logs in Vercel Functions](https://vercel.com/kb/guide/troubleshooting-inconsistent-logs-in-vercel-functions): Learn how to troubleshoot and resolve logs that appear mixed in Vercel Functions. This guide explains why logs from different requests can appear mixed and provides solutions to ensure your functions execute reliably without corrupting your log data.
+- [Troubleshooting request ECONNRESET errors](https://vercel.com/kb/guide/troubleshooting-request-econnreset-errors): Understand what ECONNRESET means in Vercel runtime logs, why it happens when calling external APIs, how to diagnose it, and when to contact Vercel Support.
+- [Troubleshooting Vercel Cron Jobs](https://vercel.com/kb/guide/troubleshooting-vercel-cron-jobs): Learn how to troubleshoot cron jobs that aren't being run or logged when using Vercel Cron Jobs.
+- [Unable to find GitHub repository](https://vercel.com/kb/guide/unable-to-find-github-repository): This is a guide to check GitHub permissions to ensure your Vercel account has sufficient access to import your repository.
+- [Understand the Cost Impact of Function Invocations](https://vercel.com/kb/guide/understand-cost-impact-of-function-invocations): Learn how to use Observability to understand function invocations and their cost impact.
+- [Understanding Cookies](https://vercel.com/kb/guide/understanding-cookies): Discover how web cookies function, the importance of cookie attributes for security, and methods for inspecting and debugging cookies.
+- [Understanding CSRF attacks](https://vercel.com/kb/guide/understanding-csrf-attacks): Understand the mechanics and risks of Cross-Site Request Forgery (CSRF) attacks, and discover crucial development practices, like anti-CSRF tokens and appropriate use of HTTP methods, to fortify web applications against such threats
+- [Understanding the SameSite cookie attribute](https://vercel.com/kb/guide/understanding-the-samesite-cookie-attribute): Explore the SameSite cookie attribute's significance in ensuring web security and user privacy to strike the right balance between security and usability.
+- [Understanding vector databases for AI apps](https://vercel.com/kb/guide/understanding-vector-databases-for-ai-apps): Learn how vector databases enable semantic search through embeddings and similarity matching.
+- [Understanding XSS Attacks](https://vercel.com/kb/guide/understanding-xss-attacks): Learn about XSS attacks, their types, risks, and effective prevention strategies in this comprehensive guide for web security.
+- [Updating large-scale site navigation with minimal revalidation](https://vercel.com/kb/guide/update-mega-nav-min-reval): When working with a large number of pages that share a common multi-level navigation, making a navigation update requires revalidating all pages. Learn how to avoid this by using smart revalidation.
+- [Use feature flags in Fumadocs with the Vercel Toolbar](https://vercel.com/kb/guide/use-feature-flags-in-fumadocs-with-the-vercel-toolbar): Control documentation visibility with feature flags. Hide inline content, entire pages, and navigation items based on flag state.
+- [Use your Vercel-owned domain on Bluesky](https://vercel.com/kb/guide/use-my-domain-bluesky): Learn how to add your domain as your handle on Bluesky
+- [Using a custom font in your OG Image](https://vercel.com/kb/guide/using-custom-font): Learn how to use a custom font from the tile system in your OG images.
+- [Using a Headless CMS with Vercel](https://vercel.com/kb/guide/using-a-headless-cms-with-vercel): Learn best practices for using databases in a serverless environment with Vercel
+- [Using an external image as OG image](https://vercel.com/kb/guide/using-an-external-dynamic-image): Learn how to pass the username as a URL parameter to pull an external profile image for the image generation.
+- [Using an SVG image in your OG image](https://vercel.com/kb/guide/using-svg-image): Learn how to use SVG embedded content to generate your OG images.
+- [Using coding agents to procure Vercel Marketplace integrations](https://vercel.com/kb/guide/using-coding-agents-to-procure-vercel-marketplace-integrations): Coding agents can now discover, provision, and manage third-party services from the Vercel Marketplace using the Vercel CLI integration commands.
+- [Using dynamic text as your OG Image](https://vercel.com/kb/guide/dynamic-text-as-image): Learn how to pass the image title as a URL parameter.
+- [Using emoji in your OG image](https://vercel.com/kb/guide/using-emoji-in-image): Learn how to use emojis to generate an OG image.
+- [Using Express.js with Vercel](https://vercel.com/kb/guide/using-express-with-vercel): Learn how to use Express.js in a Serverless environment.
+- [Using Fathom Analytics with Next.js](https://vercel.com/kb/guide/deploying-nextjs-using-fathom-analytics-with-vercel): Learn how to integrate Fathom Analytics with Next.js.
+- [Using Headless WordPress with Next.js and Vercel](https://vercel.com/kb/guide/wordpress-with-vercel): Learn how to use Headless WordPress with your Next.js application and deploy it to Vercel.
+- [Using languages in your OG image](https://vercel.com/kb/guide/using-different-languages): Learn how to use other languages in the text of your OG image.
+- [Using Non-default Branches for Production Deployments](https://vercel.com/kb/guide/can-i-use-a-non-default-branch-for-production): Learn how to set a non-default branch as Production on your Vercel project.
+- [Using PostHog with the Next.js App Router and Vercel](https://vercel.com/kb/guide/posthog-nextjs-vercel-feature-flags-analytics): Learn how to use PostHog with Next.js and Vercel to add analytics, feature flags, and more.
+- [Using private GitHub repositories with Vercel Sandbox](https://vercel.com/kb/guide/sandbox-private-github-repositories): Learn how to use Vercel Sandbox with private GitHub repositories using fine-grained tokens, classic tokens, or GitHub App tokens.
+- [Using React Context for State Management with Next.js](https://vercel.com/kb/guide/react-context-state-management-nextjs): Learn how to use React context inside Next.js in both client and server components for state management in your application.
+- [Using Self-hosted & Reverse Proxies with Vercel](https://vercel.com/kb/guide/how-to-setup-verified-proxy): Learn about using self-hosted or reverse proxies with Vercel deployments.
+- [Using SvelteKit Form Actions](https://vercel.com/kb/guide/using-sveltekit-form-actions): This guide explains how to use form actions in SvelteKit to handle form submissions, process form data, and enhance form interactions, providing seamless integration with the endpoint system.
+- [Using Tailwind CSS with your OG Image](https://vercel.com/kb/guide/using-tailwind): Learn how to use Tailwind CSS to style your OG images.
+- [Using the crypto Web API to redirect requests with a unique token](https://vercel.com/kb/guide/use-crypto-web-api): Learn how to use the Crypto Web API in your Middleware.
+- [Using Vercel as a Standalone CDN](https://vercel.com/kb/guide/using_vercel_as_a_cdn): Use Vercel's external rewrites to proxy and cache content from external websites or APIs through Vercel's global edge network.
+- [Using Vercel Sandbox to run Claude’s Agent SDK](https://vercel.com/kb/guide/using-vercel-sandbox-claude-agent-sdk): Learn how to deploy Claude's Agent SDK in Vercel Sandbox for secure and isolated execution of AI-powered code generation and autonomous agent tasks. 
+- [Vector Databases Explained](https://vercel.com/kb/guide/vector-databases): Learn about vector databases: what they are, 8 of the best examples and how to build an AI semantic search app with them.
+- [Vercel AI SDK vs TanStack AI](https://vercel.com/kb/guide/vercel-ai-sdk-vs-tanstack-ai): Compare the Vercel AI SDK and TanStack AI for building AI-powered TypeScript applications. Learn how they differ in agent abstractions, framework support, streaming, tool calling, and bundle optimization to choose the right toolkit for your project. 
+- [Vercel Integration Guide for SAP Composable Storefront](https://vercel.com/kb/guide/integration-guide-for-sap-composable-storefront): Integrate Vercel and SAP Composable Storefront with advanced rendering methods by leveraging the Vercel Build Output API
+- [Vercel Sandbox vs CodeSandbox](https://vercel.com/kb/guide/vercel-sandbox-vs-codesandbox): A detailed guide to Vercel Sandbox vs CodeSandbox: compute isolation, credential brokering, Active CPU billing, Docker support, persistent environments, and when to choose each product for your AI workloads.
+- [Vercel Sandbox vs E2B](https://vercel.com/kb/guide/vercel-sandbox-vs-e2b): A detailed guide to Vercel Sandbox vs E2B: compute lifecycle, security controls, code execution, pricing, and when to choose each sandbox for your AI agent workloads.
+- [Vercel vs Akamai](https://vercel.com/kb/guide/vercel-vs-akamai): A detailed guide to Vercel vs Akamai: compute models, AI infrastructure, framework support, media streaming, CDN capabilities, and when to choose each platform for your project.
+- [Vercel vs Fastly](https://vercel.com/kb/guide/vercel-vs-fastly): A detailed guide to Vercel vs Fastly: full-stack application platform vs edge infrastructure layer, covering framework support, CDN caching, edge compute, integrated security, AI infrastructure, and when to choose each platform.
+- [Vercel vs Netlify](https://vercel.com/kb/guide/vercel-vs-netlify): A detailed guide to Vercel vs Netlify: runtimes, compute architecture, AI infrastructure, security, and when to choose each platform for your project.
+- [Vercel vs Northflank](https://vercel.com/kb/guide/vercel-vs-northflank): A detailed guide to Vercel vs Northflank: Fluid compute, CDN and caching, security defaults, AI infrastructure, GPU compute, BYOC, and when to choose each platform for your project.
+- [Vercel vs Railway](https://vercel.com/kb/guide/vercel-vs-railway): A detailed guide to Vercel vs Railway: serverless vs always-on containers, framework-defined infrastructure, AI infrastructure, global CDN, security, and when to choose each platform for your project.
+- [Vercel vs Render](https://vercel.com/kb/guide/vercel-vs-render): A detailed guide to Vercel vs Render: compute models, AI infrastructure, Docker support, background workers, and when to choose each platform for your project.
+- [Vercel WAF vs Cloudflare WAF](https://vercel.com/kb/guide/vercel-waf-vs-cloudflare-waf): A detailed guide to Vercel WAF vs Cloudflare WAF: framework-aware rules, sub-300ms propagation, BotID bot detection, OWASP paranoia levels, leaked credential lookup, and when to choose each product for your web application.
+- [What are the best practices for hosting videos on Vercel?](https://vercel.com/kb/guide/best-practices-for-hosting-videos-on-vercel-nextjs-mp4-gif): Learn the ideal solutions for using video files like .mp4 and .gif on Vercel to prevent excess bandwidth consumption.
+- [What can I do about Vercel Functions timing out?](https://vercel.com/kb/guide/what-can-i-do-about-vercel-serverless-functions-timing-out): Learn about how you can fix Vercel Functions timing out.
+- [What can I do when I run into build output limits with Next.js on Vercel?](https://vercel.com/kb/guide/what-can-i-do-when-i-run-into-build-output-limits-with-next-js-on-vercel): Learn how to work with build output limits for Next.js on Vercel.
+- [What is a Large Language Model (LLM)?](https://vercel.com/kb/guide/what-is-a-large-language-model): Learn what Large Language Models (LLMs) are, how they work, and how you can use them to generate UI, debug code, and integrate AI features into your web applications.
+- [What is an LLM Tool?](https://vercel.com/kb/guide/what-is-an-llm-tool): Learn what tools are, how tool calling works, and how you can use them to build agents.
+- [What is Retrieval Augmented Generation (RAG)](https://vercel.com/kb/guide/what-is-rag): Learn how RAG enhances AI applications by providing Large Language Models (LLMs) with relevant context, enabling accurate responses to queries about proprietary data, recent information, and domain-specific knowledge.
+- [What is the best way to get support from Vercel?](https://vercel.com/kb/guide/how-to-get-vercel-support): Information on how to get help from Vercel Support through the available channels.
+- [What is Vercel's Green Energy Policy?](https://vercel.com/kb/guide/what-is-vercel-green-energy-policy): Information about Vercel's Green Energy Policy.
+- [What is Vercel's policy regarding load testing deployments?](https://vercel.com/kb/guide/what-s-vercel-s-policy-regarding-load-testing-deployments): Learn about Vercel's policies regarding load tests.
+- [What should I do if I receive a 503 error on Vercel?](https://vercel.com/kb/guide/what-should-i-do-if-i-receive-a-503-error-on-vercel): Learn about when Serverless Functions return a 503 status code and what can be done about them.
+- [When is the SSL Certificate on my Vercel Domain renewed?](https://vercel.com/kb/guide/renewal-of-ssl-certificates-with-a-vercel-domain): Information about the when renewal of a Vercel Domain's SSL certificate will be processed.
+- [Where can I get copies of my Vercel Invoices?](https://vercel.com/kb/guide/where-can-i-get-copies-of-my-vercel-invoices): Learn about how you can get access to your Vercel invoices.
+- [Where can I submit Vercel feature requests?](https://vercel.com/kb/guide/where-to-submit-feature-requests): Information on how to make feature requests for the Vercel platform.
+- [Why am I no longer receiving email after adding my domain to Vercel?](https://vercel.com/kb/guide/why-has-email-stopped-working): Information on why you may not be receiving email after verifying your domain with Vercel.
+- [Why am I unable to login or signup to the Vercel platform?](https://vercel.com/kb/guide/why-can-i-not-signup): Information on what to do if you are experiencing issues logging in or signing up to the Vercel platform.
+- [Why are my branch specific variables and domains not linked to my CLI deployments?](https://vercel.com/kb/guide/branch-variables-and-domains-not-linked-to-cli-deployments): How to link CLI deployments to the correct branch for use with custom environments and branch specific domains and environment variables
+- [Why are my Build Logs loading infinitely and not showing up?](https://vercel.com/kb/guide/why-are-my-build-logs-loading-infinitely-and-not-showing-up): How to mitigate the issue when build logs aren't showing up?
+- [Why are my Vercel builds queued?](https://vercel.com/kb/guide/why-are-my-vercel-builds-queued): Learn about why your Vercel builds may be getting queued and how to resolve this.
+- [Why aren't commits triggering deployments on Vercel?](https://vercel.com/kb/guide/why-aren-t-commits-triggering-deployments-on-vercel): Learn about why commits that you've pushed aren't triggering new Vercel Deployments. 
+- [Why do my Vercel deployments have multiple domains?](https://vercel.com/kb/guide/why-do-my-vercel-deployments-have-multiple-domains): Learn about why Vercel auto generates URLs for your deployments.
+- [Why does my Serverless Function work locally but not when deployed?](https://vercel.com/kb/guide/why-does-my-serverless-function-work-locally-but-not-when-deployed): Learn how to troubleshoot your Serverless Functions. 
+- [Why does npm run start not work on Vercel?](https://vercel.com/kb/guide/npm-run-start-not-working): Information on why commands that start servers may not work with Vercel.
+- [Why has my account or deployment been paused?](https://vercel.com/kb/guide/why-is-my-account-deployment-blocked): Information on why a Vercel account or deployment may have been paused.
+- [Why is my deployed project showing a 404 error?](https://vercel.com/kb/guide/why-is-my-deployed-project-giving-404): Learn the possible reasons a successful deployment gives a 404 error
+- [Why is my domain not automatically generating an SSL/TLS certificate?](https://vercel.com/kb/guide/domain-not-generating-ssl-certificate): Information on why a domain may not be automatically generating an SSL/TLS certificate.
+- [Why is my Vercel Deployment URL being shortened?](https://vercel.com/kb/guide/why-is-my-vercel-deployment-url-being-shortened): Information on why a Vercel Deployment URL may be shortened.
+- [Why is my Vercel domain not verified?](https://vercel.com/kb/guide/why-is-my-vercel-domain-unverified): Information on why a Vercel domain may not be verified and how to verify it.
+- [Why is running another CDN on top of Vercel not recommended?](https://vercel.com/kb/guide/why-running-another-cdn-on-top-of-vercel-is-not-recommended): Information about possible strategies when using a CDN on top of Vercel.
+- [Why is Vercel CLI asking me to log in? ](https://vercel.com/kb/guide/why-is-vercel-cli-asking-me-to-log-in): Information on why you may be getting prompted to log in to Vercel CLI.
+- [Why must we use the Domain Nameservers method for Wildcard Domains on Vercel?](https://vercel.com/kb/guide/why-use-domain-nameservers-method-wildcard-domains): Learn why the domain Nameservers method is needed to set up a wildcard domain as custom domain.


### PR DESCRIPTION
## Summary
Add comprehensive Vercel documentation support with smart markdown fetching and HTML fallback.

## Features
- **Smart content fetching**: Tries `.md` URL first, automatically falls back to HTML on 404
- **Full documentation index**: Parses 1,742+ entries from Vercel's llms.txt
- **Easy installation**: Makefile commands for both production and development
- **Comprehensive tests**: 11 new tests with real Vercel dataset

## Implementation Details

### Vercel Docr (`src/docr_mcp/docrs/vercel.py`)
- Implements BaseDocr interface for consistency
- **Smart markdown fetching**: Appends `.md` to URLs to get clean markdown
- **HTML fallback**: If 404, automatically falls back to original HTML URL
- URL validation (HTTPS-only, domain whitelist)
- Proper error handling and logging

### Makefile Commands
```bash
# Production (from PyPI)
make add-vercel

# Development (local code)
make add-vercel-local
```

### Configuration (`src/docr_mcp/config/vercel.yml`)
- Vercel-specific tool descriptions for LLM context
- Covers deployment, frameworks, functions, CI/CD, and more

## Test Coverage
- ✅ **11 new tests** covering all functionality
- ✅ **Full dataset**: Real Vercel llms.txt (2,016 lines → 1,742 entries)
- ✅ **All 42 tests pass** (31 existing + 11 new)

### Tests include:
- Index parsing with full dataset
- Section hierarchy tracking
- URL validation (HTTPS, domain whitelist)
- Markdown URL conversion
- HTML fallback on 404
- Search functionality
- Error handling

## Usage

### For End Users
```bash
# Install from PyPI
make add-vercel

# Restart Claude Code
# Then ask: "Search Vercel docs for Next.js deployment"
```

### For Contributors
```bash
# Use local development version
make add-vercel-local

# Run tests
uv run pytest tests/docrs/vercel/ -v
```

## Example Searches
Once installed, you can ask:
- "Search Vercel docs for Next.js deployment"
- "How do I deploy to Vercel?"
- "What frameworks does Vercel support?"

## Technical Highlights

### Smart Markdown Fetching
```python
# Try markdown first
markdown_url = f"{url}.md"
try:
    response = client.get(markdown_url)
    content_format = "markdown"
except HTTPStatusError as e:
    if e.response.status_code == 404:
        # Fallback to HTML
        response = client.get(url)
        content_format = "html"
```

### Benefits:
- Clean markdown content (no HTML parsing needed)
- Graceful degradation to HTML if needed
- Proper error propagation for non-404 errors

## Files Changed
```
Makefile                       +35 lines  (installation commands)
README.md                      +12 lines  (Vercel documentation)
src/docr_mcp/config/vercel.yml +34 lines  (configuration)
src/docr_mcp/docrs/__init__.py +7 lines   (registration)
src/docr_mcp/docrs/vercel.py   +281 lines (implementation)
tests/docrs/vercel/            +324 lines (tests)
tests/fixtures/vercel/         +2016 lines (fixture data)
```

## Checklist
- [x] Implementation follows BaseDocr interface
- [x] URL validation and security checks
- [x] Comprehensive test coverage (11 tests)
- [x] All tests passing (42/42)
- [x] Documentation updated (README, config)
- [x] Makefile commands for easy installation
- [x] Error handling with fallback mechanism
- [x] Full dataset tested (1,742 entries)

## Related
- Closes any issues related to Vercel documentation support
- Builds on existing llms.txt parsing pattern from Strands

🤖 Generated with [Claude Code](https://claude.com/claude-code)