### PR TITLE
Add Twilio documentation support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help add-strands add-vercel add-strands-local add-vercel-local
+.PHONY: help add-strands add-vercel add-twilio add-strands-local add-vercel-local add-twilio-local
 
 PROJECT_DIR := $(shell pwd)
 
@@ -8,10 +8,12 @@ help:
 	@echo "Production (from PyPI):"
 	@echo "  make add-strands           - Add Strands Agents documentation"
 	@echo "  make add-vercel            - Add Vercel documentation"
+	@echo "  make add-twilio            - Add Twilio documentation"
 	@echo ""
 	@echo "Development (local code):"
 	@echo "  make add-strands-local     - Add Strands with local development code"
 	@echo "  make add-vercel-local      - Add Vercel with local development code"
+	@echo "  make add-twilio-local      - Add Twilio with local development code"
 
 add-strands:
 	@echo "Adding Strands Agents MCP server to Claude Code..."
@@ -31,5 +33,15 @@ add-strands-local:
 add-vercel-local:
 	@echo "Adding Vercel MCP server (local development)..."
 	@claude mcp add docr-mcp-vercel-local -- uv --directory $(PROJECT_DIR) run docr-mcp --library vercel
+	@echo "✅ Done! Restart Claude Code to activate."
+
+add-twilio:
+	@echo "Adding Twilio MCP server to Claude Code..."
+	@claude mcp add docr-mcp-twilio -- uvx docr-mcp --library twilio
+	@echo "✅ Done! Restart Claude Code to activate."
+
+add-twilio-local:
+	@echo "Adding Twilio MCP server (local development)..."
+	@claude mcp add docr-mcp-twilio-local -- uv --directory $(PROJECT_DIR) run docr-mcp --library twilio
 	@echo "✅ Done! Restart Claude Code to activate."
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Give LLMs the ability to search and read documentation from any source - public 
 | -------------------------------------------- | --------- | -------------------------------------------------------------------- |
 | [Strands Agents](https://strandsagents.com) | ✅ Active | `claude mcp add docr-mcp-strands -- uvx docr-mcp --library strands` |
 | [Vercel](https://vercel.com)                 | ✅ Active | `claude mcp add docr-mcp-vercel -- uvx docr-mcp --library vercel`   |
+| [Twilio](https://twilio.com)                 | ✅ Active | `claude mcp add docr-mcp-twilio -- uvx docr-mcp --library twilio`   |
 
 **Want to add a library?** See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
@@ -40,6 +41,9 @@ claude mcp add docr-mcp-strands -- uvx docr-mcp --library strands
 
 # For Vercel documentation
 claude mcp add docr-mcp-vercel -- uvx docr-mcp --library vercel
+
+# For Twilio documentation
+claude mcp add docr-mcp-twilio -- uvx docr-mcp --library twilio
 ```
 
 **For contributors:** See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup.

--- a/src/docr_mcp/config/twilio.yml
+++ b/src/docr_mcp/config/twilio.yml
@@ -1,0 +1,38 @@
+name: "Twilio"
+description: "Twilio is a cloud communications platform for building SMS, Voice, Video, and Messaging applications"
+parser: "twilio"
+
+index:
+  source: "https://www.twilio.com/docs/llms.txt"
+
+tools:
+  search_docs:
+    description: |
+      Search Twilio platform documentation.
+
+      Twilio is a cloud communications platform. Use this tool when the user asks about:
+      - SMS messaging (sending/receiving text messages)
+      - Voice calls (making/receiving phone calls)
+      - Video communications
+      - WhatsApp Business API
+      - Twilio Flex (contact center platform)
+      - Twilio Verify (2FA and phone verification)
+      - Programmable Messaging
+      - Programmable Voice
+      - Twilio Functions (serverless)
+      - TwiML (Twilio Markup Language)
+      - Twilio APIs and SDKs
+      - Phone numbers and SIP trunking
+      - Conversations API
+      - SendGrid Email API
+      - Twilio CLI and tools
+
+      Returns a list of relevant documentation pages with titles and URLs ranked by relevance.
+
+  fetch_doc:
+    description: |
+      Fetch full content from a Twilio documentation page.
+
+      Retrieves the complete documentation content and returns it formatted
+      for easy reading. Use this after search_docs to get detailed information
+      about a specific topic.

--- a/src/docr_mcp/docrs/__init__.py
+++ b/src/docr_mcp/docrs/__init__.py
@@ -29,5 +29,10 @@ def load_docr(config: LibraryConfig) -> BaseDocr:
 
         return VercelDocr()
 
+    elif docr_name == "twilio":
+        from .twilio import TwilioDocr
+
+        return TwilioDocr()
+
     else:
-        raise ValueError(f"Unknown docr: {docr_name}. Available docrs: strands, vercel")
+        raise ValueError(f"Unknown docr: {docr_name}. Available docrs: strands, vercel, twilio")

--- a/src/docr_mcp/docrs/twilio.py
+++ b/src/docr_mcp/docrs/twilio.py
@@ -1,0 +1,285 @@
+"""Docr for Twilio documentation."""
+
+import logging
+import re
+from typing import List
+from urllib.parse import urlparse
+
+import httpx
+
+from docr_mcp.models import Document, IndexConfig, IndexEntry
+
+from .base import BaseDocr
+
+logger = logging.getLogger(__name__)
+
+
+class TwilioDocr(BaseDocr):
+    """Docr for Twilio documentation (twilio.com)."""
+
+    ALLOWED_DOMAINS = {"twilio.com", "www.twilio.com"}
+
+    def __init__(self):
+        self.client = None
+        self._timeout = 30.0
+
+    def __enter__(self):
+        """Context manager entry."""
+        self.client = httpx.Client(
+            timeout=self._timeout, follow_redirects=True, headers={"User-Agent": "docr-mcp/0.1.0"}
+        )
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit - cleanup resources."""
+        if self.client:
+            self.client.close()
+        return False
+
+    def _ensure_client(self):
+        """Ensure HTTP client is initialized."""
+        if not self.client:
+            self.client = httpx.Client(
+                timeout=self._timeout, follow_redirects=True, headers={"User-Agent": "docr-mcp/0.1.0"}
+            )
+
+    def fetch_index_entries(self, index_config: IndexConfig) -> List[IndexEntry]:
+        """Fetch and parse documentation index entries.
+
+        Args:
+            index_config: IndexConfig object with source field pointing to llms.txt URL
+
+        Returns:
+            List of IndexEntry objects with title, URL, section, and tags
+
+        Raises:
+            ValueError: If source URL is invalid or entries list is empty
+            httpx.HTTPError: If HTTP request fails
+        """
+        url = index_config.source
+        self._timeout = index_config.timeout
+
+        # Validate URL
+        self._validate_url(url)
+
+        # Initialize client if not already done
+        self._ensure_client()
+
+        logger.debug(f"Fetching llms.txt from {url}")
+
+        try:
+            # Fetch content
+            response = self.client.get(url)
+            response.raise_for_status()
+            content = response.text
+        except httpx.HTTPError as e:
+            logger.error(f"HTTP error fetching {url}: {e}")
+            raise ValueError(f"Failed to fetch index from {url}: {type(e).__name__}") from e
+
+        # Parse the content
+        entries = self._parse_llms_txt(content)
+
+        # Validate non-empty
+        if not entries:
+            raise ValueError(f"No entries found in index at {url}")
+
+        logger.info(f"Parsed {len(entries)} entries from {url}")
+        return entries
+
+    def _parse_llms_txt(self, content: str) -> List[IndexEntry]:
+        """Parse llms.txt content into IndexEntry objects.
+
+        Args:
+            content: Raw llms.txt content
+
+        Returns:
+            List of parsed IndexEntry objects
+        """
+        docs = []
+        lines = content.split("\n")
+
+        # Track current section hierarchy
+        current_section: List[str] = []
+        section_stack: List[tuple[int, str]] = []  # (indent_level, section_name)
+
+        for line in lines:
+            # Skip empty lines and top-level title (single #)
+            if not line.strip() or line.strip().startswith("# "):
+                continue
+
+            # Detect section headers (## Section Name)
+            section_match = re.match(r"^##\s+(.+)$", line)
+            if section_match:
+                section_name = section_match.group(1)
+                # Start fresh section hierarchy from this top-level section
+                current_section = [section_name]
+                section_stack = [(0, section_name)]
+                continue
+
+            # Calculate indentation level
+            indent_match = re.match(r"^(\s*)(.+)$", line)
+            if not indent_match:
+                continue
+
+            indent = len(indent_match.group(1))
+            line_content = indent_match.group(2).strip()
+
+            # Parse markdown link: * [title](url) or - [title](url)
+            link_match = re.match(r"[*-]\s+\[(.+?)\]\((.+?)\)", line_content)
+
+            if link_match:
+                title = link_match.group(1)
+                doc_url = link_match.group(2)
+
+                # Twilio uses relative URLs - prepend base URL if needed
+                if doc_url.startswith("/"):
+                    doc_url = f"https://www.twilio.com{doc_url}"
+
+                # Build full section path
+                section_path = " > ".join(current_section)
+
+                # Extract tags from title and section
+                tags = self._extract_tags(title, current_section)
+
+                docs.append(
+                    IndexEntry(
+                        title=title,
+                        url=doc_url,
+                        section=section_path,
+                        tags=tags,
+                    )
+                )
+
+            else:
+                # This is a section header without a link
+                # Update the section hierarchy
+                section_name = line_content.lstrip("*- ").strip()
+
+                # Adjust section stack based on indentation
+                # Pop sections at deeper or equal indentation levels
+                while section_stack and section_stack[-1][0] > indent:
+                    section_stack.pop()
+
+                section_stack.append((indent, section_name))
+                current_section = [name for _, name in section_stack]
+
+        logger.debug(f"Parsed {len(docs)} documents from index")
+        return docs
+
+    def _extract_tags(self, title: str, section: List[str]) -> List[str]:
+        """Extract searchable tags from title and section.
+
+        Args:
+            title: Document title
+            section: Section hierarchy
+
+        Returns:
+            List of tags for search
+        """
+        tags = []
+
+        # Add section components as tags
+        tags.extend([s.lower() for s in section if s])
+
+        # Split title by common separators and add as tags
+        title_parts = re.split(r"[-_\s]+", title.lower())
+        tags.extend([p for p in title_parts if len(p) > 2])
+
+        # Remove duplicates while preserving order
+        seen = set()
+        unique_tags = []
+        for tag in tags:
+            if tag not in seen:
+                seen.add(tag)
+                unique_tags.append(tag)
+
+        return unique_tags
+
+    def _validate_url(self, url: str) -> None:
+        """Validate URL is safe to fetch.
+
+        Args:
+            url: URL to validate
+
+        Raises:
+            ValueError: If URL is invalid or not allowed
+        """
+        try:
+            parsed = urlparse(url)
+        except Exception as e:
+            raise ValueError(f"Invalid URL format: {url}") from e
+
+        # Must be HTTPS
+        if parsed.scheme != "https":
+            raise ValueError(f"Only HTTPS URLs are allowed, got: {parsed.scheme}")
+
+        # Must be in allowed domains
+        if parsed.netloc not in self.ALLOWED_DOMAINS:
+            raise ValueError(f"Domain not allowed: {parsed.netloc}. Allowed: {self.ALLOWED_DOMAINS}")
+
+    def fetch_content(self, url: str) -> Document:
+        """Fetch and parse a Twilio documentation page.
+
+        Twilio URLs in llms.txt already include .md extension. This method
+        fetches the markdown version directly, and falls back to HTML (by
+        removing .md) if the markdown version is not available (404).
+
+        Args:
+            url: Documentation page URL (typically ends with .md)
+
+        Returns:
+            Document with markdown content (or HTML if markdown unavailable)
+
+        Raises:
+            ValueError: If URL is invalid
+            httpx.HTTPError: If HTTP request fails (non-404 errors)
+        """
+        # Validate URL
+        self._validate_url(url)
+
+        # Initialize client if not already done
+        self._ensure_client()
+
+        logger.debug(f"Fetching content from {url}")
+
+        try:
+            response = self.client.get(url)
+            response.raise_for_status()
+            content = response.text
+            content_format = "markdown" if url.endswith(".md") else "html"
+        except httpx.HTTPStatusError as e:
+            # Fallback to HTML if markdown version doesn't exist
+            if e.response.status_code == 404 and url.endswith(".md"):
+                html_url = url[:-3]  # Remove .md extension
+                logger.warning(f"Markdown not found at {url}, falling back to HTML")
+                try:
+                    response = self.client.get(html_url)
+                    response.raise_for_status()
+                    content = response.text
+                    content_format = "html"
+                    logger.info(f"Successfully fetched HTML from {html_url}")
+                except httpx.HTTPError as html_error:
+                    logger.error(f"Failed to fetch HTML from {html_url}: {html_error}")
+                    raise
+            else:
+                logger.error(f"HTTP error fetching {url}: {e}")
+                raise
+        except httpx.HTTPError as e:
+            logger.error(f"HTTP error fetching {url}: {e}")
+            raise
+
+        # Extract title from first # heading if available
+        title = ""
+        first_line = content.split("\n")[0] if content else ""
+        if first_line.startswith("# "):
+            title = first_line[2:].strip()
+
+        return Document(
+            url=url, content=content, metadata={"title": title, "source": "twilio", "format": content_format}
+        )
+
+    def close(self):
+        """Explicitly close HTTP client."""
+        if self.client:
+            self.client.close()
+            self.client = None

--- a/tests/docrs/twilio/__init__.py
+++ b/tests/docrs/twilio/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Twilio docr."""

--- a/tests/docrs/twilio/test_twilio_docr.py
+++ b/tests/docrs/twilio/test_twilio_docr.py
@@ -1,0 +1,342 @@
+"""Tests for Twilio docr."""
+
+from pathlib import Path
+
+import pytest
+
+from docr_mcp.core.search import SearchIndex
+from docr_mcp.docrs.twilio import TwilioDocr
+from docr_mcp.models import IndexConfig
+
+# Path to fixtures
+FIXTURES_DIR = Path(__file__).parent.parent.parent / "fixtures" / "twilio"
+
+
+def load_fixture(filename: str) -> str:
+    """Load a test fixture file.
+
+    Args:
+        filename: Name of the fixture file
+
+    Returns:
+        File contents as string
+    """
+    fixture_path = FIXTURES_DIR / filename
+    with open(fixture_path, "r") as f:
+        return f.read()
+
+
+class TestTwilioDocr:
+    """Test cases for Twilio docr."""
+
+    def test_parse_index_structure(self):
+        """Test that docr correctly extracts documents with sections."""
+        docr = TwilioDocr()
+
+        # Mock the HTTP client with real fixture data
+        class MockResponse:
+            def __init__(self):
+                self.text = load_fixture("llms.txt")
+
+            def raise_for_status(self):
+                pass
+
+        class MockClient:
+            def get(self, url):
+                return MockResponse()
+
+            def close(self):
+                pass
+
+        docr.client = MockClient()
+
+        # Parse index
+        config = IndexConfig(source="https://www.twilio.com/docs/llms.txt")
+        docs = docr.fetch_index_entries(config)
+
+        # Verify we got documents (Twilio has 1100+ entries)
+        assert len(docs) > 1100, f"Should parse 1100+ documents, got {len(docs)}"
+
+        # Check first few documents have expected structure
+        for doc in docs[:5]:
+            assert doc.title
+            assert doc.url
+            assert hasattr(doc, "section")
+            assert hasattr(doc, "tags")
+
+        # Verify URLs are absolute (not relative)
+        for doc in docs[:10]:
+            assert doc.url.startswith("https://"), f"Expected absolute URL, got {doc.url}"
+
+    def test_relative_url_conversion(self):
+        """Test that relative URLs are converted to absolute URLs."""
+        docr = TwilioDocr()
+
+        class MockResponse:
+            def __init__(self):
+                self.text = load_fixture("llms.txt")
+
+            def raise_for_status(self):
+                pass
+
+        class MockClient:
+            def get(self, url):
+                return MockResponse()
+
+            def close(self):
+                pass
+
+        docr.client = MockClient()
+
+        config = IndexConfig(source="https://www.twilio.com/docs/llms.txt")
+        docs = docr.fetch_index_entries(config)
+
+        # All URLs should be absolute
+        for doc in docs:
+            assert doc.url.startswith("https://www.twilio.com/"), f"Expected absolute URL, got {doc.url}"
+
+    def test_section_hierarchy(self):
+        """Test that section hierarchy is correctly tracked."""
+        docr = TwilioDocr()
+
+        class MockResponse:
+            def __init__(self):
+                self.text = load_fixture("llms.txt")
+
+            def raise_for_status(self):
+                pass
+
+        class MockClient:
+            def get(self, url):
+                return MockResponse()
+
+            def close(self):
+                pass
+
+        docr.client = MockClient()
+
+        config = IndexConfig(source="https://www.twilio.com/docs/llms.txt")
+        docs = docr.fetch_index_entries(config)
+
+        # Check if sections exist
+        sections = {d.section for d in docs}
+        assert len(sections) > 0
+
+    def test_tags_extraction(self):
+        """Test that tags are correctly extracted from titles and sections."""
+        docr = TwilioDocr()
+
+        class MockResponse:
+            def __init__(self):
+                self.text = load_fixture("llms.txt")
+
+            def raise_for_status(self):
+                pass
+
+        class MockClient:
+            def get(self, url):
+                return MockResponse()
+
+            def close(self):
+                pass
+
+        docr.client = MockClient()
+
+        config = IndexConfig(source="https://www.twilio.com/docs/llms.txt")
+        docs = docr.fetch_index_entries(config)
+
+        # Check that docs have tags
+        docs_with_tags = [d for d in docs if len(d.tags) > 0]
+        assert len(docs_with_tags) > 0
+
+    def test_url_validation(self):
+        """Test URL validation for Twilio docs."""
+        docr = TwilioDocr()
+
+        # Valid Twilio URL
+        docr._validate_url("https://www.twilio.com/docs/sms")
+
+        # Invalid scheme
+        with pytest.raises(ValueError, match="HTTPS"):
+            docr._validate_url("http://www.twilio.com/docs")
+
+        # Invalid domain
+        with pytest.raises(ValueError, match="not allowed"):
+            docr._validate_url("https://evil.com/docs")
+
+    def test_markdown_url_handling(self):
+        """Test that markdown URLs are handled correctly."""
+        docr = TwilioDocr()
+
+        class MockResponse:
+            def __init__(self, url):
+                self.url = url
+                self.text = "# Test Content\n\nTest markdown content"
+
+            def raise_for_status(self):
+                pass
+
+        class MockClient:
+            def get(self, url):
+                return MockResponse(url)
+
+            def close(self):
+                pass
+
+        docr.client = MockClient()
+
+        # Fetch content with .md extension (typical Twilio URL)
+        doc = docr.fetch_content("https://www.twilio.com/docs/test.md")
+
+        assert doc.url == "https://www.twilio.com/docs/test.md"
+        assert doc.metadata["format"] == "markdown"
+        assert "Test markdown content" in doc.content
+
+    def test_markdown_fallback_to_html(self):
+        """Test fallback to HTML when markdown is not available."""
+        docr = TwilioDocr()
+
+        class MockResponse:
+            def __init__(self, url, status_code=200):
+                self.url = url
+                self.status_code = status_code
+                if url.endswith(".md"):
+                    self.text = ""
+                else:
+                    self.text = "<!DOCTYPE html><html><body><h1>Test HTML Content</h1></body></html>"
+
+            def raise_for_status(self):
+                if self.status_code == 404:
+                    import httpx
+
+                    raise httpx.HTTPStatusError("Not Found", request=None, response=self)
+
+        call_count = {"count": 0}
+
+        class MockClient:
+            def get(self, url):
+                call_count["count"] += 1
+                if url.endswith(".md") and call_count["count"] == 1:
+                    return MockResponse(url, status_code=404)
+                else:
+                    return MockResponse(url, status_code=200)
+
+            def close(self):
+                pass
+
+        docr.client = MockClient()
+
+        # Fetch content - should try .md, get 404, then fallback to HTML
+        doc = docr.fetch_content("https://www.twilio.com/docs/test.md")
+
+        assert doc.url == "https://www.twilio.com/docs/test.md"
+        assert doc.metadata["format"] == "html"
+        assert "Test HTML Content" in doc.content
+        assert call_count["count"] == 2  # Should have tried both .md and HTML
+
+    def test_full_real_index(self):
+        """Test parsing the full real Twilio llms.txt file."""
+        docr = TwilioDocr()
+
+        class MockResponse:
+            def __init__(self):
+                self.text = load_fixture("llms.txt")
+
+            def raise_for_status(self):
+                pass
+
+        class MockClient:
+            def get(self, url):
+                return MockResponse()
+
+            def close(self):
+                pass
+
+        docr.client = MockClient()
+
+        config = IndexConfig(source="https://www.twilio.com/docs/llms.txt")
+        docs = docr.fetch_index_entries(config)
+
+        # Should have all docs from real file (1100+ entries)
+        assert len(docs) > 1100, f"Expected 1100+ docs, got {len(docs)}"
+
+        # Verify some known sections exist
+        sections = {d.section for d in docs}
+        section_names = " ".join(sections).lower()
+        # At least some common Twilio product names should appear
+        assert any(keyword in section_names for keyword in ["authy", "flex", "messaging", "voice", "sms"])
+
+        # Verify known documentation pages exist
+        titles = {d.title for d in docs}
+        # Should have SMS or Messaging related titles
+        assert any("sms" in t.lower() or "messaging" in t.lower() for t in titles)
+
+
+class TestSearchWithTwilio:
+    """Test search functionality with Twilio documents."""
+
+    def get_sample_docs(self):
+        """Helper to get parsed sample documents."""
+        docr = TwilioDocr()
+
+        class MockResponse:
+            def __init__(self):
+                self.text = load_fixture("llms.txt")
+
+            def raise_for_status(self):
+                pass
+
+        class MockClient:
+            def get(self, url):
+                return MockResponse()
+
+            def close(self):
+                pass
+
+        docr.client = MockClient()
+
+        config = IndexConfig(source="https://www.twilio.com/docs/llms.txt")
+        return docr.fetch_index_entries(config)
+
+    def test_search_by_title(self):
+        """Test searching by title."""
+        docs = self.get_sample_docs()
+        search_index = SearchIndex(docs)
+
+        # Search for a common Twilio term
+        results = search_index.search("SMS", top_k=5)
+
+        assert len(results) > 0
+        # Should find SMS related docs
+        assert any("sms" in r["title"].lower() for r in results)
+
+    def test_search_by_product(self):
+        """Test searching for Twilio product names."""
+        docs = self.get_sample_docs()
+        search_index = SearchIndex(docs)
+
+        results = search_index.search("messaging", top_k=10)
+
+        assert len(results) > 0
+
+    def test_search_returns_limited_results(self):
+        """Test that search respects top_k limit."""
+        docs = self.get_sample_docs()
+        search_index = SearchIndex(docs)
+
+        results = search_index.search("twilio", top_k=3)
+
+        assert len(results) <= 3
+
+    def test_search_no_match(self):
+        """Test searching for something that doesn't exist."""
+        docs = self.get_sample_docs()
+        search_index = SearchIndex(docs)
+
+        results = search_index.search("nonexistentxyz123", top_k=5)
+
+        assert len(results) == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/fixtures/twilio/__init__.py
+++ b/tests/fixtures/twilio/__init__.py
@@ -1,0 +1,1 @@
+"""Twilio test fixtures."""

--- a/tests/fixtures/twilio/llms.txt
+++ b/tests/fixtures/twilio/llms.txt
@@ -1,0 +1,1536 @@
+# Twilio Documentation
+
+> Reference documentation for all Twilio products. Code snippets, tutorials, and sample apps for common use cases and communications solutions.
+
+## Authy: 2FA and Passwordless Login
+
+* [Authy: 2FA and Passwordless Login](/docs/authy.md): Easily add two-factor authentication and passwordless logins via API or with our SDKs. Protect logins and step-up transactions with SMS, Voice, PushAuthentications, and TOTP through a simple API. Reduce fraud and increase user trust - follow these guides, reference docs, and tutorials.
+
+## Conversation Intelligence (classic)
+
+* [Pre-built Language Operators](/docs/conversation-intelligence-classic/pre-built-operators.md): Explore Pre-built Language Operators for Twilio Conversation Intelligence (classic), designed to classify, summarize, and extract key insights from conversation transcripts.
+* [Conversation Intelligence (classic) onboarding guide](/docs/conversation-intelligence-classic/onboarding.md): Learn the basic concepts and how to configure Conversation Intelligence (classic) for AI insights from conversations. Set up via API or Twilio Console for seamless integration.
+* [Language Operators](/docs/conversation-intelligence-classic/language-operators.md): Discover AI-powered Language Operators to analyze conversations and gain valuable insights. Learn about Pre-built and Custom Operators.
+* [Conversation Intelligence (classic)](/docs/conversation-intelligence-classic.md): Conversation Intelligence (classic) turns the content of your voice calls and messages into structured information to help you enrich customer profiles, optimize lead generation campaigns, address compliance issues, and assess agent performance across every conversation.
+* [Generative Custom Operators](/docs/conversation-intelligence-classic/generative-custom-operators.md): LLM-backed Language Operators provide flexible and powerful conversational analysis supporting a wide range of sophisticated natural language understanding use cases.
+* [Customize Your Conversation Intelligence (classic) Configuration](/docs/conversation-intelligence-classic/customize.md): Learn more advanced concepts and implementations for Conversation Intelligence (classic), including using transcript sources outside of Twilio.
+* [Conversation Relay integration for AI agent observability](/docs/conversation-intelligence-classic/conversation-relay-integration.md): Built-in AI agent observability with AI-powered language analysis
+* [AI Nutrition Fact Labels](/docs/conversation-intelligence-classic/ai-nutrition-fact-labels.md): View AI Nutrition Fact Labels for the Twilio Conversation Intelligence (classic) Base Models.
+* [Conversation Intelligence (classic) - Transcript Sentence Subresource](/docs/conversation-intelligence-classic/api/transcript-sentence-subresource.md): Full API reference for the Transcript Sentence subresource in the Twilio Conversation Intelligence (classic) API. Sample code shows how to list the Sentences of a Transcript.
+* [Conversation Intelligence (classic) - Transcript Resource](/docs/conversation-intelligence-classic/api/transcript-resource.md): API reference for the Conversation Intelligence (classic) API Transcript resource, which represents a voice conversation that has automatically been converted to text through Twilio's transcription engine.
+* [Conversation Intelligence (classic) - Service Resource](/docs/conversation-intelligence-classic/api/service-resource.md): Learn how to create, fetch, list, update, and delete a Service with Twilio's Conversation Intelligence (classic) API. Access detailed API reference and code samples.
+* [Conversation Intelligence (classic) API Overview](/docs/conversation-intelligence-classic/api.md): Learn how to use the Twilio Conversation Intelligence (classic) API to analyze and extract actionable insights from conversations using AI and machine learning.
+
+## Elastic SIP Trunking
+
+* [Protect your account with Voice Dialing Geographic Permissions](/docs/sip-trunking/voice-dialing-geographic-permissions.md): Protect your account with Voice Dialing Geographic Permissions - prevent IRSF toll-fraud
+* [Test your Elastic SIP Trunk](/docs/sip-trunking/trunk-verification.md): Read how to test your SIP Trunk for termination, origination, and emergency calling, as well as how to diagnose common problems.
+* [Troubleshooting your Trunk](/docs/sip-trunking/troubleshooting.md): Troubleshoot your SIP Trunk, use the Twilio debugger, and explore common issues and possible solutions around SIP termination, origination, and audio issues.
+* [Elastic SIP Trunking — Solution Blueprints](/docs/sip-trunking/solution-blueprints.md): Solution blueprints for your Twilio Elastic SIP Trunk including a list of contact centers, unified communications, and session border controllers.
+* [SIP Header Manipulation](/docs/sip-trunking/sip-header-manipulation.md): Enables you to manipulate the SIP Header messages
+* [Twilio SIP Trunking Scale and Limits](/docs/sip-trunking/scale-and-limits.md): This guide outlines the SIP Trunking limits you should be aware of when building with Twilio for standard accounts and when working with trial accounts.
+* [IP Addresses for Elastic SIP Trunking Services](/docs/sip-trunking/ip-addresses.md): A complete list of Twilio's Gateway IP address ranges and ports, required for SIP signaling and RTP media traffic when using Elastic SIP Trunking.
+* [Elastic SIP Trunking](/docs/sip-trunking.md): Global pay-as-you-go connectivity for VoIP infrastructure with Twilio's Elastic SIP Trunking. Learn how to configure, troubleshoot, and connect your SBC or PBX SIP infrastructure to a Twilio Elastic SIP Trunk with our API reference documentation, tutorials, and usage guides.
+* [Extended Call Duration](/docs/sip-trunking/extended-call-duration.md): 24 hour calling that removes 4 hour call limit
+* [Emergency Calling for SIP Trunking](/docs/sip-trunking/emergency-calling.md): Enable and configure Twilio's Emergency Calling, enabling emergency call routing to Public Safety Answering Points using Elastic SIP Trunking.
+* [Calls per Second (CPS) — Trunking Termination](/docs/sip-trunking/cps-trunk-termination.md): Learn about trunk-level Calls Per Second (CPS), parent account CPS, and debugger alerts for CPS limits.
+* [Configure your Trunk using Twilio Interconnect](/docs/sip-trunking/configure-with-interconnect.md): Configure your SIP Trunk with Twilio Interconnect, allowing you to connect your SIP infrastructure using a private connection to an Elastic SIP Trunk.
+* [Elastic SIP Trunking Codecs](/docs/sip-trunking/codecs.md): Learn about supported codecs for Elastic SIP Trunking, including origination, termination, and codec priority.
+* [Call Transfer via SIP REFER](/docs/sip-trunking/call-transfer.md): Enable and configure Twilio's Emergency Calling, enabling 911 call routing to Public Safety Answering Points in the US and Canada using Elastic SIP Trunk.
+* [Elastic SIP Trunking Configuration Guides](/docs/sip-trunking/sample-configuration.md): Use these Configuration Guides to help you connect your SIP Infrastructure (IP-PBX, SBC, etc) to a Twilio Elastic SIP Trunk.
+* [Trunk Resource](/docs/sip-trunking/api/trunk-resource.md): Full API reference for the SIP Trunking Trunk resource in the Twilio API. Learn how to create, read (list), and delete SIP Trunks.
+* [PhoneNumber Resource](/docs/sip-trunking/api/phonenumber-resource.md): Full API reference for the SIP Trunking PhoneNumber resource in the Twilio API. Learn how to create, read (list), and delete PhoneNumbers for SIP Trunks.
+* [Elastic SIP Trunking REST API Reference](/docs/sip-trunking/api.md): Learn how to get started with Twilio Elastic SIP Trunking and view the REST API reference.
+* [Emergency Calling for SIP Trunking API](/docs/sip-trunking/api/emergency-calling.md): Twilio's Emergency Address registration enables emergency call routing to Public Safety Answering Points (PSAPs) in the US, Canada and the UK.
+
+## Event Streams
+
+* [Event Streams](/docs/events.md): Learn what you can do with Event Streams, an API that allows you to tap into a unified stream of every interaction sent or received on Twilio's network.
+
+## Flex
+
+* [Flex](/docs/flex.md): Find the documentation, sample code, and developer tools needed to build and tailor a contact center to your unique needs with Flex.
+* [How we release Flex](/docs/flex/how-we-release-flex.md): Explore Twilio Flex platform changes, release strategies, and feature deployment. Understand version release frequency and feature updates.
+* [Get Started with Flex Conversations](/docs/flex/conversations.md): Get started with Flex Conversations, which uses next-generation architecture for async channel capabilities in Flex.
+* [Checklist for setting up Twilio Flex](/docs/flex/building-checklist.md): Plan and set up Flex efficiently by following this checklist.
+* [Flex Webchat release notes](/docs/flex/release-notes/webchat-ui-release-notes.md): Explore the latest release notes for Flex Webchat, including updates to dependencies.
+* [Flex UI 2.x.x release notes](/docs/flex/release-notes/flex-ui-release-notes-for-v2xx.md): Find out what's been added, changed, and fixed in the latest version of Flex UI version 2.x.x, as well as past 2.x.x releases.
+* [Flex Plugins CLI release notes](/docs/flex/release-notes/flex-plugins-cli-release-notes.md): Find out what's been added, changed, and fixed in the latest version of the Flex Plugins CLI.
+* [Flex Mobile (public beta)](/docs/flex/flex-mobile.md): Flex Mobile is a pre-built app available for iOS and Android devices that brings the Flex experience to your phone or tablet.
+* [Twilio Flex Quickstart: Getting Started with Flex Plugin Development](/docs/flex/quickstart/getting-started-plugin.md): We enhance a Twilio Flex hosted contact center with a basic React plugin. See step-by-step process and code, and how to upload assets to Twilio.
+* [Warm transfer](/docs/flex/end-user-guide/warm-transfer.md): This guide for call center operators explains how warm transfer works using a Flex call center.
+* [User Guide to Troubleshooting the Flex UI](/docs/flex/end-user-guide/troubleshooting.md): Troubleshoot Flex UI errors using the Status Report for detailed logs, understand error types and where they appear, and learn about the Flex UI degraded mode.
+* [Advanced Team view filters](/docs/flex/end-user-guide/team-view-filters.md): Discover Team view filters, enabling more focused supervision in contact centers.&#x20;
+* [Service Level Preferences](/docs/flex/end-user-guide/service-level-preferences.md): Use Service Level Preferences to customize how metrics in the Real-Time Queues View are calculated.
+* [Pre-Release Features - End User Guide](/docs/flex/end-user-guide/pre-release-features.md): Explore Twilio's beta products available in the Pre-Release Features Page on Flex. Enable, disable, and test betafeatures.
+* [Use Chat and Messaging](/docs/flex/end-user-guide/messaging.md): Understand how to use chat and messaging in Flex UI 1.x.x as an agent and as a supervisor.
+* [Keyboard Shortcuts](/docs/flex/end-user-guide/keyboard-shortcuts.md): Flex UI 2.1 includes a keyboard shortcuts menu for the most common contact center agent operations.
+* [Initial Audio Device Check](/docs/flex/end-user-guide/initial-audio-device-check.md): Learn about the audio device health check that is automatically run on Flex startup.
+* [Use Flex on a mobile device (public beta)](/docs/flex/end-user-guide/flex-mobile.md): Flex Mobile lets agents send and receive calls and messages from a phone or tablet.
+* [Use the Flex Dialpad](/docs/flex/end-user-guide/dialpad-use.md): Use the native Flex Dialpad to make local and international outbound calls and perform warm or cold transfers to an agent or a queue.
+* [Debugger Integration with Flex](/docs/flex/end-user-guide/debugger.md): Learn how to use the debugger to troubleshoot exceptions and errors in the Twilio Flex UI and plugins.
+* [Chat Attachments](/docs/flex/end-user-guide/chat-attachments.md): Learn to send and receive chat attachments in Flex UI 1.x.x.
+* [Change your language (Public Beta)](/docs/flex/end-user-guide/change-display-language.md): Learn how to set which language you want to use for Flex.
+* [AI overview (Public Beta)](/docs/flex/ai.md): Twilio's AI capabilities combine the power of large language models (LLMs) with real-time customer and communications data to power Unified Profiles and Agent Copilot in Flex.
+* [Unified Profiles Container (Public Beta)](/docs/flex/developer/unified-profiles-container.md): This guide introduces the developer experience for Unified Profiles and the Unified Profiles Container.
+* [Getting Started with TaskRouter](/docs/flex/developer/routing.md): Leverage TaskRouter for attribute-based routing in Flex contact centers. Enhance agent actions and visibility with dynamic task data exposure.
+* [Flex developer documentation](/docs/flex/developer.md): Twilio Flex allows developers to customize the digital sales and service experience, providing full control over customer engagement.
+* [Agent Copilot: wrap-up notes webhook (public beta)](/docs/flex/developer/copilot-webhooks.md): This guide describes the developer experience for Agent Copilot.
+* [What is Twilio Flex?](/docs/flex/admin-guide/what-is-twilio-flex.md): Twilio Flex is a digital engagement center for Sales and Service that provides a single UI and native channels to manage omnichannel customer experiences.
+* [Manage Flex Mobile (public beta)](/docs/flex/admin-guide/flex-mobile.md): Flex Mobile is a pre-built mobile app you can add to your existing Flex instance with no additional development effort.
+* [Monitor agent activity](/docs/flex/end-user-guide/real-time-reporting/monitor-agent-activity.md): Learn how supervisors and administrators can monitor communications in real-time using Twilio Flex
+* [Workload Reporting](/docs/flex/end-user-guide/insights/workload-reporting.md): Use Flex Insights Workload Reporting to get granular information about agent activity in a given day.&#x20;
+* [Conversation Segment Kinds](/docs/flex/end-user-guide/insights/segments.md): Learn how to distinguish between segment types in Flex Insights with the Kind attribute.
+* [Schedule Flex Insights Dashboards with Email](/docs/flex/end-user-guide/insights/schedule-dashboards-with-email.md): Make sure that you're keeping everyone in the know about your Flex Insights data by sending regularly-updated dashboards via email. Learn how in this guide.
+* [Flex Insights Quality Management](/docs/flex/end-user-guide/insights/questionnaires.md): Learn how to assess the quality of your customer conversations in Twilio Flex Insights.
+* [Play Calls](/docs/flex/end-user-guide/insights/player.md): Learn how to navigate the Flex Insights Player to get a quick overview of a call
+* [Flex Insights Maintenance and Updates](/docs/flex/end-user-guide/insights/maintenance-and-updates.md): Flex Insights has timed maintenance and update windows. Get the maintenance schedule and impact on your custom content in this guide.
+* [Flex Insights KPI Dashboards](/docs/flex/end-user-guide/insights/kpi-dashboards.md): Learn more about Twilio Flex Insights KPI dashboards, which contain Key Performance Indicators (KPIs) and insights about your business.
+* [Flex Insights](/docs/flex/end-user-guide/insights.md): Learn the basics of Twilio Flex Insights, out-of-the-box custom data views that let you drill down from top-level KPIs to individual conversation segments.
+* [Getting Started with Flex Insights](/docs/flex/end-user-guide/insights/getting-started.md): Learn how to enable access, customize event collection, optimize performance, and understand data retention in Flex Insights.
+* [Format Metrics in Flex Insights Reports](/docs/flex/end-user-guide/insights/format-report-metrics.md): Learn how to format numerical metrics in your Flex Insights reports.
+* [Flex Insights Data Model](/docs/flex/end-user-guide/insights/data-model.md): A thorough overview of the attributes in the Flex data model's key data sets, designed for the analytical needs of your contact center.
+* [Flex Insights Data Model Caveats](/docs/flex/end-user-guide/insights/data-model-caveats.md): The Flex Insights Data Model was designed for ease of use and maximum query performance. There are a few things to be aware of when working with measures and attributes.
+* [Customer Geolocation in Flex Insights](/docs/flex/end-user-guide/insights/customer-geolocation.md): Leverage geolocation of customers for insightful data and to detect location-based issues. Improve accuracy by evaluating geolocation data with Flex Insights.
+* [Conversation Structure](/docs/flex/end-user-guide/insights/conversation-structure.md): Understand how voice conversations are split into segments and how handling time is calculated in Flex Insights.
+* [Conversation Screen](/docs/flex/end-user-guide/insights/conversation-screen.md): Access and analyze customer conversation details with Flex Insights. Listen to call segments, view transcripts, add comments, make assessments, and more.
+* [Conversation Assessment](/docs/flex/end-user-guide/insights/conversation-assessments.md): Get up and running with Twilio Flex Insights assessments by learning how to create questionnaires to assess the quality of agent calls with your customers.
+* [Best Practices and Performance Limits for Flex Insights](/docs/flex/end-user-guide/insights/best-practices-and-performance-limits.md): Read our recommended settings for fine-tuning your reports and dashboards in Flex Insights.
+* [Flex Insights Assessment Reporting](/docs/flex/end-user-guide/insights/assessment-reporting.md): Learn about the metrics and attributes used to build robust reports and dashboards on top of customer feedback with Twilio Flex Insights.
+* [Track Abandoned Conversations in Flex Insights](/docs/flex/end-user-guide/insights/abandoned-conversations.md): Manage and analyze abandoned conversations with Flex Insights.
+* [View an email](/docs/flex/end-user-guide/email/view-email.md): When a customer sends an email in HTML format, you'll see the content of the email as you would expect in the Flex UI. An HTML email can contain links, images, tables, and symbols, such as emojis.
+* [Handle an email task](/docs/flex/end-user-guide/email/task.md): Accept, read and reply to an inbound email: Inbound email tasks come in like any other task for any other Task Channel. When an email arrives, the task appears at the top of the Task list.
+* [Initiate an email conversation](/docs/flex/end-user-guide/email/initiate-email.md): You can initiate an email thread from an inbound task or initiate an email task from the Flex Agent UI.
+* [Email-specific reporting from Flex Insights](/docs/flex/end-user-guide/email/flex-insights-reporting.md): As a supervisor, you may want to see email-related metrics and include data for email-specific reports. You can do this through Flex Insights.
+* [Compose an email](/docs/flex/end-user-guide/email/compose-email.md): When handling an email task, you can use the HTML editor to apply formatting to your message for the customer.
+* [Work with messaging transfers](/docs/flex/end-user-guide/conversations/work-with-messaging-transfers.md): Learn how to transfer a message from a Conversations channel to another agent or to a queue.
+* [Use Chat and Messaging](/docs/flex/end-user-guide/conversations/use-chat-and-messaging.md): Learn about using chat and messaging in Flex UI 2.x.x for agents and supervisors.
+* [Send an attachment](/docs/flex/end-user-guide/conversations/messaging-attachments.md): Learn how to send and receive files as a Flex agent.
+* [Use auto-generated notes with Agent Copilot (Public Beta)](/docs/flex/end-user-guide/copilot/wrapupnotes.md): This guide describes the Agent Copilot agent experience
+* [Use Agent Copilot for suggested responses and answers (public beta)](/docs/flex/end-user-guide/copilot/real-time-assist-features.md): Learn how to use Agent Copilot for suggested responses and answers to enhance productivity and customer interactions.
+* [Agent Copilot and Unified Profiles overview for agents (public beta)](/docs/flex/end-user-guide/copilot.md): Agent Copilot and Unified Profiles provide information and automations that enable you to assist customers more effectively.
+* [View customer profiles with Unified Profiles (Public Beta)](/docs/flex/end-user-guide/copilot/customerprofiles.md): View details about a customer that help you tailor your conversation to their needs.
+* [Voice in Twilio Flex](/docs/flex/developer/voice.md): Set up basic inbound and outbound calls for your Cloud Contact Center using Twilio's Programmable Voice API
+* [How to Implement Click-to-Dial](/docs/flex/developer/voice/dialpad-click-to-dial.md): Implement click-to-dial functionality using Flex's native outbound dialing capabilities. Integrate with CRMs and customize calls so you can initiate calls seamlessly.
+* [Flex Users API (public beta)](/docs/flex/developer/user-management/flex-users-api.md): Flex user management APIs
+* [Flex User Token API (public beta)](/docs/flex/developer/user-management/flex-token-api.md): Flex user token APIs
+* [Flex Teams API (public beta)](/docs/flex/developer/user-management/flex-teams-api.md): Use the Flex Teams REST API to group users together for easier user management, reporting, and oversight.
+* [Override Flex UI 2.x.x themes, branding and styling](/docs/flex/developer/ui-and-plugins/themes-branding-styling.md): Twilio Flex UI offers a range of customizations. Learn how to configure a base theme, override base themes and individual components, and apply your custom theme.
+* [Flex UI and Flex Plugins](/docs/flex/developer/ui-and-plugins.md): A high-level overview of Twilio Flex Plugins, the recommended way of customizing your Flex UI, with links to more in-depth documentation.
+* [Work with Notifications](/docs/flex/developer/ui/work-with-notifications.md): Manage and customize notifications through Flex UI's client-side API. Use NotificationBar for icons and actions, and enable browser notifications.
+* [Work with Components and Props](/docs/flex/developer/ui/work-with-components-and-props.md): Work with programmable Flex UI 2.0 components and props.
+* [Web Accessibility](/docs/flex/developer/ui/web-accessibility.md): Flex UI 2.x.x includes enhanced support for WCAG 2.1 AA compliance. This page explains accessibility features that Flex UI supports and the accessibility tools that Flex UI provides.&#x20;
+* [Use UI Actions](/docs/flex/developer/ui/use-ui-actions.md): Leverage Flex UI's emitted event data with Actions Framework. Register, modify, and replace actions, create custom alerts, and monitor incoming calls.
+* [Use Twilio Paste with a Flex Plugin](/docs/flex/developer/ui/use-paste-with-a-plugin.md): Learn how to use Twilio Paste design tokens, leverage it on a Flex plugin, or customize Paste elements using a Flex method.
+* [Developer Guide to Troubleshooting the Flex UI](/docs/flex/developer/ui/troubleshoot-the-flex-ui.md): Monitor and maintain your Flex application with Flex UI and Twilio Console debugging tools. Retrieve error reports and logs, and send them to error monitoring systems or directly to Twilio.
+* [Advanced Team View Filters](/docs/flex/developer/ui/team-view-filters.md): Customize Team View Filters in your Flex application to help supervisors with agent filtering.
+* [Sounds and audio in Flex](/docs/flex/developer/ui/sound-and-audio.md): Leverage the Flex AudioPlayerManager API for sound implementation. Manage playing, stopping, and muting sounds efficiently while handling media errors.
+* [Flex UI Requirements](/docs/flex/developer/ui/requirements.md): See software, equipment, and networking requirements for running Flex in your contact center.
+* [Use Redux with Flex](/docs/flex/developer/ui/redux.md): Learn about Redux and how it can help data move through your omnichannel contact center with Twilio Flex.
+* [Real-Time Queues View Programmability](/docs/flex/developer/ui/queues-view-programmability.md): Customize the Real-Time Queues View to display the queue statistics that you want to monitor in your contact center.
+* [Overview of Flex UI programmability options](/docs/flex/developer/ui/overview-of-flex-ui-programmability-options.md): Manage your Flex UI 2.x.x instance with Flex Manager. Learn to customize different components and manage states and task channels.
+* [Modify Flex UI Keyboard Shortcuts](/docs/flex/developer/ui/modify-keyboard-shortcuts.md): Flex UI 2.1 includes a customizable and programmable keyboard shortcuts menu for the most common contact center operations.
+* [Flex UI local logging](/docs/flex/developer/ui/local-logging.md): Capture client-side logs into a text file that you can share with Twilio support to help with troubleshooting.
+* [The Flex UI](/docs/flex/developer/ui.md): Use the Twilio Flex UI component library to build custom user experiences and custom behaviors for the Flex Agent Desktop and Flex Supervisor Desktop.
+* [Error Handling and Debugging](/docs/flex/developer/ui/errors-and-debugging.md): Learn how to handle errors, retrieve logs, and use Flex UI in Degraded Mode.
+* [Create Custom Views and Routes](/docs/flex/developer/ui/custom-views-and-routes.md): Twilio Flex allows you to build custom views and routes for your contact center using familiar libraries like React Router.
+* [Create and Style Custom Components](/docs/flex/developer/ui/creating-styling-custom-components.md): Build custom Flex components and read about best practices using the Twilio Paste design system and Emotion library for bundling styles and plugin code.
+* [Flex UI Components](/docs/flex/developer/ui/components.md): Learn how to programmatically add, replace, or remove Twilio Flex UI components.
+* [Use Apollo Client with Flex UI](/docs/flex/developer/ui/apollo-client.md): Learn how to adjust your Apollo Client configuration to work with Flex UI and your custom GraphQL APIs.
+* [Add Components to Flex UI](/docs/flex/developer/ui/add-components-flex-ui.md): Learn how to add a custom component to your Flex application using a plugin.
+* [Add Task and Theme Context to Components](/docs/flex/developer/ui/add-component-context.md): Learn how to add context such as Task and Theme data into your Flex custom component.
+* [Keeping Plugins Up-To-Date](/docs/flex/developer/plugins/updating.md): Upgrade the Flex Plugins CLI and dependencies. You can try out new features in your latest plugins without risking backwards-incompatible changes in your other codebases.
+* [Selecting React versions for Flex](/docs/flex/developer/plugins/react-versions.md): Learn how to select and verify React and ReactDOM versions for a Flex application. Includes installation guidelines for new and existing plugins.
+* [Plugins Resource Limits](/docs/flex/developer/plugins/plugins-resource-limits.md): Manage Flex plugins effectively with restrictions on quantity, versions, and file size to optimize your Flex application's capabilities.
+* [Flex Plugin Library](/docs/flex/developer/plugins/plugin-library.md): The Flex Plugin Library is a collection of ready-to-install Flex plugins for common contact center use cases.
+* [Migrate Legacy Plugins to the CLI](/docs/flex/developer/plugins/migrate.md): Migrate from Flex Plugin Builder to the Twilio CLI Flex plugin. Learn how you can migrate and manage your plugins with the new CLI.
+* [Localize a plugin (Public Beta)](/docs/flex/developer/plugins/localize-a-plugin.md): Learn how to configure your custom plugin to display in another language.
+* [Environment variables in Flex Plugins](/docs/flex/developer/plugins/environment-variables.md): Manage Flex apps using multiple accounts for different environments. Use the Flex Plugins CLI and environment variables for effective deployment and integration.
+* [Debugging a Flex Plugin with VS Code](/docs/flex/developer/plugins/debugging-with-vscode.md): Set up Visual Studio (VS) Code for local Flex Plugin debugging. Learn to configure plugins and efficiently manage breakpoints.
+* [Custom Plugins Dashboard](/docs/flex/developer/plugins/dashboard.md): Manage custom plugins, view the history of custom plugin releases, and roll back to prior deployments with the Custom Plugins dashboard.
+* [How to call Twilio Functions from a Flex plugin](/docs/flex/developer/plugins/call-functions.md): Learn how to use Twilio's serverless Functions to make secure requests from custom Plugins in your Flex contact center.
+* [TaskRouter Data in Flex Insights](/docs/flex/developer/insights/taskrouter-data.md): Understand what data is available from TaskRouter in Flex Insights.
+* [Workforce Management Real-Time Adherence](/docs/flex/developer/insights/real-time-adherence.md): Monitor real-time activity and status of Flex contact center agents using Workforce Management Real-Time Adherence Feed. Get JSON-formatted agent updates via HTTPS.
+* [Secure Playback of Recordings from Custom Storage](/docs/flex/developer/insights/playback-recordings-custom-storage.md): Manage user access to call recordings with Flex Insights. Create custom authorization of users, log access to individual recordings, and decrypt recordings.
+* [Label Data for Flex Insights](/docs/flex/developer/insights/labels.md): Enhance efficiency in Historical Reporting with Labels. Manage attributes and labels to maximize data value without reaching the limit for unique attribute labels.
+* [Dashboards Programmability](/docs/flex/developer/insights/insights-dashboards-programmability.md): Learn to customize project and analytical dashboards filters to control how they appear.
+* [Embedding Dashboards](/docs/flex/developer/insights/insights-dashboards-embedding.md): Learn how to enable and work with Insights - Programmable Dashboards on your Flex application.
+* [Building with Flex Insights](/docs/flex/developer/insights.md): Enhance your Flex Insights integration and export data via custom code development.
+* [HIPAA for Flex Insights Historical Reporting](/docs/flex/developer/insights/hipaa-flex-insights-historical-reporting.md): Flex Insights adheres to HIPAA guidelines, safeguarding personal health data by removing identifiable information from Historical Reporting.
+* [Add additional TaskRouter data](/docs/flex/developer/insights/enhance-integration.md): Learn how to add additional data to TaskRouter to enhance your Flex Insights reports and link multiple communications to a single customer.
+* [Turn on dual-channel recording](/docs/flex/developer/insights/enable-dual-channel-recordings.md): Unlock advanced call analysis with dual-channel recording. Enhance transcription, keyword analysis, and playback using Flex Insights, the Twilio Console, and Voice API.
+* [Custom Media attached to Conversations](/docs/flex/developer/insights/custom-media-attached-conversations.md): Learn how to attach custom media to a Flex Insights Conversation.
+* [Run Flex Insights on a Custom Domain](/docs/flex/developer/insights/custom-domain.md): Learn how to run Flex Insights on a custom domains in self-hosted Flex environments.
+* [Flex SDK methods](/docs/flex/developer/flex-sdk/sdk-methods.md): Learn more about the Flex SDK methods that are included with the Flex SDK.
+* [Flex SDK overview](/docs/flex/developer/flex-sdk.md): Learn about the Flex SDK and what's included.
+* [Flex SDK glossary](/docs/flex/developer/flex-sdk/glossary.md): Learn about key terms that will help you use the Flex SDK.
+* [Getting started](/docs/flex/developer/flex-sdk/getting-started.md): Learn how to get started with the Flex SDK.
+* [Flex SDK authentication](/docs/flex/developer/flex-sdk/authentication.md): Learn how to access the Flex SDK using secure authentication options.
+* [Customize the Email in Flex UI](/docs/flex/developer/email/ui-customization.md): Email in Flex uses the same programmable model as other parts of the Flex UI. This means that you can add, replace, and remove the new email editor components or invoke various actions related to email in the Flex UI.
+* [Email in Flex limitations](/docs/flex/developer/email/limitations.md): This page describes limitations of Email in Flex.
+* [Manage email conversations](/docs/flex/developer/email/conversations.md): Email in Flex uses the Conversations API as a basis for message orchestration.
+* [Agent Copilot: Upload your knowledge sources using the API (public beta)](/docs/flex/developer/copilot/upload-source-api.md): Step-by-step guide on how to use the Knowledge API to upload your sources for Agent Copilot.
+* [WebChats Resource](/docs/flex/developer/conversations/webchats-resource.md): Simplify creating a web channel for starting a Flex Conversations chat in Flex UI 2.x.x.
+* [Send Outbound Messages with Flex Conversations Channels](/docs/flex/developer/conversations/send-outbound-messages-via-sms-and-whatsapp.md): Send an outbound message using Flex Conversations channels, such as SMS, WhatsApp, or chat, in Flex UI 2.x.x.
+* [Register a webhook to receive Interactions events](/docs/flex/developer/conversations/register-interactions-webhooks.md): Create an Interactions API webhook and subscribe to events to get details when those events occur during Flex Conversations.
+* [Receive Inbound Messages with Flex Conversations Channels](/docs/flex/developer/conversations/receive-inbound-messages-from-sms-and-whatsapp.md): Learn how to configure inbound messages on different Flex Conversations channels.
+* [Park an Interaction](/docs/flex/developer/conversations/park-an-interaction.md): Learn how to remove agents but keep a Flex UI 2.x.x interaction open while waiting for more information. This page includes example commands and responses.
+* [File Attachments and API Limits](/docs/flex/developer/conversations/limits.md): View limits for Flex Conversations attachments and APIs.&#x20;
+* [Known Issues](/docs/flex/developer/conversations/known-issues.md): View known issues and workarounds for Flex Conversations.
+* [Integrate the Twilio Webchat React app with Flex](/docs/flex/developer/conversations/integrate-twilio-webchat-react-app.md): Explore an open-source React demo of a webchat widget that you can integrate with Flex UI 2.x.x.
+* [Integrate a Custom Chat Client with Flex](/docs/flex/developer/conversations/integrate-a-custom-chat-client-with-flex.md): Integrate custom chat with Flex UI 2.x.x and hand off incoming Conversation messages to your agents.
+* [Flex Conversations](/docs/flex/developer/conversations.md): Dive into the architectural overview, inbound and outbound flows on a messaging channel when using Flex Conversations in Flex UI 2.x.x.
+* [Conversations FAQ and Troubleshooting](/docs/flex/developer/conversations/faq-and-troubleshooting.md): Read answers to frequently asked questions about building with Flex Conversations.
+* [Best Practices](/docs/flex/developer/conversations/best-practices.md): Follow these best practices for setting up Twilio Flex Conversations.
+* [Known issue: Self-hosted Flex 2.7.0 and later requires specific react-scripts version](/docs/flex/developer/config/known-issue-react-scripts-version.md): If you use self-hosted Flex and your custom application uses react-scripts v5, you must apply a workaround to use Flex UI 2.7.0 or later due to a react-scripts issue. Without the workaround, Flex will fail to initialize.
+* [Flex Configuration REST API](/docs/flex/developer/config/flex-configuration-rest-api.md): Manage and modify your Flex Configuration properties via REST API. Oversee, retrieve, and update API Configuration resources efficiently.
+* [The appConfig.js object](/docs/flex/developer/config/appconfigjs.md): Learn how to manage your self-hosted Flex UI app configuration.
+* [Flex alerts: Notification configuration API (public beta)](/docs/flex/developer/alerts/notifications-api.md): API reference for Flex alerts notification configuration.
+* [Flex alerts: Rules API (public beta)](/docs/flex/developer/alerts/alerts-insights-api.md): API reference for Flex alerts rules.
+* [Handle a Voice Contact](/docs/flex/admin-guide/tutorials/voice-setup.md): Purchase a new Twilio number, configure it with a Studio Flow for handling calls, and test the voice experience on your Flex account.
+* [Manage legacy SMS addresses](/docs/flex/admin-guide/tutorials/sms-setup.md): Set up a new legacy SMS address to route incoming SMS messages for a phone number into Flex. Learn to manage SMS addresses, create new conversations, and sync with Flex Proxy Service.
+* [Routing Part 1: Assign skills to your Flex agents](/docs/flex/admin-guide/tutorials/skills-assignment.md): As part of your Twilio Flex contact center setup, you can assign skills to your agents using the Flex Admin UI. We build on our Twilio Flex contact center with a more powerful IVR, extra agents, skills tagging, and automatic skill-based routing.
+* [Routing Part 2: Set Up Queues and Skills-based Routing](/docs/flex/admin-guide/tutorials/queues-and-skills-based-routing.md): Set up task queues for your Twilio Flex contact center and enable skills-based routing by creating your TaskRouter Workflows and Studio Flows for Flex.
+* [Build an IVR for Flex with Twilio Studio](/docs/flex/admin-guide/tutorials/ivr.md): Learn to route calls with an IVR menu in Twilio Studio as part of the Flex system, reducing agent calls and enhancing efficiency.
+* [System checkup](/docs/flex/admin-guide/setup/system-checkup.md): System checkup detects common issues with your Flex configuration.
+* [Securely embed Flex as an iframe](/docs/flex/admin-guide/setup/secure-iframe.md): Register and update your Allowed URLs list in the Twilio Console if you are embedding flex.twilio.com as an iframe.
+* [Manage Flex logout settings](/docs/flex/admin-guide/setup/logout-settings.md): Specify when and how Flex UI users are automatically logged out when they become unavailable.
+* [Turn on language selection for agents (Public Beta)](/docs/flex/admin-guide/setup/enable-language-selection.md): Turn on language selection to give agents the option to set their display language.
+* [Turn on a ringtone for inbound tasks](/docs/flex/admin-guide/setup/default-ringtone.md): Learn how to turn on a ringtone to play for inbound tasks in Twilio Flex.
+* [Manage Twilio Console users](/docs/flex/admin-guide/setup/console-users.md): Add and modify Flex users with administrator, developer, billing manager, or support roles in the Twilio Console.
+* [Set up your Twilio Flex instance](/docs/flex/admin-guide/setup/account-creation.md): Sign up for Twilio and set up your Flex instance.
+* [Integrate Flex with Veridas Voice Biometrics](/docs/flex/admin-guide/integrations/veridas-voice-biometrics.md): Explore Veridas Voice Biometrics for a digital authentication solution. Validate the identity of your customers with just 3 seconds of their voice, in any language, and without the need of making them repeat any given sentence.
+* [Integrate Flex with Spoke Phone (UCaaS)](/docs/flex/admin-guide/integrations/spoke-phone-ucaas.md): Explore Spoke Phone, a Unified Communications solution integrated with Twilio and Flex. Spoke Phone can serve as a full PBX replacement, enhancing connectivity.
+* [Set up Salesforce Service Cloud Voice (SCV) with Twilio](/docs/flex/admin-guide/integrations/salesforce-service-cloud-voice.md): Learn how to integrate Salesforce Service Cloud Voice to use Twilio as the Partner Telephony Provider.
+* [Integrate Flex with Puzzel WFM](/docs/flex/admin-guide/integrations/puzzel-wfm.md): Learn how to integrate Puzzel WFM with Twilio Flex. Puzzel WFM provides a simple, cloud-based platform that enables forecasting, scheduling, and adherence monitoring for your Twilio Flex workforce.
+* [Integrate the Mindful platform With Flex](/docs/flex/admin-guide/integrations/mindful.md): Integrate Flex and Mindful for efficient customer callbacks. Learn to set up a SIP domain and trunk and to configure return call priority.
+* [Integrate Mindful Feedback with Flex](/docs/flex/admin-guide/integrations/mindful-feedback.md): Explore Mindful Feedback, a tool that automatically collects customer feedback after any Flex interaction. View customer feedback within Flex UI on the integrated real-time reporting dashboard available for agents, supervisors and managers.
+* [Integrate Flex with Lionbridge Language Cloud](/docs/flex/admin-guide/integrations/lionbridge-language-cloud.md): Explore Lionbridge Language Cloud for real-time translation in over 110 languages. Lionbridge Language Cloud is a real-time language translation solution that enables your agents and customers to each send and receive messages in their own native languages.
+* [Google Dialogflow CX integration in Flex for virtual agents](/docs/flex/admin-guide/integrations/google-dialogflow-cx-native-integration.md): You can use Google Dialogflow CX Virtual Agent in Flex to handle incoming calls and conversations and route them to a live agent.
+* [Integrate Flex with Glance Cobrowse](/docs/flex/admin-guide/integrations/glance.md): Learn how to integrate Twilio Flex with Glance Cobrowse. This integration enables agents to launch a Cobrowse session to instantly join customers in viewing your app or website.
+* [Integrate Flex with Alvaria WFM](/docs/flex/admin-guide/integrations/alvaria.md): Learn how to integrate Alvaria Workforce Management with Twilio Flex for efficient contact center operations. Alvaria WFM enables you to efficiently forecast staff scheduling, schedule individual agents, and monitor schedule adherence.
+* [Core concepts: Voice](/docs/flex/admin-guide/core-concepts/voice.md): Learn about Flex voice features, including conferencing, secure payment options, and access to real-time audio streams.
+* [Core concepts: Studio Flows, Functions, Assets, TwiML](/docs/flex/admin-guide/core-concepts/studio-flows-functions-assets-twiml.md): Learn about the relationship of Studio Flows, REST API v2, Functions & Assets, and TwiML for Voice and SMS with Twilio Flex.
+* [Core concepts: Routing](/docs/flex/admin-guide/core-concepts/routing.md): Learn how Flex uses Taskrouter to route tasks to workers in your contact center workspace.
+* [Core concepts: Numbers](/docs/flex/admin-guide/core-concepts/numbers.md): This core concepts guide covers the various number types available to your Flex applications and includes provisioning and porting numbers.
+* [Core concepts introduction](/docs/flex/admin-guide/core-concepts/introduction.md): This introduces Flex administrators to core concepts and products that Flex leverages to build your contact center.
+* [Core concepts](/docs/flex/admin-guide/core-concepts.md): Explore key concepts and building blocks for Twilio Flex.
+* [Core concepts: Flex UI](/docs/flex/admin-guide/core-concepts/flex-ui.md): Learn the core concepts and structure of Twilio Flex UI, including different user views, settings, SSO, themes, and plugins.
+* [Core concepts: Chat and Messaging](/docs/flex/admin-guide/core-concepts/chat-and-messaging.md): Understand how chat and messaging works within Flex.
+* [Queues stats monitoring in Flex](/docs/flex/end-user-guide/real-time-reporting/real-time-queues-view.md): This guide for call center operators covers the Flex Real-Time Queues View, which displays metrics for inbound tasks.
+* [Messaging transfer metrics](/docs/flex/end-user-guide/insights/metrics/transfer.md): Learn about the custom metrics available to collect data an agent transfers a Flex Conversations message.
+* [SLA Metrics](/docs/flex/end-user-guide/insights/metrics/sla.md): Learn how to configure SLA Metrics and pass information via TaskRouter attributes with Flex Insights Historical Reporting.
+* [Flex Insights Metrics](/docs/flex/end-user-guide/insights/metrics.md): Explore Flex Insights Historical Reporting for integrated metrics in report and dashboard building.
+* [Hold Time Metric](/docs/flex/end-user-guide/insights/metrics/hold-time.md): Explore Hold Time, a metric that shows the total time that a customer spent on hold in that segment. Find out more about how this metric is calculated and how to build reports that include it.
+* [Agent Copilot  metrics](/docs/flex/end-user-guide/insights/metrics/agent-copilot.md): Learn about the custom metrics available to collect data about customer sentiment during an interaction.
+* [Rollup Summary in Tables](/docs/flex/end-user-guide/insights/dashboards/rollup-summary-tables.md): Learn how to use Flex Insights' rollup summary to create intelligent aggregation in your reports.
+* [Dashboards](/docs/flex/end-user-guide/insights/dashboards.md): Explore the Analytics Portal's features: create dashboards, manage visibility, interact with data, and send reports seamlessly via email.
+* [Flex Insights Analyze View](/docs/flex/end-user-guide/insights/dashboards/analyze.md): Learn about Twilio's Flex WFO analyze tab, an environment for data discovery and visualization.
+* [Update plugins for Flex UI 2.x.x](/docs/flex/developer/ui/migration-guide/migration-guide-update-plugins.md): This page explains how to update your plugins when migrating to Flex UI 2.x.x
+* [Flex UI 2.x.x updates that can affect your customizations](/docs/flex/developer/ui/migration-guide/migration-guide-2x-updates.md): This page describes Flex UI updates that you should be aware of when migrating to Flex UI 2.x.x.
+* [Migrate from Flex UI 1.x.x to 2.x.x](/docs/flex/developer/ui/migration-guide.md): Migrate smoothly from Flex UI 1.x.x to 2.x.x. This guide outlines UI and SDK changes that can affect your customizations.
+* [Upgrade Flex Plugins CLI](/docs/flex/developer/plugins/cli/upgrade.md): Upgrade the Flex Plugins CLI. Review resources for migrating existing plugins to use the latest CLI version.
+* [Run Multiple Plugins Locally Using the Flex Plugins CLI](/docs/flex/developer/plugins/cli/run-multiple-plugins.md): Use the Flex CLI to test and load multiple plugins both locally and remotely in your Flex application.
+* [Plugins CLI Reference](/docs/flex/developer/plugins/cli/reference.md): Use the Flex Plugins CLI to manage, build, and deploy Twilio Flex plugins.
+* [Install Flex Plugins CLI](/docs/flex/developer/plugins/cli/install.md): Manage and install Flex plugins with the Flex Plugins CLI. Migrate existing plugins, initiate new ones, or remove old installations.
+* [Flex Plugins CLI](/docs/flex/developer/plugins/cli.md): Develop, test, and release your Flex plugins using the Flex CLI.
+* [Validate, deploy, and release a plugin using the Flex Plugins CLI](/docs/flex/developer/plugins/cli/deploy-and-release.md): Deploy your plugins using the command line with the Flex Plugins CLI. Learn how to manage releases and configurations for multiple Twilio accounts.
+* [Common Use Cases](/docs/flex/developer/plugins/cli/common-uses.md): Read the common use cases for the Flex Plugins CLI, including sample commands and responses.
+* [Archive Plugins and Configurations](/docs/flex/developer/plugins/cli/archive.md): Archive plugins effectively with the Flex API. Prevent accidental redeployments and view archived plugins in the Flex Dashboard.
+* [Rolling Back a Release using Plugins API](/docs/flex/developer/plugins/api/rollback.md): Use the Plugins API to quickly and simply roll back a release.&#x20;
+* [Plugin Release Resource](/docs/flex/developer/plugins/api/release.md): Activate a Configuration on a Flex project using the Plugin Release resource. Manage multiple plugins, audit changes, and implement releases efficiently.
+* [Create a new release with new and updated Plugins](/docs/flex/developer/plugins/api/release-update.md): This guide explains how to roll out a new version of a plugin that is already active on your contact center or introduce a new plugin in your Flex contact center.
+* [Releasing Flex plugins with the Plugins API](/docs/flex/developer/plugins/api/release-guide.md): Create, deploy and manage Flex plugin versions using the Plugins API.
+* [Plugin Resource](/docs/flex/developer/plugins/api/plugin.md): The Plugin Resource serves as an identifier for the Plugin itself. You can find information about a given plugin, like its name, description, and the account that owns the plugin.
+* [Plugin Version Resource](/docs/flex/developer/plugins/api/plugin-version.md): Create, fetch, or read all or a specific Flex plugin version using the Flex API.
+* [Plugin Configuration Resource](/docs/flex/developer/plugins/api/plugin-configuration.md): Create and manage custom contact center plugin configurations using the Flex API.
+* [The Plugins API](/docs/flex/developer/plugins/api.md): Learn about the Plugins API, which defines which plugins the Flex UI loads during initialization. The Plugins API is used by the Flex Plugin CLI and the Custom Plugins Dashboard to simplify common workflows.
+* [Mapping Global Identifiers to Workspace Identifiers](/docs/flex/developer/insights/api/mapping-identifiers.md): Flex Insights can identify reports, metrics, dashboards, and other objects using multiple identifiers. Learn why these identifiers are useful, and how to map global identifiers to workspace identifiers.
+* [Flex Insights API General Usage](/docs/flex/developer/insights/api/general-usage.md): Learn how to authenticate and use the Flex Insights API.
+* [Export Data from Flex Insights via API](/docs/flex/developer/insights/api/export-data.md): Learn how to export reports from within Flex Insights to store the data in a warehouse of your own.
+* [Use custom styling for Webchat components in Webchat 3.x.x](/docs/flex/developer/conversations/webchat/styling-customizations.md): Learn how to customize the style of Webchat 3.x.x components by overriding CSS classes.
+* [Set up and use Webchat 3.x.x](/docs/flex/developer/conversations/webchat/setup.md): Get started with Webchat for Twilio Flex. Learn how to add this chat widget to your web applications and understand the chat widget's default behavior.
+* [Webchat 3.x.x security](/docs/flex/developer/conversations/webchat/security.md): Webchat 3.x.x includes enhanced security measures, including a randomly generated deployment key, fingerprinting, and the ability to add allowed origins.
+* [Using pre-engagement form data and context in Webchat 3.x.x](/docs/flex/developer/conversations/webchat/pre-engagement-and-context.md): Learn about using pre-engagement forms and context to gather user information before the start of a chat.
+* [Migrate to Webchat 3.x.x](/docs/flex/developer/conversations/webchat/migrate.md): Understand the differences between webchat versions. Learn how to migrate to Webchat 3.x.x.
+* [Webchat 3.x.x overview](/docs/flex/developer/conversations/webchat.md): Flex Webchat is a natively integrated chat widget that you can embed on your website. The widget helps your customers chat with an agent without leaving your webpage.
+* [Cookies and the Web Storage API in Webchat 3.x.x](/docs/flex/developer/conversations/webchat/cookies-and-web-storage.md): This page discusses cookies, local storage, and session storage, and how Flex Webchat utilizes each one.
+* [Invites Subresource](/docs/flex/developer/conversations/interactions-api/invites-subresource.md): Use the Interaction Channel Invite subresource to add an agent as a new participant to an existing Flex 2.x.x interaction channel.
+* [Interactions resource](/docs/flex/developer/conversations/interactions-api/interactions.md): A full API reference for the Interactions resource.
+* [Interaction Channel Participants](/docs/flex/developer/conversations/interactions-api/interaction-channel-participants.md): Manage participants in a Flex Interaction. Examples include how to use the API to wrap up and complete a Flex Conversations task for an agent and how to change an agent's reservation status to Completed.
+* [Interactions API](/docs/flex/developer/conversations/interactions-api.md): Review the list of Interactions API subresources and attributes that are consumed by the Flex UI and Insights.
+* [Channels Subresource](/docs/flex/developer/conversations/interactions-api/channels-subresource.md): Fetch and update interaction channels using this Flex Interaction endpoint.
+* [Test Voice](/docs/flex/admin-guide/setup/voice/test.md): Test the voice experience in Flex UI 1.x.x by answering a test voice call.&#x20;
+* [Flex on Citrix VDI](/docs/flex/admin-guide/setup/voice/flex-citrix-vdi.md): Overview and setup for Flex Citrix VDI.
+* [Flex on Azure Virtual Desktop or Windows 365 Cloud PC](/docs/flex/admin-guide/setup/voice/flex-azure-vdi.md): Overview and setup for Flex on Azure Virtual Desktop or Windows 365 Cloud PC
+* [Configure the Flex Dialpad](/docs/flex/admin-guide/setup/voice/dialpad-configure.md): Enable and configure outbound dialing in Flex using Flex Dialpad.
+* [Topics, subtopics, and disposition codes (Public Beta)](/docs/flex/admin-guide/setup/topics.md): Use topics to automatically categorize customer conversations.
+* [Set up and configure Unified Profiles in Flex (Public Beta)](/docs/flex/admin-guide/setup/unified-profiles/setup.md): Learn how to set up and configure Unified Profiles in Flex.
+* [Connect your Segment space (Public Beta)](/docs/flex/admin-guide/setup/unified-profiles/segment-space.md): Learn how to connect your Segment space to work with Unified Profiles.
+* [Known issues and limitations in Unified Profiles in Flex (Public Beta)](/docs/flex/admin-guide/setup/unified-profiles/limitations.md): Known issues and limitations in Unified Profiles in Flex
+* [Unified Profiles in Flex for administrators (Public Beta)](/docs/flex/admin-guide/setup/unified-profiles.md): Provide your teams with information about each customer to enhance their understanding of customer intent and enable them to personalize every conversation.
+* [Confirm or update your customer identifier settings (Public Beta)](/docs/flex/admin-guide/setup/unified-profiles/identifiers.md): Unified Profiles uses customer identifiers to search for customer profiles. You can configure these identifiers.
+* [Enrich profiles with Flex interaction data](/docs/flex/admin-guide/setup/unified-profiles/enrichment.md): Learn how to enrich Segment profiles with Flex customer interaction data.
+* [Add Flex customer history (Public Beta)](/docs/flex/admin-guide/setup/unified-profiles/customer-history-and-interaction.md): Learn how to configure Flex customer history and interaction data in Unified Profiles.
+* [Teams in Flex (Public Beta)](/docs/flex/admin-guide/setup/teams.md): Group Flex users together for easier user management, reporting, and oversight.
+* [Self-hosted Flex: additional SSO configuration](/docs/flex/admin-guide/setup/sso-configuration/self-hosted-sso.md): Learn about the additional SSO configuration needed for self-hosted Flex deployments.
+* [Configure Salesforce SSO with Flex](/docs/flex/admin-guide/setup/sso-configuration/salesforce.md): Step by Step instructions for setting up Salesforce SSO with Twilio Flex.
+* [Configure Okta IdP with Flex](/docs/flex/admin-guide/setup/sso-configuration/okta.md): Have your agents log in to Twilio Flex using the Okta. Learn how to integrate Okta with Twilio Flex with this step-by-step guide.
+* [Flex SSO URL Migration Guide](/docs/flex/admin-guide/setup/sso-configuration/migration-guide.md): Learn how to migrate your Flex SSO to a solution with enhanced security using OAuth 2.0.
+* [Flex Insights User Roles](/docs/flex/admin-guide/setup/sso-configuration/insights-user-roles.md): Provision users and assign roles in Flex Insights using Okta. Learn about the roles and access to analytical dashboards that you can enable in Flex Insights.
+* [Configuring SSO and IdP in Flex](/docs/flex/admin-guide/setup/sso-configuration.md): Learn how to configure single sign-on (SSO) and identity provider (IdP) in Twilio Flex for popular identity providers.
+* [Configure Google Single Sign-On (SSO) with Twilio Flex](/docs/flex/admin-guide/setup/sso-configuration/google.md): Google Single Sign-On helps your users safely sign into Twilio Flex via Google sign-in. Learn how to configure Google SSO with Twilio Flex here.
+* [Configure Auth0 IdP with Twilio Flex](/docs/flex/admin-guide/setup/sso-configuration/auth0.md): Auth0 single sign-on helps your users safely sign into Twilio Flex through the Auth0 sign-in. Learn how to configure Auth0 SSO with Flex.
+* [Test legacy SMS and chat](/docs/flex/admin-guide/setup/messaging/test-channels.md): Test sample experiences for legacy Voice, SMS, and Chat in Twilio Flex.
+* [Read-only Admin role](/docs/flex/admin-guide/setup/flex-ui-users/read-only-admin-role.md): As a Read-only Admin, you can enter Flex to view and troubleshoot issues.
+* [Manage Flex UI users](/docs/flex/admin-guide/setup/flex-ui-users.md): Learn about Flex UI users (TaskRouter Workers), including available user roles, and how to view, create, and delete users.
+* [Agent Copilot: Configure wrap-up notes (public beta)](/docs/flex/admin-guide/setup/copilot/setup.md): This guide describes how to configure wrap-up notes for Agent Copilot.
+* [Configure real time-assist features for Agent Copilot (public beta)](/docs/flex/admin-guide/setup/copilot/real-time-assist.md): Learn how to configure real time-assist features for Agent Copilot to enhance agent productivity and customer interactions.
+* [AI Nutrition Facts for Agent Copilot (public beta)](/docs/flex/admin-guide/setup/copilot/nutritionfacts.md): Agent Copilot's AI qualities are outlined in the following Nutrition Facts label.
+* [Agent Copilot: Known issues and limitations (public beta)](/docs/flex/admin-guide/setup/copilot/limitations.md): This page describes limitations of Agent Copilot.
+* [Agent Copilot: Enable additional languages for wrap-up notes (public beta)](/docs/flex/admin-guide/setup/copilot/languages.md): Agent Copilot uses generative AI to assist agents with wrap-up.
+* [Knowledge for Agent Copilot (public beta)](/docs/flex/admin-guide/setup/copilot/knowledge.md): Learn how to configure knowledge sources for Agent Copilot.
+* [Agent Copilot for administrators (public beta)](/docs/flex/admin-guide/setup/copilot.md): Agent Copilot uses generative AI to assist agents.
+* [Agent Copilot: Configure customer highlights (public beta)](/docs/flex/admin-guide/setup/copilot/highlights.md): This guide describes how to configure customer highlights for Agent Copilot.
+* [Configure Agent Copilot (public beta)](/docs/flex/admin-guide/setup/copilot/configure.md): Agent Copilot uses generative AI to assist agents with wrap-up.
+* [Warm up an IP address for Email in Flex](/docs/flex/admin-guide/setup/email/warm-up-an-ip-address-for-email-in-flex.md): Warming up your IP allows you to gradually send more emails over your new IP to establish a good sender reputation.
+* [Set up outbound email](/docs/flex/admin-guide/setup/email/outbound.md): Set up the email address that is used in the Flex UI when an agent starts a new outbound conversation.
+* [Email in Flex for administrators](/docs/flex/admin-guide/setup/email.md): Learn to set up email in Twilio Flex.
+* [Prepare your Flex account for email](/docs/flex/admin-guide/setup/email/flex-account-preparation.md): Before you can use email in Flex, you must prepare your Flex account.
+* [Enable Email in Flex](/docs/flex/admin-guide/setup/email/enable-email-in-flex.md): Learn to enable email as a channel in Twilio Flex.
+* [Add and authenticate email domains](/docs/flex/admin-guide/setup/email/domains.md): To prove that you own the domains you will use for Flex, you must add and authenticate your email domains in Twilio.
+* [Turn on messaging transfers for Conversations](/docs/flex/admin-guide/setup/conversations/messaging-transfers.md): When you turn on messaging transfers, agents can transfer a message (including the conversation history) to another agent or to a queue.
+* [Manage Conversations WhatsApp Addresses](/docs/flex/admin-guide/setup/conversations/manage-conversations-whatsapp-addresses.md): Create a Flex Conversations WhatsApp address using the Twilio Console or the API. Set up a WhatsApp Sandbox to work with Flex Conversations.
+* [Manage Conversations SMS Addresses](/docs/flex/admin-guide/setup/conversations/manage-conversations-sms-addresses.md): Manage and configure your Flex phone number for the SMS channel in Flex Conversations. Test sending and receiving an SMS.
+* [Manage Conversations Addresses for Facebook Messenger (Public Beta)](/docs/flex/admin-guide/setup/conversations/manage-conversations-fbmessenger-addresses.md): Manage inbound Facebook messages by connecting your Facebook Business Page to Flex Conversations.
+* [Manage Conversations Chat Addresses](/docs/flex/admin-guide/setup/conversations/manage-conversations-chat-addresses.md): Create a Flex Conversations Chat address in the Twilio Console and test it with the demo app.
+* [Leave and pause options for Conversations](/docs/flex/admin-guide/setup/conversations/leave-and-pause-for-conversations.md): Conversations in Flex provides a leave option that enables agents to temporarily close a conversation and move on to other tasks. If you want the pause and leave options to be available to agents, you must turn them on.
+* [Turn on content templates for Flex Conversations](/docs/flex/admin-guide/setup/conversations/content-templates.md): Learn how to turn on content templates so that agents can send predefined content in Flex Conversations.
+* [Configure with a Messaging Service (advanced)](/docs/flex/admin-guide/setup/conversations/configure-with-messaging-service-advanced.md): These advanced, optional steps to configure messaging are available to help customers with accounts created during or before December 2021.
+* [Subscribe to Interactions events](/docs/flex/admin-guide/setup/conversations/configure-interactions-webhook.md): Create an Interactions API webhook and subscribe to events to get details when those events occur during Flex Conversations.
+* [Send Application-to-Person SMS in the US](/docs/flex/admin-guide/setup/conversations/a2p-10dlc.md): Register for an A2P use case, create a messaging service, and associate your A2P phone numbers with Flex Conversations.
+* [Alerts for contact center metrics in Flex (public beta)](/docs/flex/admin-guide/setup/alerts/alerts-contact-center-metrics.md): Configure alerts for your contact center metrics.
+* [Upgrade Guide for Flex-Zendesk](/docs/flex/admin-guide/integrations/zendesk/upgrade-guide.md): Upgrade your Flex-Zendesk integration to use Native Outbound Dialing.
+* [Flex-Zendesk integration release notes](/docs/flex/admin-guide/integrations/zendesk/release-notes.md): Release notes for the Flex-Zendesk integration
+* [Integrate Flex with Zendesk](/docs/flex/admin-guide/integrations/zendesk.md): Use Twilio Flex and Zendesk together to offer an omnichannel and personalised experience to your Customers
+* [Customize your Flex-Zendesk Integration](/docs/flex/admin-guide/integrations/zendesk/customize.md): Learn how to customize your Flex-Zendesk integration experience and call flows.
+* [Manage Flex-Zendesk Call Flows](/docs/flex/admin-guide/integrations/zendesk/call-flows.md): Learn how to power up your Customer Engagements using Twilio Flex with Zendesk
+* [Integrate Flex with Calabrio ONE WFM](/docs/flex/admin-guide/integrations/calabrio.md): Learn how Twilio Flex integrates with Calabrio ONE and how the workforce optimization solution can enhance contact center planning and operations.
+* [Upgrade Guide for Flex-Salesforce](/docs/flex/admin-guide/integrations/salesforce/upgrade-guide.md): Migrate your Flex-Salesforce Integration to use Native Outbound Dialing. Native Outbound Dialing enables you to take advantage of the increased stability and scale of the Flex platform and to gain access to additional features as they become available.
+* [Integrate Flex with Salesforce](/docs/flex/admin-guide/integrations/salesforce.md): Use the Flex and Salesforce consoles to integrate your call center with Salesforce.
+* [Customize your Flex-Salesforce Integration](/docs/flex/admin-guide/integrations/salesforce/customize.md): Learn how to customize your Flex-Salesforce integration experience and call flows.
+* [Manage Flex-Salesforce call flows](/docs/flex/admin-guide/integrations/salesforce/call-flows.md): Learn how to accept incoming calls from new and existing contacts and make outgoing calls from your Flex-Salesforce integration.
+* [Core concepts: Conversations](/docs/flex/admin-guide/core-concepts/conversations.md): Explore Flex Conversations, a feature supporting various asynchronous channels for both inbound and outbound communications using Flex UI 2.x.x and the Interactions API.
+* [Flex Dialpad Overview](/docs/flex/admin-guide/setup/voice/dialpad.md): Get started with the Flex Dialpad and review the resources available for developers and administrators.
+* [Enable the Flex Dialpad](/docs/flex/admin-guide/setup/voice/dialpad/enable.md): Flex Dialpad allows agents to place outbound calls within the Flex UI. This page explains how to enable Flex Dialpad.
+* [Configure Microsoft Entra ID with Flex](/docs/flex/admin-guide/setup/sso-configuration/azure-ad.md): Configure Entra ID as an identity provider for your Flex application.
+* [Pass custom Entra ID attributes as Twilio Flex SAML claims](/docs/flex/admin-guide/setup/sso-configuration/azure-ad/custom-azure-ad-attributes-as-saml-claims.md): Use Microsoft Graph Explorer to pass custom Entra ID attributes as claims to your Flex application in the SAML response.
+* [Wrap-up notes (Public Beta)](/docs/flex/admin-guide/setup/unified-profiles/setup/configure-ui/wrap-up-notes.md): DESCRIPTION Learn how to set up wrap-up notes in Flex.
+* [Configure Flex UI components (Public Beta)](/docs/flex/admin-guide/setup/unified-profiles/setup/configure-ui.md): Configure how customer profile data is shown to agents in your contact center.
+* [Configure customer header and search (Public Beta)](/docs/flex/admin-guide/setup/unified-profiles/setup/configure-ui/header-search.md): DESCRIPTION Learn how to set up and configure Unified Profiles in Flex.
+* [Configure customer history (Public Beta)](/docs/flex/admin-guide/setup/unified-profiles/setup/configure-ui/customer-history.md): Enable the customer history component to display customer events to your agents in Flex UI.
+* [Customer highlights (Public Beta)](/docs/flex/admin-guide/setup/unified-profiles/setup/configure-ui/customer-highlights.md): DESCRIPTION Learn how to set up and configure customer highlights in Flex.
+* [Configure customer details (Public Beta)](/docs/flex/admin-guide/setup/unified-profiles/setup/configure-ui/customer-details.md): Enable the customer details component to display customer profile information to your agents in Flex.
+
+## General Usage
+
+* [Twilio API responses](/docs/usage/twilios-response.md): Explore the various response formats, exceptions, and resources returned from Twilio to your application
+* [Secure your Twilio Credentials](/docs/usage/secure-credentials.md): Learn how to keep your Twilio credentials secure. Store them in environment variables on Mac, Windows, Linux, and cloud providers. Read environment variables with C#, Java, Node.js, PHP, Python, Ruby, and Curl.
+* [API best practices](/docs/usage/rest-api-best-practices.md): Secure your Twilio API integration with best practices on encryption, access control, rate limits, and more.
+* [Twilio API requests](/docs/usage/requests-to-twilio.md): Explore the basics of HTTP requests. Learn how to authorize your account, create or update API resources, and understand Twilio's responses.
+* [API mutation and conflict resolution](/docs/usage/mutation-and-conflict-resolution.md): Discover how Twilio's ETag and If-Match headers ensure data integrity with optimistic concurrency, resolving conflicts efficiently and safely.
+* [Monitor Events resource](/docs/usage/monitor-events.md): The Events resource provides comprehensive event-logging
+  and change-tracking for Twilio resources.
+* [Monitor REST API: Alerts](/docs/usage/monitor-alert.md): An Alert instance resource represents a single log entry for an error or warning encountered when Twilio makes a webhook request to your server.
+* [General Usage](/docs/usage.md): Learn how to use Twilio's REST API, manage accounts, set up your dev environment, and protect your accounts, applications, and users against fraud.
+* [Global Safe List](/docs/usage/global-safe-list.md): Full API reference for Twilio's Global Safe List API. Sample code shows how to add and check a phone number on the Safe List.
+* [Anti-Fraud Developer's Guide](/docs/usage/anti-fraud-developer-guide.md): Learn how to build applications that prevent bad actors from compromising your app, including best practices, fraud scenarios, and anti-fraud practices.
+* [Debugging Your Twilio Application](/docs/usage/troubleshooting/debugging-your-application.md): Troubleshoot issues with Twilio APIs, webhooks, and more.
+* [Debugging Events Webhook](/docs/usage/troubleshooting/debugging-event-webhooks.md): Learn about how you can use the Console Debugger webhook to solve errors, what its callback parameters are, and what its payload contains.
+* [Alarms](/docs/usage/troubleshooting/alarms.md): Learn how to configure and manage Error Log Alarms in the Twilio Console.
+* [ISO/IEC Certification](/docs/usage/security/iso-iec-certification.md): Learn how Twilio's certified compliance with ISO/IEC 27001 standards assures your protection.
+* [Security](/docs/usage/security.md): Twilio protects communications between Twilio and your web application with encryption. Learn how to authenticate, report vulnerabilities, and detect fraud
+* [Validate: Is this actually fraud?](/docs/usage/fraud-response-guide/validate.md): Learn how to identify and distinguish between different types of fraud activity on your Twilio account, including SMS pumping, toll fraud, account takeover, vishing, and smishing.
+* [Fraud & Abuse Response Guide](/docs/usage/fraud-response-guide.md): Learn how to quickly identify, contain, and remediate fraud or abuse on your Twilio account with this practical phase-based incident response guide.
+* [Example: RCA Summary Request Form](/docs/usage/fraud-response-guide/example-rca-summary-request-form.md): See an example of a completed Root Cause Analysis (RCA) summary request form for reporting and resolving fraud incidents on your Twilio account.
+* [Engage: Contact Twilio Support](/docs/usage/fraud-response-guide/engage.md): Learn when and how to contact Twilio Support during a fraud incident, including account suspension reasons, reactivation steps, and general assistance options.
+* [Diagnose: Root Cause Analysis (RCA)](/docs/usage/fraud-response-guide/diagnose.md): Learn how to perform a Root Cause Analysis (RCA) to identify and resolve fraud incidents on your Twilio account.
+* [Contain: Immediate Countermeasures](/docs/usage/fraud-response-guide/contain.md): Learn how to contain fraud on your Twilio account with immediate countermeasures including Auth Token rotation, API key deletion, 2FA enablement, geo permission restrictions, and subaccount suspension.
+* [Analyze: Investigate](/docs/usage/fraud-response-guide/analyze.md): Learn how to investigate fraud events on your Twilio account by reviewing log sources including Monitor Events, messaging logs, call logs, error codes, and Verify logs.
+* [Job Resource](/docs/usage/bulkexport/job.md): Full API reference for the Job resource in the BulkExport API. Learn how to fetch (get) and delete a Job.
+* [Bulk Export API overview](/docs/usage/bulkexport.md): An overview of the BulkExport API, which helps you retrieve all of your activity logs from Twilio's platform on an ongoing or one-off basis.
+* [ExportConfiguration resource](/docs/usage/bulkexport/exportconfiguration.md): Full API reference for the ExportConfiguration resource in the BulkExport API. Learn how to fetch (get) and update (post) an ExportConfiguration resource
+* [Export Custom Job Resource](/docs/usage/bulkexport/export-custom-job.md): API reference for the Export Custom Job Resource. Custom Jobs allow you to create exports for any date range.
+* [Day Resource](/docs/usage/bulkexport/day.md): A full reference for the Day Resource of the BulkExport API and code samples for how to fetch an exported day file and a list of exported days.
+* [REST API: UsageTrigger](/docs/usage/api/usage-trigger.md): Full API reference for the UsageTrigger resource in the Twilio API. Learn how to create, fetch (get), read (list), and update Usage Triggers for your account.
+* [REST API: Usage Records](/docs/usage/api/usage-record.md): REST API resources for retrieving usage by your Twilio account during any period, by any usage category.
+* [Twilio API overview](/docs/usage/api.md): Learn how to authenticate your requests to the Twilio APIs, what content type to use for API requests, and how the Twilio APIs handle webhooks.
+* [REST API: Applications](/docs/usage/api/applications.md): Full API reference for the Application Resource (also called a "TwiML App") in Twilio's Voice REST API.
+* [REST API: Addresses](/docs/usage/api/address.md): An Address instance resource represents your or your customer's physical
+  location within a country.
+* [Webhooks security](/docs/usage/webhooks/webhooks-security.md): Learn how to secure your web application that uses Twilio webhooks by verifying the sender of the webhook. This guide also covers other common security practices for Twilio webhooks, such as HTTPS and authentication.
+* [Webhooks Overview](/docs/usage/webhooks/webhooks-overview.md): Overview of the various webhooks that Twilio can send to web applications, including what webhooks are, and how you can respond to them.
+* [Webhooks FAQ](/docs/usage/webhooks/webhooks-faq.md): Commonly asked questions about Twilio webhooks and status callbacks, including what webhooks are, how to validate webhooks, and how to respond to webhooks.
+* [Webhooks (HTTP callbacks): Connection Overrides](/docs/usage/webhooks/webhooks-connection-overrides.md): Webhook URL Connection Overrides
+* [Voice Webhooks](/docs/usage/webhooks/voice-webhooks.md): Learn how to work with webhooks from Twilio Programmable Voice to process events in your web application. Set your project up to receive HTTPS callbacks from Twilio when important events occur, such as an inbound voice call to your Twilio phone number.
+* [Messaging Webhooks](/docs/usage/webhooks/messaging-webhooks.md): Learn how to use webhooks to process events in your Twilio Programmable Messaging application. You can use Twilio webhooks to handle incoming messages as well as tracking delivery status on outbound messages.
+* [Webhooks: an Introduction](/docs/usage/webhooks.md): Launching point for information about Twilio webhooks, including product-specific guides, tutorials, and getting started information.
+* [Getting Started with Twilio Webhooks](/docs/usage/webhooks/getting-started-twilio-webhooks.md): Get started using Twilio webhooks with this step-by-step guide that tells you what you need to do to process incoming callbacks from Twilio servers.
+* [How to use ngrok with Windows and Visual Studio to test webhooks](/docs/usage/tutorials/how-use-ngrok-windows-and-visual-studio-test-webhooks.md): This guide shows you ngrok, a tool to prototype websites locally, working harmoniously with Visual Studio and IIS Express on Windows.  Follow along!
+* [Get started with your Twilio free trial account](/docs/usage/tutorials/how-to-use-your-free-trial-account.md): Start building with a Twilio trial account. Verify phone numbers, get a Twilio phone number, and learn about trial account restrictions and limitations.
+* [Set up your Python and Flask development environment](/docs/usage/tutorials/how-to-set-up-your-python-and-flask-development-environment.md): Guide to setting up Python for web development with the Flask web framework. Use pip   to manage packages, virtual environments for isolation, and ngrok to publish. &#x20;
+* [Set up your PHP development environment](/docs/usage/tutorials/how-to-set-up-your-php-development-environment.md): Learn how to set up PHP for web development using vanilla PHP. Manage dependencies with Composer and expose your local development machine to the Internet with ngrok.
+* [Set up your Node.js and Express development environment](/docs/usage/tutorials/how-to-set-up-your-node-js-and-express-development-environment.md): Learn how to set up Node.js for web development using the Express web app framework. Manage dependencies with npm and use ngrok to expose your dev server.
+* [Set up a your Java development environment](/docs/usage/tutorials/how-to-set-up-your-java-development-environment.md): Get your local Java development environment ready-to-go starting with installing a Java distribution, then a build tool, then a Twilio app.&#x20;
+* [Set up your C# and ASP.NET MVC development environment](/docs/usage/tutorials/how-to-set-up-your-csharp-and-asp-net-mvc-development-environment.md): Learn how to set up C# for web development using the ASP.NET Core MVC web app framework. Expose your local development machine to the Internet with ngrok.
+* [Secure your Flask App by Validating Incoming Twilio Requests](/docs/usage/tutorials/how-to-secure-your-flask-app-by-validating-incoming-twilio-requests.md): Secure the views in your Flask application which accept incoming requests from Twilio. Use the Twilio Python SDK's request validator utility to confirm incoming requests to your views genuinely originated from Twilio.
+* [Secure your Express app by validating incoming Twilio requests](/docs/usage/tutorials/how-to-secure-your-express-app-by-validating-incoming-twilio-requests.md): Secure the views in your Express application which accepts incoming requests from Twilio. Use the Twilio Node SDK's webhook middleware to confirm incoming requests to your views genuinely originated from Twilio.
+* [Secure your C# / ASP.NET Core app by validating incoming Twilio requests](/docs/usage/tutorials/how-to-secure-your-csharp-aspnet-core-app-by-validating-incoming-twilio-requests.md): Secure the actions in your C# / ASP.NET Core application which accepts incoming requests from Twilio. Use the Twilio C# SDK's request validator utility to confirm incoming requests to your views genuinely originated from Twilio.
+* [Secure your C# / ASP.NET app by validating incoming Twilio requests](/docs/usage/tutorials/how-to-secure-your-csharp-aspnet-app-by-validating-incoming-twilio-requests.md): Secure the actions in your C# / ASP.NET application which accepts incoming requests from Twilio. Use the Twilio C# SDK's request validator utility to confirm incoming requests to your views genuinely originated from Twilio.
+* [How To Make REST API Requests in PowerShell](/docs/usage/tutorials/how-to-make-http-basic-request-twilio-powershell.md): We'll show Powershell's Invoke-WebRequest making a REST API request to an HTTP Basic Authentication protected endpoint to send an outbound SMS text message.
+* [A Beginner's Guide to the Command Line](/docs/usage/tutorials/a-beginners-guide-to-the-command-line.md): Learn all about shells, files, directories, arguments, and useful commands in this beginner's guide to the Command Line. Includes a sample script to send SMS.&#x20;
+
+## Global Infrastructure
+
+* [Using the Twilio REST API in a non-US Region](/docs/global-infrastructure/using-the-twilio-rest-api-in-a-non-us-region.md): Learn how to use the Twilio REST API in the Region of your choice.
+* [Use the Programmable Voice JavaScript SDK with a non-US Twilio Region](/docs/global-infrastructure/use-the-programmable-voice-javascript-sdk-with-a-non-us-twilio-region.md): Learn to integrate your Twilio Voice-powered web application with our Australia (AU1) Region.
+* [Twilio Regions](/docs/global-infrastructure/understanding-twilio-regions.md): Learn about the data centers around the world where Twilio performs processing and storage.
+* [Understanding Edge Locations](/docs/global-infrastructure/understanding-edge-locations.md): Learn how Twilio Edge Locations work. Interconnect and Voice/SIP customers can select their edge location. For REST API requests, the CDN selects the optimal edge automatically — the hostname determines your processing region.
+* [Regional SIP Trunks](/docs/global-infrastructure/regional-sip-trunks.md): Learn how to control which Region is used for processing and storage of your Twilio Elastic SIP Trunking traffic.
+* [Regional SIP Domains](/docs/global-infrastructure/regional-sip-domains.md): Learn how to control which Region is used for processing and storage of your Twilio SIP Domain traffic.
+* [Regional product availability](/docs/global-infrastructure/regional-product-and-feature-availability.md): These products and features are available in Twilio Regions around the world.
+* [Migrating your application to a new Region](/docs/global-infrastructure/migrating-your-application-to-a-new-region.md): Learn how to migrate your existing Twilio-powered application to a new Twilio Region.
+* [Managing Regional Resources in Console](/docs/global-infrastructure/managing-regional-resources-in-console.md): Learn to manage Region-specific resources using Twilio Console.
+* [Global Infrastructure](/docs/global-infrastructure.md): Optimize your application performance and control data residency using Twilio Edge Locations and Regions.
+* [Set a phone number's inbound processing Region using the Console](/docs/global-infrastructure/inbound-processing-console.md): Learn how to control the Region used for processing inbound calls using the Twilio Console.
+* [Set a phone number's inbound processing Region using the REST API](/docs/global-infrastructure/inbound-processing-api.md): Learn how to control the Region used for processing inbound calls using the Twilio REST API.
+* [Inbound Call Processing](/docs/global-infrastructure/inbound-call-processing.md): Learn how to select the processing and storage Region for inbound calls
+* [Make an outbound phone call via REST API in a non-US Twilio Region](/docs/global-infrastructure/create-an-outbound-call-via-rest-api-in-a-non-us-twilio-region.md): Follow this quickstart to learn how to initiate a call using Twilio's Ireland (IE1) Region.
+* [Termination](/docs/global-infrastructure/localized-uris/termination.md): List of public SIP Trunk Termination URI domains for each Twilio Edge Location
+* [SIP URIs](/docs/global-infrastructure/localized-uris/sip-uris.md): List of public SIP URI domains for each Twilio Edge Location
+* [Twilio Programmable Voice SIP Domains Regional Migration Best Practices](/docs/global-infrastructure/localized-uris/sip-domains-regional-migration-best-practices.md): Learn best practices for migrating your Programmable Voice SIP Domains to a new Twilio Region.
+* [General Twilio Voice Regional Migration Best Practices](/docs/global-infrastructure/localized-uris/regional-migration-best-practices.md): Learn best practices for migrating your Voice solutions to a new Twilio Region.
+* [Twilio Elastic SIP Truking Regional Migration Best Practices](/docs/global-infrastructure/localized-uris/elastic-sip-trunk-regional-migration-best-practices.md): Learn best practices for migrating your Elastic SIP Trunks to a new Twilio Region.
+* [Legacy Edge Location IDs](/docs/global-infrastructure/edge-locations/legacy-regions.md): Mapping of deprecated Twilio edge location IDs (au1, ie1, us2, etc.) to current Edge Location names (sydney, dublin, umatilla, etc.)
+* [Edge Locations](/docs/global-infrastructure/edge-locations.md): Reference list of all Twilio Edge Location IDs for public internet and private Interconnect connections.
+* [Media Streams Configuration](/docs/global-infrastructure/firewall-configurations/media-streams-configuration.md): Firewall configuration information for Voice Media Streams traffic
+* [Firewall Configurations](/docs/global-infrastructure/firewall-configurations.md): Find firewall configuration information for Twilio Voice traffic
+
+## Glossary
+
+* [What is Voice Trace?](/docs/glossary/what-voice-trace.md): Voice trace is a voice quality troubleshooting feature that captures the media stream for calls and stores them for Twilio Support to use in their investigations. 
+* [What is a Virtual Phone Number?](/docs/glossary/what-virtual-phone-number.md): A virtual phone number is a standard telephone number that is not locked down to a specific phone. A virtual number can route a voice call or text message to any phone or workflow. With virtual numbers powered by an API, complex software workflows can be built that are triggered by calls and texts.
+* [What is UTF-8?](/docs/glossary/what-utf-8.md): UTF-8 is a variable-width character encoding standard that uses between one and four eight-bit bytes to represent all valid Unicode code points.
+* [What is an SMS tracker?](/docs/glossary/what-sms-tracker.md): An SMS tracker is software that uncovers detailed information about the delivery and content of text and picture messages. It allows anyone to analyze an individual message or group of messages to see delivery patterns, encoding details, and error conditions.
+   
+* [How long can a message be?](/docs/glossary/what-sms-character-limit.md): The number of characters that a service can transmit varies according to the service protocol and character encoding.
+* [What is a Long Code?](/docs/glossary/what-long-code-phone-number.md): A long code number is a standard phone number used to send and receive voice calls and SMS messages. Phone numbers are typically called "long codes" (10-digit numbers in many countries) when comparing them with SMS short codes (5-6 digit numbers).
+* [What is VoIP (Voice Over IP)?](/docs/glossary/what-is-voip.md): Voice Over Internet Protocol (VoIP) is a category of hardware and software that enables voice calls to be made and received over the internet.
+* [What is a Voice API?](/docs/glossary/what-is-voice-api.md): A PSTN) and applications connected to the internet. By using a voice API, software developers can program voice calling into their applications without specialized telecommunications knowledge and hardware.
+* [What is Unicode?](/docs/glossary/what-is-unicode.md): Unicode is an international character encoding standard that provides a unique number for every character across languages and scripts, making almost all characters accessible across platforms, programs, and devices.
+* [What is UCS-2 Character Encoding?](/docs/glossary/what-is-ucs-2-character-encoding.md): UCS-2 is a character encoding standard in which characters are represented by a fixed-length 16 bits (2 bytes).  It is used as a fallback on many GSM networks when a message cannot be encoded using GSM-7 or when a language requires more than 128 characters to be rendered.
+* [What is Two Factor Authentication?](/docs/glossary/what-is-two-factor-authentication-2fa.md): Two-factor authentication (commonly abbreviated 2FA) adds an extra layer of security to your user's account login by requiring two types of authentication. This is usually something your user knows and something they have.
+* [What is the Twilio Markup Language (TwiML)?](/docs/glossary/what-is-twilio-markup-language-twiml.md): TwiML, or the Twilio Markup Language, is an XML based language which instructs Twilio on how to handle various events such as incoming and outgoing calls, SMS messages and MMS messages.  When building a Twilio application you will use TwiML when communicating your desired actions to Twilio.
+* [What is Toll Fraud?](/docs/glossary/what-is-toll-fraud.md): Toll fraud, also known as International Revenue Sharing Fraud (IRSF), happens when an application is exploited to generate a high volume of voice calls to the fraudster's own international premium rate numbers. The victim of the toll fraud bears the entire financial responsibility for each minute of the call.
+* [What is the Telephone Consumer Protection Act (TCPA)?](/docs/glossary/what-is-telephone-consumer-protection-act-tcpa.md): The TCPA (Telephone Consumer Protection Act) is a federal statute enacted in 1991 designed to safeguard consumer privacy. This legislation restricts telemarketing communications via voice calls, SMS texts, and fax.
+* [What is SMS Pumping Fraud?](/docs/glossary/what-is-sms-pumping-fraud.md): SMS pumping fraud happens when fraudsters take advantage of a phone number input field to receive a one-time passcode, an app download link, or anything else via SMS. The messages are sent to a range of numbers controlled by a specific mobile network operator (MNO) and the fraudsters get a share of the generated revenue. 
+* [What is SMS Delivery or Deliverability?](/docs/glossary/what-is-sms-delivery-deliverability.md): SMS Delivery is a measure of the percentage of outgoing SMS and MMS messages which are received at their intended destination.  While sometimes referring to the status of a single message, SMS delivery usually is a rate of delivered versus intended messages and summarized as an 'SMS Delivery Rate.'
+* [What is an SMS API?](/docs/glossary/what-is-sms-api-short-messaging-service.md): A SMS API is well-defined software interface which enables code to send SMS Gateway.
+  As the infrastructures for SMS communications and the internet are mostly divided, SMS APIs are often used to 'bridge the gap' between telecommunications carrier networks and the wider web.  SMS APIs are used to allow web applications to send and receive text messages through logic written for standard web frameworks.
+* [What is SIP Trunking?](/docs/glossary/what-is-sip-trunking.md): What is SIP Calling?
+  SIP (Session Initiation Protocol) trunking refers to phone calls that are routed over the Internet rather than traditional phone lines. SIP calling, therefore, refers to the act of placing calls via a SIP trunk. Because SIP calls take place across the Internet, they tend to be cheaper and more efficient than calls placed through traditional phone systems.
+  Physical connections to a phone company are eliminated with the use of a SIP trunk. Using SIP trunks, a SIP provider can connect multiple channels to your private branch exchange (Voice-over-IP (VoIP) infrastructure.
+* [What is Session Initiation Protocol (SIP)?](/docs/glossary/what-is-session-initiation-protocol-sip.md): Session Initiation Protocol (SIP) is a signalling protocol for initiating, terminating, and modifying user sessions over an IP network.  Most commonly, SIP is used for Voice Over IP (VoIP) services, but is also often used for other communications sessions such as video calls and instant messaging sessions.
+* [What is a Push Notification?](/docs/glossary/what-is-push-notification.md): A push notification (also known as a server push notification) is the delivery of information to a computing device from an application server where the request for the transaction is initiated by the server rather than by an explicit request from the client. While 'push notification' is most often used to refer to notifications on mobile devices, web applications also leverage this technology.
+* [What is Personally Identifiable Information (PII)?](/docs/glossary/what-is-personally-identifiable-information-pii.md): Any data of a degree of specificity that it can locate, identify, or contact a single person. This data includes phone numbers, national ID numbers, and email addresses. It covers any data that can be used, either on its own or with combined with other data, to contact, identify, or locate a person.
+* [What is a Private Branch Exchange (PBX)?](/docs/glossary/what-is-pbx-private-branch-exchange.md): PBX, short for Private Branch Exchange, is a phone system in an enterprise that manages incoming and outgoing phone calls as well as an organization's internal communications.
+* [What is an MMS?](/docs/glossary/what-is-mms.md): MMS, short for Multimedia Messaging Service, is a standard way to send multimedia such as pictures, videos, and other attachments over text messaging channels.
+* [What is a Mean Opinion Score (MOS)?](/docs/glossary/what-is-mean-opinion-score-mos.md): A Mean Opinion Score (MOS) is a numerical measure of the human-judged overall quality of an event or experience.  In telecommunications, a Mean Opinion Score is a ranking of the quality of voice and video sessions.
+  Most often judged on a scale of 1 (bad) to 5 (excellent), Mean Opinion Scores are the average of a number of other human-scored individual parameters.  Although originally Mean Opinion Scores were derived from surveys of expert observers, today a MOS is often produced by an Objective Measurement Method approximating a human ranking.
+* [Masked Calling](/docs/glossary/what-is-masked-calling.md): Masked Calling is a technique used in ecommerce to protect buyers' and sellers' personal phone numbers. Each party gets a temporary number, allowing them to communicate for a specified time period. When the time period expires, the numbers are recycled and reassigned to other parties on the platform. This prevents transactions from happening outside the platform. 
+* [What is Live Chat?](/docs/glossary/what-is-live-chat.md): Live chat is a type of online chat distinguished by its simplicity and user accessibility. Live chat appears in a web browser or in mobile applications, usually via a small pop-up modal through which the visitor can exchange text messages with a chat operator in real time.
+* [What is Latency?](/docs/glossary/what-is-latency.md): Latency is the time delay between the initiation of an event and its perception by some observer. In networking and telecommunications, latency is the time between a sender causing a change in a system's state and its reception by an observer. Network latency is often informally used interchangeably with lag.
+* [Interactive Voice Response (IVR)](/docs/glossary/what-is-ivr.md): Interactive voice response (IVR), also known as a phone tree, provides an automated telephony system for callers using voice and touch-tones (DTMF).
+* [What is GSM-7 character encoding?](/docs/glossary/what-is-gsm-7-character-encoding.md): The original assignment of 128 alphanumeric characters accepted and displayed in text messages to numerical values for transmission across mobile networks.
+* [What are DTMF Tones?](/docs/glossary/what-is-dtmf.md): DTMF, or Dual-Tone Multi-Frequency tones, are in-band telecommunications signals sent over voice frequencies.  Commonly used over telephone lines, DTMF tones are also commonly called Touch Tones.
+* [What is Click-to-Call?](/docs/glossary/what-is-click-to-call.md): Click-to-call, sometimes called click-to-talk or click-to-dial, is a way to let people connect with a company representative by phone while they're browsing a website or in an app.
+* [What is Call Transcription?](/docs/glossary/what-is-call-transcription.md): Call transcription is the conversion of a voice or video call audio track into written words to be stored as plain text in a conversational language. Call transcription can either be live - as a call or event happens - or based on the recording of a past conversation.
+* [What is Call Routing?](/docs/glossary/what-is-call-routing.md): Call routing refers to the procedure of sending voice calls to a specific queue based on predetermined criteria. A call routing system is also known as an automatic call distributor (ACD).
+* [Basic Authentication](/docs/glossary/what-is-basic-authentication.md): Basic Authentication is a method for an HTTP user agent (e.g., a web browser) to provide a username and password when making a request.
+* [Artificial Intelligence](/docs/glossary/what-is-artificial-intelligence.md): Artificial Intelligence (AI) is the ability of a computer to mimic human cognitive skills, such as learning and understanding.
+* [What is an SMS?](/docs/glossary/what-is-an-sms-short-message-service.md): The text messaging service that telephone, internet, and mobile devices use.
+* [API](/docs/glossary/what-is-an-api.md): An Application Programming Interface (API) is provided by a service owner so that others may use the features and functions enabled by the service. APIs describe how a consumer will make requests of the service, and what they will receive in return.
+* [API Key](/docs/glossary/what-is-an-api-key.md): An Application Programming Interface (API) Key is a unique identifier that is used to authenticate a developer or program to an API.
+* [Ahoy!](/docs/glossary/what-is-ahoy.md): Ahoy, a signal word originally used to call a ship, was once a standard way to greet others and was Alexander Graham Bell's suggested greeting for answering the telephone.
+* [What is a Webhook?](/docs/glossary/what-is-a-webhook.md): An event-driven communication that sends data between apps using custom HTTP POST request to a URL.
+* [What is an SMS Gateway?](/docs/glossary/what-is-a-sms-gateway.md): An SMS Gateway enables a computer to send and receive SMS text messages to and from a SMS capable device over the global telecommunications network (normally to a mobile phone). The SMS Gateway translates the message sent, and makes it compatible for delivery over the network to be able to reach the recipient.
+* [What is a String Identifier (SID)?](/docs/glossary/what-is-a-sid.md): A unique key string that Twilio uses to identify specific resources.
+* [What's an SMS Short Code?](/docs/glossary/what-is-a-short-code.md): A numeric sender ID used for text messaging containing fewer digits than typical phone numbers.
+* [What is a Call Center?](/docs/glossary/what-is-a-call-center.md): A call center is the heart of customer service for many businesses, where customers call in for help and reps call out for sales. It's referred to as a call center because traditional models of customer service are based on phone support as the main method of contact between customers and companies. A modern call center is often referred to as a contact center.
+* [What is E.164?](/docs/glossary/what-e164.md): A numbering plan standard that provides a globally unique number for each device on the PSTN. These devices can then route phone calls and text messages to individual devices in different countries.
+* [What is Direct Inward Dialing (DID)?](/docs/glossary/what-direct-inward-dialing-did.md): Direct Inward Dialing (DID) is a telephone service that allows a phone number to ring through directly to a specific phone at a business instead of going to a menu or a queue and needing to dial an extension. A phone number that is used like this is often called a "DID" (and multiple numbers are called "DIDs").
+* [What are WebSockets?](/docs/glossary/what-are-websockets.md): A WebSocket is a persistent bi-directional communication channel between a client (e.g. a browser) and a backend service. In contrast with HTTP request/response connections, websockets can transport any number of protocols and provide server-to-client message delivery without polling.
+* [What are SMS Notifications?](/docs/glossary/what-are-sms-notifications.md): SMS Notifications are out-of-band text messages sent in response to events or transactions which occur somewhere else. While often used as a marketing tool to increase the percentage of returning visitors, SMS notifications are very useful for organization and public safety purposes as well.
+* [What are Masked Phone Numbers?](/docs/glossary/what-are-masked-phone-numbers.md): Masked Phone Numbers are a common pattern to anonymize communication between multiple parties and hide participant phone numbers. Instead of dialing directly from phone to phone, users communicate via a third ('proxy') phone number that forwards a call to the eventual destination. 
+* [Alphanumeric Sender ID](/docs/glossary/what-alphanumeric-sender-id.md): Your company name or brand displayed as the sender ID for one-way text messaging.
+* [Application-to-Person Messaging](/docs/glossary/what-a2p-sms-application-person-messaging.md): Application-to-Person messaging (A2P) is any kind of message traffic in which a person is receiving messages from an application rather than another individual, and which is not expected to receive a reply. A2P message includes, but is not limited to, marketing communications, appointment reminders, chatbots, notifications, and one-time passwords (OTPs) or PIN codes.
+* [What is a Time-based One-time Password (TOTP)?](/docs/glossary/totp.md): A standardized algorithm that uses the current time as an input and generates unique numeric passwords.
+* [SIP INVITEs](/docs/glossary/sip-invites.md): A SIP INVITE is a SIP request message that initiates a SIP call. 
+   
+  A SIP INVITE is made up of lines of text. The first line in an INVITE is called a Request-Line, which is followed by more lines of text called headers. The headers contain information about the INVITE, such as the identity of the caller, whether the INVITE was forwarded before being sent to the recipient, and the number of times a call may be forwarded. 
+* [What are North American Area Codes?](/docs/glossary/north-american-area-codes.md): North American Area Codes are prefixed to a phone number to assist in routing phone calls in North America. The North American Numbering Plan (NANP) dictates the regional and non-geographic area codes assigned to signatory countries. The United States, Canada, some Caribbean countries, and all US territories are covered by the plan.
+* [Glossary](/docs/glossary.md): A repository of the technical terms and jargon intrepid Twilio developers may encounter on their building journey.
+* [CPS](/docs/glossary/cps.md): Calls per second
+* [What is Call Whisper?](/docs/glossary/call-whisper.md): Call Whisper, also commonly referred to as Call Screening, involves playing a message to the callee while the caller continues to hear ringing. It can provide additional information such as the source or purpose of the call to the callee before the call begins and even allow the callee to accept or reject the call based on that information.
+
+## Identity and Access Management (IAM)
+
+* [Test Credentials](/docs/iam/test-credentials.md): REST API resources for working with Twilio's test credentials.
+* [Identity and Access Management (IAM)](/docs/iam.md): Learn about Identity and Access Management (IAM) in your Twilio applications: securely control access to your Twilio projects, authenticate your applications, and dig into best practices in these docs.
+* [Credentials PublicKey Resource](/docs/iam/credentialpublickey-resource.md): Full API reference for the CredentialPublicKey resource in the Twilio API. Learn how to create, fetch (get), read (list), update, and delete Public Keys for your Twilio account.
+* [Access Tokens](/docs/iam/access-tokens.md): Create short-lived Access Tokens to authenticate Twilio client-side SDKs like Voice, Conversations, and Video.
+* [Okta SCIM integration](/docs/iam/scim/okta-integration.md): Learn how to configure user synchronization from Okta to Twilio using SCIM provisioning.
+* [SCIM API reference](/docs/iam/scim/api-reference.md): Complete API reference for the Twilio SCIM API, including endpoints for creating, retrieving, updating, and deactivating users.
+* [Single Sign On](/docs/iam/single-sign-on.md): This document describes the SSO (single sign-on) capabilities supported by Twilio and necessary steps for integrating with your Identity Provider (IdP).
+* [Configuring SSO with any other SAML2.0 Identity Provider](/docs/iam/single-sign-on/configuring-sso-with-other-saml2-idp.md): This guide covers configuring your SAML 2.0 Identity Provider with Twilio for SSO login to Twilio Console.
+* [Configuring Okta with Twilio SSO](/docs/iam/single-sign-on/configuring-okta-with-twilio-sso.md): Learn how to configure Okta to work with Twilio in this step-by-step guide.
+* [Configuring Azure Active Directory with Twilio SSO](/docs/iam/single-sign-on/configuring-azure-active-directory-with-twilio-sso.md): Learn how to configure Azure Active Directory to work with Twilio SSO in this step-by-step guide.
+* [Managed Users](/docs/iam/organizations/managed-users.md): Learn about managed users, how they can help your organization, and how to create, view, and delete them.
+* [Managed Accounts](/docs/iam/organizations/managed-accounts.md): Learn about Managed Accounts, how they can help your organization, and how to create, add, and configure them.
+* [Organizations](/docs/iam/organizations.md): An Organization is a resource that helps you manage all of your company's Twilio accounts. Learn how to centrally manage all of your accounts, users, and configure your Organization-wide policies.
+* [Domains](/docs/iam/organizations/domains.md): Learn how to associate your Organization with one or more internet domains that you own. Follow instructions to add a domain or import users that signed up with your domain.
+* [OAuth apps](/docs/iam/oauth-apps/overview.md): This document describes how to create an OAuth app and use its credentials to access Twilio APIs. OAuth apps enable OAuth 2.0 authorization for Twilio APIs using the client credentials grant type.
+* [OAuth Token API](/docs/iam/oauth-apps/oauth-access-token.md): This document describes how to use Token API endpoint to generate Access Tokens. It also covers example of how to call Messaging API using the access token.
+* [OAuth apps FAQs](/docs/iam/oauth-apps/faqs.md): This document describes the Frequently Asked Questions (FAQs) related to OAuth apps.
+* [Public Key Client Validation Quickstart](/docs/iam/pkcv/quickstart.md): Learn how to implement Public Key Client Validation with Twilio. Includes sample cURL commands, HTTP requests, and a Java example.
+* [Get Started with Public Key Client Validation](/docs/iam/pkcv.md): Public Key Client Validation helps organizations in compliance-heavy industries meet strict security requirements. Learn how to get started in this overview.
+* [REST API: Connect Apps](/docs/iam/connect-apps/api.md): API reference for the ConnectApps list resource.
+* [Twilio Connect](/docs/iam/connect.md): Let your users authorize access to their accounts with Twilio Connect so your application can buy phone numbers, make calls, send SMS, and access log data.
+* [REST API: Credentials](/docs/iam/credentials/api.md): Learn the basics of the Credentials REST API, which allows you to upload Public Keys to Twilio and manage them.
+* [REST API: Authorized Connect Apps](/docs/iam/authorized-connect-apps/api.md): API reference for the AuthorizedConnectApps list resource which shows all of the Connect Apps that you have authorized for your account.
+* [Restricted API keys](/docs/iam/api-keys/restricted-api-keys.md): Leverage role-based access control (RBAC) with Twilio's Restricted API keys. Grant granular API permissions for Twilio APIs.
+* [Create API keys in the Twilio Console](/docs/iam/api-keys/keys-in-console.md): Authenticate your requests to Twilio's APIs with API keys. Create and manage API keys in the Twilio Console.
+* [REST API: Key Resource v2010](/docs/iam/api-keys/key-resource-v2010.md): Full API reference for the API Key resource in the Twilio API. Learn how to create, fetch (get), read (list), and update API keys to authenticate to the REST API and create and revoke access tokens.
+* [REST API: Key Resource v1](/docs/iam/api-keys/key-resource-v1.md): Full API reference for the Key resource in the Twilio API. Learn how to create, fetch, list, update, and delete API keys.
+* [API keys overview](/docs/iam/api-keys.md): Authenticate your requests to Twilio's APIs with API keys. Keep your Twilio Account credentials safe and take control of the lifecycle of your API keys.
+* [REST API: Secondary Auth Token](/docs/iam/api/secondary_authtoken.md): Full API reference for the Account resource in the Twilio API. Learn how to create, fetch (get), read (list), and update Accounts and Subaccounts.
+* [Our API: the basics](/docs/iam/api.md): Twilio's REST API allows you to query metadata about your account, make phone calls, send text messages, and monitor usage.
+* [REST API: Auth Token](/docs/iam/api/authtoken.md): Learn about the REST API Auth Token, its properties, and how to promote the secondary Auth Token to primary.
+* [REST API: Accounts](/docs/iam/api/account.md): Full API reference for the Account resource in the Twilio API. Learn how to create, fetch (get), read (list), and update Accounts and Subaccounts.
+* [Types of Roles](/docs/iam/access-control/types-of-roles.md): This document describes the different types of roles which are available for user assignment. It has the details of the New RBAC roles, general roles and organization roles.&#x20;
+* [Access Control](/docs/iam/access-control/overview.md): This document describes the new Enhanced RBAC capabilities supported by Twilio and the introduction of new granular roles.
+* [Twilio Connect Python Quickstart](/docs/iam/connect/quickstart/python.md): Learn how to connect your application to Twilio's APIs on behalf of other account holders in this step-by-step quickstart using Python and Flask.
+* [Twilio Connect Java Quickstart](/docs/iam/connect/quickstart/java.md): Learn how to connect your application to Twilio's APIs on behalf of other account holders in this step-by-step quickstart using Java servlets.
+* [REST API: Subaccounts](/docs/iam/api/subaccounts.md): Explore how to use Twilio Subaccounts to segment your Twilio usage and act on behalf of your customers, agents or employees
+
+## Interconnect
+
+* [Interconnect](/docs/interconnect.md): Ensure consistent connectivity between your communication infrastructure and the Twilio platform with Interconnect, a private connection to the Twilio cloud.
+
+## Lookup
+
+* [Using Lookup with Twilio Regions](/docs/lookup/using-lookup-with-twilio-regions.md): Learn how to use Twilio's Lookup API with Regional support to optimize performance and control data residency in this overview.
+* [Lookup v2 Quickstart](/docs/lookup/quickstart.md): Learn how to query phone number and carrier information with Twilio's Lookup v2 API in this Quickstart.
+* [Lookup SIM Swap Overview](/docs/lookup/lookup-sim-swap.md): Learn how to use Twilio's Lookup API SIM Swap feature to get data on if a SIM linked to a phone number has recently changed in this overview.
+* [Lookup](/docs/lookup.md): Improve your message deliverability with Twilio Lookup. Validate numbers, identify carriers, and ensure compliance for accurate and secure messaging.
+* [Lookup v1 Tutorial: Validation and Formatting](/docs/lookup/v1-api/validation-and-formatting.md): Instructions and sample code for using the Lookup API to check the format of an international phone number and validate any phone number in ISO format.
+* [Lookup v1 Quickstart](/docs/lookup/v1-api/quickstart.md): Learn how to query phone number information with Twilio's Lookup API. Identify local-friendly number formats and reduce the likelihood of undelivered messages.
+* [Lookup v1 API](/docs/lookup/v1-api.md): Identify local-friendly number formats, reduce undelivered messages, and protect from scams and spam with Lookup by Twilio.
+* [Lookup v1 Tutorial: Carrier and Caller Name](/docs/lookup/v1-api/carrier-and-caller-name.md): Learn how to use Lookup to identify a phone number's carrier and what type of phone it is in your programming language of choice.
+* [SMS Pumping Risk Score](/docs/lookup/v2-api/sms-pumping-risk.md): Get real-time SMS fraud risk assessments with Twilio's SMS Pumping Risk Score.
+* [SIM Swap](/docs/lookup/v2-api/sim-swap.md): Detect SIM swap fraud with Twilio's Lookup API. Get real-time updates on SIM changes to prevent account takeovers.
+* [Reassigned Number](/docs/lookup/v2-api/reassigned-number.md): Verify phone number ownership with Twilio Lookup's Reassigned Number to prevent TCPA violations and ensure compliance.
+* [Line Type Intelligence](/docs/lookup/v2-api/line-type-intelligence.md): Discover carrier data and phone line types to streamline messaging and connectivity. Ideal for filtering out landlines before sending SMS.
+* [Line Status](/docs/lookup/v2-api/line-status.md): Validate phone number status with Twilio Lookup's Line Status. Enhance data quality and campaign efficiency by detecting number activity.
+* [Lookup v2 API](/docs/lookup/v2-api.md): API reference for the Twilio Lookup API that allows you to query information on a phone number so that you can make a trusted interaction with your user.
+* [Identity Match](/docs/lookup/v2-api/identity-match.md): Use Identity Match to verify phone number ownership by comparing user data with authoritative sources. Available in the US, Brazil, and more.
+* [Formatting and Validation](/docs/lookup/v2-api/formatting-validation.md): Learn how to use Twilio Lookup API's Line Type Intelligence package with this reference.
+* [Caller Name](/docs/lookup/v2-api/caller-name.md): Retrieve caller names and types for US mobile numbers using Twilio Lookup's Caller Name.
+* [Call Forwarding](/docs/lookup/v2-api/call-forwarding.md): Check if a mobile phone number is unconditionally forwarding calls using Twilio Lookup's Call Forwarding.
+
+## Marketplace
+
+* [Marketplace](/docs/marketplace.md): Do more with less code. Marketplace lets you use pre-integrated partner technologies through the Twilio API.
+
+## Network Traversal Service
+
+* [STUN-TURN IP Addresses & Ports](/docs/stun-turn/regions.md): List the static IP addresses for the Twilio STUN and TURN servers. This allows local network configuration and communication or application of routing rules with Twilio.
+* [Network Traversal Service](/docs/stun-turn.md): Deploy more reliable WebRTC communications applications with Twilio's Network Traversal Service, a globally distributed STUN/TURN service.
+* [Frequently Asked Questions](/docs/stun-turn/faq.md): Frequently Asked Questions and troubleshooting tips for working with Twilio's Network Traversal Service
+* [REST API: Network Traversal Service Tokens](/docs/stun-turn/api.md): API reference for NTS Tokens.
+
+## Notify: Multi-Channel Notifications
+
+* [Notify: Multi-Channel Notifications](/docs/notify.md): Reach your users on their preferred channel with just one API call using Notify. Find API reference documentation, quickstarts, and tutorials to help you build great notification experiences across multiple channels.
+
+## OpenAPI
+
+* [OpenAPI](/docs/openapi.md): Learn about building with the Twilio OpenAPI Spec.
+
+## Phone Numbers
+
+* [Pricing: Phone Numbers Resource](/docs/phone-numbers/pricing.md): Twilio's Phone Numbers resource allows users of the Pricing API to view pricing information for Twilio phone numbers in different countries and area codes.
+* [Phone Numbers](/docs/phone-numbers.md): Twilio's virtual phone numbers give you instant access to local, national, mobile, and toll-free phone numbers in over 100 countries for your voice call and messaging applications.
+* [Best Practices for Phone Number Use](/docs/phone-numbers/best-practices.md): Learn about best practices for using Twilio Phone Numbers, including buying, upgrading, and releasing numbers.
+* [Letter of Authorization (LOA) Template](/docs/phone-numbers/regulatory/letter-authorization-loa-template.md): A templated example of a Letter of Authorization (LOA) requesting authorization for inbound customer calls made to your business' Customer Support.
+* [Phone Number Regulatory FAQ](/docs/phone-numbers/regulatory/faq.md): Learn about Twilio Phone Number regulations, what you need to do to stay compliant, and why.
+* [Hosted Number Orders - API Quickstart](/docs/phone-numbers/hosted-numbers/quickstart.md): Get started with the Hosted Number Orders API and learn how to verify number ownership, create and sign an LOA, and configure your Hosted Number.
+* [Hosted Numbers FAQ](/docs/phone-numbers/hosted-numbers.md): Find answers to frequently asked questions about Hosted SMS, which lets you to use Programmable SMS with your existing US & Canada phone numbers.
+* [Global Phone Numbers Catalog](/docs/phone-numbers/global-catalog.md): The Global Phone Numbers Catalog gives you access to our full suite of available phone numbers, featuring numbers tailored to specific use cases.
+* [Phone Numbers](/docs/phone-numbers/api.md): Find relevant links for working with Twilio's Phone Numbers REST API on this page.
+* [IncomingPhoneNumber resource](/docs/phone-numbers/api/incomingphonenumber-resource.md): Full API reference for the Incoming Phone Number resource in the Twilio API. Learn how to create, fetch (get), read (list), update, and delete IncomingPhoneNumbers.
+* [AvailablePhoneNumber Local resource](/docs/phone-numbers/api/availablephonenumberlocal-resource.md): Search for Twilio phone numbers available for purchase in a specific geographic location.
+* [AvailablePhoneNumber TollFree resource](/docs/phone-numbers/api/availablephonenumber-tollfree-resource.md): A full API reference for the AvailablePhoneNumber TollFree resource, including code samples.
+* [AvailablePhoneNumber resource](/docs/phone-numbers/api/availablephonenumber-resource.md): Full reference for the AvailablePhoneNumber resource in the Phone Numbers API, with properties and sample code showing how to find supported countries.
+* [AvailablePhoneNumber Mobile resource](/docs/phone-numbers/api/availablephonenumber-mobile-resource.md): A full reference for the AvailablePhoneNumber Mobile resource with code samples to find mobile numbers by region.
+* [Regulatory Compliance REST APIs](/docs/phone-numbers/regulatory/api.md): View the resources available to be leveraged with the new v2 Regulatory Compliance platform.
+* [Bundles Resource](/docs/phone-numbers/regulatory/api/bundles.md): Full API reference for the Twilio API Regulatory Compliance Bundle resource: create, fetch, read, and update your Bundle.
+* [How to Find a BU SID or an AD SID](/docs/phone-numbers/regulatory/getting-started/how-find-bu-sid-or-ad-sid.md): Follow this guide to find an ID for an identity document bundle (BU) or address (AD) in your account.
+* [Console: Getting Started with Phone Number Regulatory Compliance](/docs/phone-numbers/regulatory/getting-started/console-create-new-bundle.md): Learn how to make sure your phone numbers are compliant with local regulators' requirements by following this step-by-step guide and the Twilio Console.
+* [Hosted Number Order Resource](/docs/phone-numbers/hosted-numbers/hosted-numbers-api/hosted-number-order-resource.md): Full API reference for the Hosted Number Order resource in the Twilio Hosted Numbers API. Sample code shows how to create, read fetch, update, and delete.
+* [REST API: Available Numbers](/docs/phone-numbers/global-catalog/api/available-numbers.md): Learn more about the Available Numbers endpoint that provides a rich view into Twilio's inventory of phone numbers available for purchase.
+
+## Programmable Chat
+
+* [Programmable Chat](/docs/chat.md): Twilio Programmable Chat API allows you to embed chat functionality in any of your apps with SDKs for iOS (Swift and Objective-C), Android (Java), and web (JavaScript).
+
+## Programmable Messaging
+
+* [Programmable Messaging](/docs/messaging.md): Everything you need to get started sending SMS and WhatsApp messages with Programmable Messaging. Quickstarts, sample code, & tutorials for many use cases. SDKs in popular web languages and examples and API Reference documentation.
+* [TwiML™ Message: \<Message>](/docs/messaging/twiml/message.md): Follow sample code to learn how to programmatically send a message to a phone number with the \<Message> verb for Programmable Messaging.
+* [TwiML™ for Programmable Messaging](/docs/messaging/twiml.md): Learn how Twilio uses the TwiML markup language to talk to your Programmable SMS applications.
+* [No-code SMS quickstart with Twilio Studio](/docs/messaging/quickstart/no-code-sms-studio-quickstart.md): Learn how to use Twilio Studio to send SMS text messages without using code.
+* [SMS developer quickstart](/docs/messaging/quickstart.md): This developer quickstart teaches you how to send and receive text messages with Twilio programmatically. Choose the language of your preference and start building with Twilio Programmable SMS.
+* [Programmable Messaging Onboarding](/docs/messaging/onboarding.md): Learn how to plan and build your Programmable Messaging application
+* [Traffic Optimization Engine](/docs/messaging/features/traffic-optimization-engine.md): Traffic Optimization Engine is a throughput allocation platform for Messaging customers to send high-speed, high-volume messages anywhere in the world.
+* [SMS Pumping Protection for Programmable Messaging](/docs/messaging/features/sms-pumping-protection-programmable-messaging.md): Use SMS Pumping Protection for Programmable Messaging to prevent SMS pumping fraud. Understand how to enable the protection and avoid false positives.
+* [Message Scheduling](/docs/messaging/features/message-scheduling.md): Schedule RCS, SMS, MMS, and WhatsApp messages to be sent at a fixed time in the future.
+* [Twilio's request to your incoming message Webhook URL](/docs/messaging/guides/webhook-request.md): What does Twilio send in its request to your webhook URL? See what parameters are included for SMS, RCS, and WhatsApp-messages using Programmable Messaging.
+* [Track the Message Status of Outbound Messages](/docs/messaging/guides/track-outbound-message-status.md): Learn how to track the status of outbound messages you send with Programmable Messaging in your web application. Track the sent and delivery status of SMS, MMS, and WhatsApp Messages using status callbacks. Understand the differences when using a Messaging Service.
+* [What to know before sending international SMS messages](/docs/messaging/guides/sending-international-sms-guide.md): Send international SMS on Twilio's API. Learn global SMS basics: country best practice, long & short code, P2P, A2P, GSM-7, UCS-2, alphanumeric sender ID.
+* [Outbound Message Status in Status Callbacks](/docs/messaging/guides/outbound-message-status-in-status-callbacks.md): Learn for which changes in outbound message status Twilio sends status callback requests. Understand the status lifecycle from creation, through sending and delivery to read receipt. Recognize the differences when using a Messaging Service.
+* [Best Practices for Messaging Delivery Status Logging](/docs/messaging/guides/outbound-message-logging.md): Best practices for logging SMS messages sent using Programmable Messaging, focusing on logging for Mobile Terminated/Outbound messaging.
+* [Test SMS messaging with the Virtual Phone](/docs/messaging/guides/guide-to-using-the-twilio-virtual-phone.md): Test SMS messages with the Twilio Virtual Phone. Send and receive texts without carrier restrictions, and explore Twilio's Messaging API hassle-free.
+* [Debugging Common Issues with SMS](/docs/messaging/guides/debugging-common-issues.md): Debugging tips for common issues with SMS and MMS messages.
+* [Best Practices for Scaling with Messaging Services](/docs/messaging/guides/best-practices-at-scale.md): Best practices for scaling a Twilio Messaging application, including sender selection and calculating message throughput.
+* [Accepted content types for media](/docs/messaging/guides/accepted-mime-types.md): Learn about MIME types and size restrictions for media messages on Twilio's API. Optimize your MMS, RCS, and WhatsApp communications effectively.
+* [Twilio Messaging Channels](/docs/messaging/channels.md): Twilio Messaging Channels include SMS, MMS and a collection of 3rd-party integrations (WhatsApp, Facebook Messenger) to send and receive messages using the Programmable Messaging APIs and other Twilio products.
+* [Messaging Services](/docs/messaging/services.md): Use the Twilio Messaging Services API and Programmable Messaging to send high volumes of messages in the US and globally.
+* [Get started with Messaging Services](/docs/messaging/tutorials/send-messages-with-messaging-services.md): Enhance your Messaging application with Messaging Services. Send bulk messages with short codes by using multiple numbers and improve message delivery.
+* [Test your SMS Application](/docs/messaging/tutorials/automate-testing.md): Learn how to send test SMS using Twilio's Programmable SMS API and test credentials
+* [Customize users' opt-in and opt-out experience with Advanced Opt-Out](/docs/messaging/tutorials/advanced-opt-out.md): Customize Opt-in/Opt-out options for Twilio Programmable SMS. Localize with country-specific keywords in different languages with Twilio Advanced Opt-Out.
+* [Services resource](/docs/messaging/api/service-resource.md): Full API reference for sending SMS or WhatsApp messages at scale with Twilio Messaging Services. Learn how to create, fetch, read, and update Messaging Services.
+* [Pricing: Messaging Countries resource](/docs/messaging/api/pricing.md): Full API reference for pricing of Twilio's Programmable Messaging API. Get pricing information for a country or list all countries with Twilio Message Resource services.
+* [Services PhoneNumbers subresource](/docs/messaging/api/phonenumber-resource.md): Full API reference for sending SMS messages at scale with Twilio. Learn how to create, fetch, read, and update Phone Numbers on your Messaging Services.
+* [Messages resource](/docs/messaging/api/message-resource.md): API reference for the Message resource: send SMS, MMS, and WhatsApp messages, query message statuses, and get, update, or delete sent messages.
+* [Feedback subresource](/docs/messaging/api/message-feedback-resource.md): API Reference for Twilio's Feedback subresource. Use Feedback to track and report SMS message delivery back to Twilio.
+* [Media subresource](/docs/messaging/api/media-resource.md): Full API Reference for the Media subresource of the Programmable Messaging API. Get and manage Media related to Messages originating with MMS (SMS), WhatsApp and other Messaging Channels.
+* [Messaging API Overview](/docs/messaging/api.md): Use the Programmable Messaging REST API to send and receive SMS, MMS, and WhatsApp messages, track delivery status, and manage message media and history.
+* [Link Shortening Onboarding Guide](/docs/messaging/features/link-shortening/onboarding-guide.md): Bring your own company-branded domain and send messages with shortened links and click tracking.
+* [Link Shortening](/docs/messaging/features/link-shortening.md): Send messages with shortened links using your own domain and track engagement with click tracking.
+* [Toll-Free Verification Console Onboarding Guide](/docs/messaging/compliance/toll-free/console-onboarding.md): Guide on verifying Toll-Free numbers via Twilio Console, covering steps for submission, status review, and deleting verification for U.S. messaging compliance.
+* [Get started with toll-free verification using the API](/docs/messaging/compliance/toll-free/api-onboarding.md): Guide to verify Toll-Free numbers via Twilio API, covering submission, record management, and status updates for compliant messaging in North America.
+* [ISV A2P 10DLC Onboarding Overview](/docs/messaging/compliance/a2p-10dlc/onboarding-isv.md): Onboarding overview for ISVs on Twilio A2P 10DLC messaging: covers registration, various Account architectures, and special cases for efficient compliance.
+* [A2P 10DLC - Standard and Low-Volume Standard Brand Onboarding Guide for ISVs](/docs/messaging/compliance/a2p-10dlc/onboarding-isv-api.md): Detailed REST API onboarding guide for ISVs to register their customers for A2P 10DLC. For Standard and Low-Volume Standard Brands.
+* [Programmable Messaging and A2P 10DLC](/docs/messaging/compliance/a2p-10dlc.md): Start the new registration process to get a verified sender identity for A2P 10DLC. Send high volume SMS and MMS over trusted, compliant carrier routes.
+* [Direct Standard and Low-Volume Standard Registration Guide](/docs/messaging/compliance/a2p-10dlc/direct-standard-onboarding.md): A step-by-step guide for Direct customers to onboard Standard Brands to US A2P 10DLC messaging.
+* [A2P 10DLC - Gather the Required Business Information](/docs/messaging/compliance/a2p-10dlc/collect-business-info.md): Begin the A2P 10DLC onboarding process for your business or your customers' businesses. This page covers the information needed for registration.
+* [Send SMS and MMS messages](/docs/messaging/tutorials/how-to-send-sms-messages.md): A guide to send SMS text messages and MMS messages programmatically from your application or the cURL command line utility using Twilio Programmable Messaging.
+* [Receive and Reply to Incoming Messages - Python](/docs/messaging/tutorials/how-to-receive-and-reply/python.md): Learn how to respond to an incoming message using Twilio's Programmable Messaging API and Python.
+* [Receive and Reply to Incoming Messages - Node.js](/docs/messaging/tutorials/how-to-receive-and-reply/node-js.md): Learn how to respond to an incoming message using Twilio's Programmable Messaging API and Node.js.
+* [Receive and Reply to Incoming Messages](/docs/messaging/tutorials/how-to-receive-and-reply.md): Learn how to respond to an incoming message using Twilio's Programmable Messaging API
+* [Receive and Reply to Incoming Messages - C#](/docs/messaging/tutorials/how-to-receive-and-reply/csharp.md): Learn how to respond to an incoming message using Twilio's Programmable Messaging API and C# / ASP.NET.
+* [Media subresource](/docs/messaging/tutorials/how-to-receive-and-download-images-incoming-mms/ruby-sinatra.md): Full API Reference for the Media subresource of the Programmable Messaging API. Get and manage Media related to Messages originating with MMS (SMS), WhatsApp and other Messaging Channels.
+* [Receive and Download Images on Incoming Media Messages with Python and Django](/docs/messaging/tutorials/how-to-receive-and-download-images-incoming-mms/python-django.md): Use Python, Django, and Twilio to receive and download images and other media on incoming MMS messages.
+* [Receive and Download Images on Incoming Media Messages with PHP and Laravel](/docs/messaging/tutorials/how-to-receive-and-download-images-incoming-mms/php-laravel.md): Use PHP, Laravel, and Twilio to receive and download images and other media on incoming MMS messages.
+* [Receive and Download Images on Incoming Media Messages with Node.js](/docs/messaging/tutorials/how-to-receive-and-download-images-incoming-mms/node.md): Use Node.js and Twilio to receive and download images and other media on incoming MMS messages.
+* [Receive and Download Images on Incoming Media Messages with Java](/docs/messaging/tutorials/how-to-receive-and-download-images-incoming-mms/java.md): Use Java and Twilio to receive and download images and other media on incoming MMS messages.
+* [Receive and Download Images on Incoming Media Messages](/docs/messaging/tutorials/how-to-receive-and-download-images-incoming-mms.md): Learn how to use Twilio Programmable Messaging to receive and download images and other media on incoming MMS and media messages.
+* [Receive and Download Images on Incoming Media Messages with C#](/docs/messaging/tutorials/how-to-receive-and-download-images-incoming-mms/csharp.md): Use C#, ASP.NET, and Twilio to receive and download images and other media on incoming MMS messages.
+
+## Programmable Voice
+
+* [Troubleshooting Voice Calls](/docs/voice/troubleshooting.md): Troubleshoot common issues with voice calls made via the Twilio REST API
+* [Pricing: Voice Resource](/docs/voice/pricing.md): Twilio's Pricing Voice resource provides a simple API to pull real-time, account-specific pricing for Twilio's programmable voice product.
+* [Interactive Voice Response](/docs/voice/interactive-voice-response.md): Twilio makes it easy to add IVR, or Interactive Voice Response to your application. With these tutorials, guides, and code samples, you'll have a call center menu built quickly. Twilio can help you gather DTMF (touch tone) input or voice input from incoming callers.
+* [Programmable Voice](/docs/voice.md): Use Twilio Programmable Voice to add inbound and outbound voice calls to your web or mobile app. Use our Voice API or SDKs for web languages. Build Interactive Voice Response, conference calling, automated surveys and more. Integrate your VoIP system with Twilio SIP. See call analytics and insights.
+* [How to Share Information Between Your Applications](/docs/voice/how-share-information-between-your-applications.md): Follow sample code to learn how to exchange custom parameters between your backend Programmable Voice application and your frontend applications.
+* [Voice Conference](/docs/voice/conference.md): Get a high-level overview of Voice Conference, a flexible way for developers to manage multi-party calls from 2 to 250 participants.
+* [Brand you calls using CNAM](/docs/voice/brand-your-calls-using-cnam.md): Learn how to brand your Programmable Voice calls with Caller ID Name (CNAM) to associate your business with your Twilio-powered phone number.
+* [Answering Machine Detection](/docs/voice/answering-machine-detection.md): Detect whether a human, answering machine, or fax machine has picked up your outbound voice API calls with Twilio's REST API Answering Machine Detection
+* [Answering Machine Detection FAQ & Best Practices](/docs/voice/answering-machine-detection-faq-best-practices.md): Twilio Answering Machine Detection frequently asked questions and best practices.
+* [Virtual Agent](/docs/voice/virtual-agent.md): Connect your Twilio Voice calls to Google Dialogflow ES or CX agents for rich conversational AI experiences. Learn how to get started with the integration in this overview page and find additional resources for building your Virtual Agent applications.
+* [Dialogflow CX Onboarding Guide](/docs/voice/virtual-agent/dialogflow-cx-onboarding.md): Follow this onboarding guide to integrate your voice calls with a Google Dialogflow CX agent.
+* [Voice Insights](/docs/voice/voice-insights.md): Learn how to gather call and conference metrics, quality events, and metadata. Use Voice Insights dashboards, APIs and event streams to analyze trends and issues.
+* [Voice Insights Advanced Features](/docs/voice/voice-insights/advanced-features.md): Learn to activate and use Voice Insights Advanced Features for event and metric time-series, and programmatic access through Event Streams or API.
+* [TwiML™ Voice: \<Transcription>](/docs/voice/twiml/transcription.md): Real-Time Transcription allows you to receive and use voice call transcriptions in real time. Integrate Real-Time Transcription into your call center quality assurance applications or lead generation applications for real-time, actionable insights.&#x20;
+* [TwiML™ Voice: \<Sip>](/docs/voice/twiml/sip.md): Learn how to programmatically set up VoIP sessions and send a call to any SIP endpoint by using the \<Sip> noun for TwiML Voice.
+* [TwiML™ Voice: \<Refer>](/docs/voice/twiml/refer.md): The TwiML™ Voice \<Refer> verb instructs Twilio to initiate a Session Initiation Protocol (SIP) transfer towards a SIP infrastructure. It can be invoked on both inbound and outbound SIP calls.
+* [TwiML™ Voice: \<Redirect>](/docs/voice/twiml/redirect.md): Learn how to programmatically transfer control of a call to the TwiML at a different URL with the \<Redirect> verb for TwiML Voice.
+* [TwiML™ Voice: \<Recording>](/docs/voice/twiml/recording.md): Learn how to manage call recording with the \<Recording> noun for TwiML Voice and your preferred coding language.
+* [TwiML™ Voice: \<Record>](/docs/voice/twiml/record.md): Learn how to record a call, record a voicemail, and transcribe a recording with the \<Record> verb for TwiML Voice and your preferred coding language.
+* [TwiML™ Voice: \<Queue>](/docs/voice/twiml/queue.md): Learn how to dial into a queue and connect to the first enqueued call using TwiML Voice's \<Queue> noun, using the programming language of your choice.
+* [TwiML™ Voice: \<Play>](/docs/voice/twiml/play.md): Learn how to play an audio file back to your callers with TwiML Voice's \<Play> verb using the programming language of your choice.
+* [TwiML™ Voice: \<Pause>](/docs/voice/twiml/pause.md): Find sample code and instructions on how to programmatically wait during calls with the \<Pause> verb for TwiML Voice.
+* [TwiML™ Voice: \<Number>](/docs/voice/twiml/number.md): Learn how to specify a phone number with the \<Number> noun with TwiML for Programmable Voice with sample code that shows you how to work with this noun.
+* [TwiML™ for Programmable Voice](/docs/voice/twiml.md): Learn how Twilio uses the TwiML markup language to talk to your Programmable Voice applications.
+* [TwiML™ Voice: \<Hangup>](/docs/voice/twiml/hangup.md): Learn how to programmatically end a call with the \<Hangup> verb for TwiML Voice, complete with sample code in your language of choice.
+* [TwiML™ Voice: \<Gather>](/docs/voice/twiml/gather.md): Use TwiML's \<Gather> to collect input over the phone, including DTMF tones from your caller's keypad or speech transcriptions using Twilio's speech recognition.
+* [TwiML™ Voice: \<Enqueue>](/docs/voice/twiml/enqueue.md): Learn how to programmatically enqueue a call with the \<Enqueue> verb for TwiML Voice to place your users on hold until the call is dequeued or transferred.
+* [TwiML Voice: \<Conference>](/docs/voice/twiml/conference.md): Connect calls to a conference with the \<Conference> verb for TwiML Voice to implement hold, transfer, and barge users' calls, complete with sample code.
+* [TwiML™ Voice: \<Client>](/docs/voice/twiml/client.md): The TwiML Voice Client noun specifies a client identifier to dial. This is used along with the \<dial> verb.
+* [Programmable Voice Tutorials](/docs/voice/tutorials.md): A round-up of links for our most popular tutorials on how to build with Twilio Programmable Voice, in a wide variety of programming languages.
+* [How to route calls to your SIP network with an outbound call](/docs/voice/tutorials/how-to-route-calls-to-your-sip-network.md): Learn how to use Programmable Voice to programmatically route calls to your SIP network with sample code that shows you how to make a SIP call with the API.
+* [Make outbound phone calls](/docs/voice/tutorials/how-to-make-outbound-phone-calls.md): Learn how to make outbound phone calls with Twilio Programmable Voice.
+* [How to capture your first payment using \<Pay>](/docs/voice/tutorials/how-capture-your-first-payment-using-pay.md): Boost your revenue by capturing payments using Twilio's  Programmable Voice Pay feature. Learn how to capture your first payment with Stripe.
+* [Consume a real-time Media Stream using WebSockets, Python, and Flask](/docs/voice/tutorials/consume-real-time-media-stream-using-websockets-python-and-flask.md): Step-by-step instructions for accessing voice data in real-time with Media Streams, Python, and Flask using WebSockets.
+* [Trusted Calling with SHAKEN/STIR](/docs/voice/trusted-calling-with-shakenstir.md): Find general information on SHAKEN/STIR verification for Programmable Voice and some implementation details, including the effects on Twilio calls.
+* [Increase Call Answer Rates with Voice Integrity](/docs/voice/spam-monitoring-with-voiceintegrity.md): Find information on  Increasing Call Answer Rates through Spam Remediation with Voice Integrity
+* [SIP Quickstart](/docs/voice/sip/quickstart.md): Learn how to register a SIP (Session Initiation Protocol) Domain with Twilio's Programmable Voice SIP API, that will allow multiple SIP clients to register, and connect with each other, as well as route out to the traditional public switched telephone network (PSTN).
+* [SIP](/docs/voice/sip.md): Connect your existing Session Initiation Protocol (SIP) communications infrastructure to us, and get access to Twilio's global reach, powerful automation and scripting functions.
+* [No-code Voice quickstart with Twilio Studio](/docs/voice/quickstart/no-code-voice-studio-quickstart.md): Learn how to use Twilio Studio to receive and respond to phone calls without using code.
+* [Voice SDKs Network Connectivity Requirements](/docs/voice/sdks/network-connectivity-requirements.md): A Programmable Voice SDK connectivity checklist and overview, a list of our servers' ports and IP addresses, and the bandwidth required for quality audio.
+* [Voice SDKs](/docs/voice/sdks.md): The Twilio Programmable Voice SDKs make it easy for you to add voice-over-IP (VoIP) calling into your web and native mobile applications quickly.
+* [Voice SDK Error Codes](/docs/voice/sdks/error-codes.md): Explore Voice SDK error codes and find solutions for Twilio Voice issues with our comprehensive guide, covering common errors, causes, and fixes.
+* [Media Streams - WebSocket Messages](/docs/voice/media-streams/websocket-messages.md): Learn about the WebSocket Messages sent to and from Twilio when using Media Streams.&#x20;
+* [Media Streams Overview](/docs/voice/media-streams.md): Learn how to receive raw audio streams from a live phone call over WebSockets in near real-time with Twilio Media Streams.
+* [Bring Your Own Carrier (BYOC) Trunking for Programmable Voice](/docs/voice/bring-your-own-carrier-byoc.md): Bring Your Own Carrier BYOC Trunking
+* [Branded Calling overview](/docs/voice/branded-calling.md): Boost trust with Branded Calling by showing your verified name, logo, and call reason on mobile phones.
+* [Verifying Caller IDs at Scale](/docs/voice/api/verifying-caller-ids-scale.md): In this guide, learn how to programmatically verify many phone numbers with Twilio.
+* [Streams subresource](/docs/voice/api/stream-resource.md): The Streams subresource allows you to start a media stream on a live phone call and send that Stream to a secure WebSocket URL.
+* [SIP Registration](/docs/voice/api/sip-registration.md): Register, make calls and receive calls with SIP Registration with Twilio's Programmable Voice
+* [Making SIP Calls](/docs/voice/api/sip-making-calls.md): Use Twilio's REST API to connect to your SIP-enabled endpoints and set up a VoIP session using SIP
+* [Use SIP with Twilio Voice](/docs/voice/api/sip-interface.md): Twilio's Programmable Voice SIP Interface helps you route your voice calls with global reach to any phone, browser, mobile app, or other SIP endpoint.
+* [Inbound - Sending SIP to Twilio](/docs/voice/api/sending-sip.md): Send SIP calls to a Twilio endpoint seamlessly with Programmable Voice SIP
+* [Recordings resource](/docs/voice/api/recording.md): Full detailed REST API reference for managing recordings with Twilio's Programmable Voice REST API.
+* [Outbound - Receiving SIP from Twilio](/docs/voice/api/receiving-sip.md): Twilio's Programmable Voice SIP enables your advanced voice applications to initiate SIP sessions from Twilio towards your existing SIP infrastructure
+* [Calls Transcriptions subresource](/docs/voice/api/realtime-transcription-resource.md): Full API reference for the Calls Transcriptions subresource in the Twilio API. Learn how to start and stop a real-time Transcription during a call.
+* [OutgoingCallerIds resource](/docs/voice/api/outgoing-caller-ids.md): Manage outgoing caller IDs and verify phone numbers with the Twilio REST API
+* [Programmable Voice API Overview](/docs/voice/api.md): Introduction to the Twilio Voice REST API. Use this API to make phone calls, modify calls in progress, and query metadata about calls, conferences, queues, and recordings.
+* [Conferences resource](/docs/voice/api/conference-resource.md): Use the Twilio Voice REST API Conferences resource to programmatically update active conferences and get conference data from your account.
+* [Conferences Participants subresource](/docs/voice/api/conference-participant-resource.md): Use the Twilio Voice REST API Participants subresource to manage participants in an active conference or add a participant to an Agent Conference.
+* [Call resource](/docs/voice/api/call-resource.md): Full detailed REST API reference for the Call resource in Twilio's Programmable Voice REST API.
+* [Events subresource](/docs/voice/api/call-event-resource.md): Full API reference for the Event subresource in the Voice API. Sample code shows how to read (list) resources in Node, Python, PHP, Ruby, C#, and more.
+* [TwiML™️ Voice: \<Stream>](/docs/voice/twiml/stream.md): Learn how to receive raw audio streams from a live phone call over WebSockets in near real-time with the \<Stream> instruction for TwiML Voice.
+* [Pay Connectors](/docs/voice/twiml/pay/pay-connectors.md): Learn about Pay Connectors, what products support it, and how to install and configure one.
+* [TwiML™ Voice: \<Pay>](/docs/voice/twiml/pay.md): Take credit card details during voice calls with PCI-compliant Twilio \<Pay>. Sample code, examples, and guides to take payments during calls.
+* [TwiML™ Voice: \<Dial>](/docs/voice/twiml/dial.md): Use Twilio's \<Dial> TwiML to connect a caller to another party. Connect two phone calls, reach a conference room or SIP endpoint, record a call, and more.
+* [TwiML™ Voice: \<Connect>](/docs/voice/twiml/connect.md): The \<Connect> verb in TwiML instructs Twilio to connect an incoming request, such as a phone call originating over PSTN or SIP, to another system.
+* [Text-to-Speech (TTS)](/docs/voice/twiml/say/text-speech.md): Text-to-Speech (TTS) is a process where text is converted into a human-sounding voice. Learn more about Twilio TTS technology.
+* [TwiML™ Voice: \<Say>](/docs/voice/twiml/say.md): Learn how to build text-to-speech into your applications with TwiML Voice's \<Say> verb, with options for voices and  supported languages.
+* [Retrieve Call Logs](/docs/voice/tutorials/how-to-retrieve-call-logs.md): Find links to step-by-step tutorials that show how to use the Programmable Voice API to manipulate live phone calls and retrieve call information.
+* [Respond to Incoming Phone Calls in Python](/docs/voice/tutorials/how-to-respond-to-incoming-phone-calls/python.md): Learn how to respond to incoming phone calls in your Python web application in this guide. This example uses the Flask web framework and ngrok to respond to incoming phone calls to your Twilio phone number.
+* [Respond to Incoming Phone Calls in Node.js](/docs/voice/tutorials/how-to-respond-to-incoming-phone-calls/node.md): Learn how to respond to incoming phone calls in your Node.js web application in this guide. This example uses the Express web framework and ngrok to respond to incoming phone calls to your Twilio phone number.
+* [Respond to Incoming Phone Calls](/docs/voice/tutorials/how-to-respond-to-incoming-phone-calls.md): Links to step-by-step tutorials with sample code and learn how to use the Programmable Voice API to respond to incoming phone calls in your applications.
+* [How to Record Phone Calls in Python](/docs/voice/tutorials/how-to-record-phone-calls/python.md): Learn how to record incoming and outgoing Twilio Voice phone calls using Python.
+* [Record Phone Calls in Node.js](/docs/voice/tutorials/how-to-record-phone-calls/node.md): Learn how to record incoming and outgoing Twilio Voice phone calls using Node.js.
+* [Record Phone Calls](/docs/voice/tutorials/how-to-record-phone-calls.md): Find links to step-by-step tutorials complete with sample code to learn how to use the Programmable Voice API to record phone calls in your programming language of choice.
+* [Modify Calls In Progress](/docs/voice/tutorials/how-to-modify-calls-in-progress.md): Find links to step-by-step tutorials complete with sample code to learn how to use the Programmable Voice API to manipulate live phone calls.
+* [Gather User Input via Keypad (DTMF Tones)](/docs/voice/tutorials/how-to-gather-user-input-via-keypad.md): Links to step-by-step tutorials complete with sample code that show how to gather user input through a phone's keypad during a call.
+* [Create Conference Calls](/docs/voice/tutorials/how-to-create-conference-calls.md): Find links to step-by-step tutorials in your programming language to learn how to use Programmable Voice to create and manage conference calls.
+* [Emergency Calling for Programmable Voice](/docs/voice/tutorials/emergency-calling-for-programmable-voice.md): Configure Twilio's Emergency Calling, enabling emergency call routing to Public Safety Answering Points using Programmable Voice
+* [IVR: Phone Tree with Python and Flask](/docs/voice/tutorials/build-interactive-voice-response-ivr-phone-tree/python.md): Learn how to create a seamless customer service experience by building an IVR Phone Tree for your company with Python, Flask and Twilio.
+* [Build an Interactive Voice Response (IVR) Phone Tree](/docs/voice/tutorials/build-interactive-voice-response-ivr-phone-tree.md): Find links to step-by-step tutorials complete with sample code to learn how to build an Interactive Voice Response (IVR) phone tree in your programming language of choice.
+* [Voice React Native SDK](/docs/voice/sdks/react-native.md): Learn the basics of working with the Programmable Voice SDK for React Native.
+* [Voice iOS SDK](/docs/voice/sdks/ios.md): Learn the basics of working with the Programmable Voice SDK for iOS, including installation, versioning, and authentication.
+* [Getting Started with the Voice iOS SDK](/docs/voice/sdks/ios/get-started.md): Learn how to get started Programmable Voice for iOS and add Voice over IP (VoIP) to your iOS application.
+* [Voice JavaScript SDK: Twilio.Call](/docs/voice/sdks/javascript/twiliocall.md): Reference documentation for Call, an API object that represents a call to or from Twilio's network, with methods, events, accessors, and sample code.
+* [Voice JavaScript SDK: Twilio in the browser](/docs/voice/sdks/javascript.md): Use the Voice JavaScript SDK to make and receive voice calls in web browsers. Supports Chrome, Firefox, Safari, and Edge.
+* [Voice JavaScript SDK quickstart](/docs/voice/sdks/javascript/get-started.md): Learn how to add voice communications to your front-end applications with Twilio's Programmable Voice API in this Voice JavaScript SDK Quickstart.
+* [Voice JavaScript SDK: Changelog](/docs/voice/sdks/javascript/changelog.md): Changelog for the Voice JavaScript SDK including new features, bug fixes and updates.
+* [Voice JavaScript SDK: Best Practices](/docs/voice/sdks/javascript/best-practices.md): Get the most out of the Twilio Voice JavaScript SDK by following these best practices, and ensure your users have a seamless calling experience. They will also make it easier to troubleshoot connection and call quality issues.
+* [Voice Android SDK](/docs/voice/sdks/android.md): Learn how to add voice-over-IP (VoIP) calling into your native Android applications with the Programmable Voice SDK.
+* [Getting Started with the Voice Android SDK](/docs/voice/sdks/android/get-started.md): Learn how to add voice communications to your mobile applications with Twilio's Programmable Voice API in this Twilio Voice Quickstart for Android.
+* [Transcriptions resource](/docs/voice/api/recording-transcription.md): Use the Twilio Voice REST API Transcriptions resource to fetch or delete transcriptions of recorded calls.
+* [Details: Voice Insights SDK Events](/docs/voice/voice-insights/api/call/details-sdk-call-quality-events.md): Supplementary details and explanations of Voice SDK events underlying Voice Insights for programmatic use with REST API, Events Streams or application code.
+* [TwiML™ Voice: \<Application>](/docs/voice/twiml/dial/application.md): The \<Dial> verb's \<Application> noun allows you to connect a call to another Twilio account without losing the original call leg's context.
+* [Voice JavaScript SDK: Twilio.Device](/docs/voice/sdks/javascript/twiliodevice.md): Learn how to use the Programmable Voice JavaScript SDK to facilitate connections between Twilio and audio connections.
+* [Twilio.Device.audio](/docs/voice/sdks/javascript/twiliodevice/device-audio.md): How to control the audio on a device on web-based calls with the Twilio Voice JavaScript SDK. Info on browser support, methods, properties, events, and more.
+
+## Proxy: One-to-one Masked Communications
+
+* [Using the Reserved Numbers and Auto-Create functionalities to support the "online directory" scenarios](/docs/proxy/using-the-reserved-numbers-and-auto-create-functionalities-to-support-the-online-directory-scenarios.md): Learn how to support online directory scenarios by forwarding all out-of-session communications to a specific person with Twilio's Proxy API in this guide.
+* [Phone Number Management](/docs/proxy/understanding-phone-number-management.md): We walk through how Twilio Proxy manages phone numbers and selects numbers from the number pool when creating cloaked communications channels between two people
+* [Reserved Phone Numbers](/docs/proxy/reserved-phone-numbers.md): Learn how to mark phone numbers in your pool as reserved with Twilio's Proxy API in this usage guide.
+* [Proxy Quickstart](/docs/proxy/quickstart.md): Build masked, one-to-one communications over SMS and Voice with the Proxy quickstart. Step-by-step tutorial with code examples to set up anonymous conversations using C# and .NET, Java, Node.js, PHP, Python, and Ruby.
+* [Proxy Limits](/docs/proxy/proxy-limits.md): Learn about the limits of Twilio Proxy including number pool, participants, data, and throughput limits in this guide.
+* [Proxy Changelog](/docs/proxy/proxy-changelog.md): Learn more about Twilio Proxy's recent releases and updates in this Changelog.
+* [How many Phone Numbers do I need?](/docs/proxy/phone-numbers-needed.md): Learn how to determine how many phone numbers to have in your Twilio Proxy number pool (the Proxy service) for masked communications in your apps and websites.
+* [Out-of-Session Callback Response Guide](/docs/proxy/out-session-callback-response-guide.md): Learn how Twilio Proxy handles incoming communications from out-of-session participants with callback responses in this usage guide.
+* [Opt-out keywords](/docs/proxy/opt-out-keywords.md): Learn how Twilio Proxy handles opt-out and opt-in keywords and special considerations to make during implementation in this guide.
+* [Moving to Proxy Beta from Developer Preview](/docs/proxy/moving-to-beta-from-preview.md): If you are a customer who previously used the developer preview version of Proxy, you will need to update your code to use the new beta version.
+* [Proxy: One-to-one Masked Communications](/docs/proxy.md): Twilio Proxy lets you add masked conversations with two parties to your app or site. Use the REST API or SDKs to automatically associate temporary numbers, with tracking and custom timeouts. For services which need two-way temporary comms on Voice or SMS, it makes implementation fast.
+* [Using Proxy with Flex A2P SMS](/docs/proxy/flex-a2p-10dlc.md): Is your contact center sending application-to-person SMS in the United States? A2P 10DLC is probably relevant to you. Read on to learn how to register your phone numbers and configure your Twilio Flex Contact Center to send registered traffic.
+* [Using Proxy with Channels](/docs/proxy/channels.md): Learn how to configure Twilio Proxy to use multiple communication channels such as WhatsApp and Facebook Messenger in this usage guide.
+* [Webhooks](/docs/proxy/api/webhooks.md): A reference page showing the available webhooks in the Twilio Proxy masked communications API and a list of the parameters that are passed with each webhook.
+* [Session Resource](/docs/proxy/api/session.md): Full API reference for the Session resource in the Twilio Proxy REST API for masked communications.
+* [Service](/docs/proxy/api/service.md): Full API reference for the Service resource in the Twilio Proxy REST API for masked communications.
+* [Sending Messages](/docs/proxy/api/sending-messages.md): Full API reference for the MessageInteraction resource in the Twilio Proxy REST API for masked communications. How to send messages to a session participant.
+* [Phone Number](/docs/proxy/api/phone-number.md): Full API reference for the Phone Number resource and managing the number pool in the Twilio Proxy REST API for masked communications.
+* [Participant](/docs/proxy/api/participant.md): Full API reference for the Participant resource in the Twilio Proxy REST API for masked communications.
+* [Interaction](/docs/proxy/api/interaction.md): Full API reference for the Interaction resource in the Twilio Proxy REST API for masked communications.
+* [The Proxy API Overview](/docs/proxy/api.md): Twilio Proxy lets you add masked conversations with two parties to your app or site. Use the REST API or SDKs to automatically associate temporary numbers, with tracking and custom timeouts. Dive into our REST API reference here.
+
+## RCS Business Messaging
+
+* [Send and receive RCS messages](/docs/rcs/send-an-rcs-message.md): Learn how to send and receive Rich Communication Services (RCS) messages with Twilio Programmable Messaging.
+* [Programmable Messaging RCS Regional Availability](/docs/rcs/regional.md): Learn about the regional availability and considerations of Rich Communication Services in Twilio Programmable Messaging.
+* [Get started with branded RCS messaging](/docs/rcs/onboarding.md): Learn the setup and configuration required to send Rich Communication Services (RCS) messages with Twilio Programmable Messaging.
+* [RCS Business Messaging](/docs/rcs.md): Learn how Twilio uses RCS Business Messaging in its products to help businesses communicate with their customers.
+
+## SDKs
+
+* [SDKs](/docs/libraries.md): Easily use Twilio APIs in the programming language of your choice. Download and install helpers for Node.js, Python, Go, PHP, iOS, Android, C#, and more.
+
+## SMPP API
+
+* [SMPP API](/docs/smpp.md): Enhance SMS delivery with Twilio's SMPP API, offering secure, scalable messaging solutions for global businesses.
+
+## Studio
+
+* [Subflows](/docs/studio/subflows.md): Overview of Subflows in Studio including basic usage, working with variables, limitations, and testing.
+* [Studio](/docs/studio.md): Use Twilio Studio's low-code builder to create and manage communication workflows like SMS chatbots and order notifications.
+* [TwiML Redirect widget](/docs/studio/widget-library/twiml-redirect.md): Redirect a Voice Call to be handled outside of Studio with the TwiML Redirect widget and pass parameters to your TwiML Redirect URL.
+* [Trigger (Start) widget](/docs/studio/widget-library/trigger-start.md): Begin the Studio Flow with the Trigger (Start) widget and communicate between Studio and the parts of your business logic.
+* [Split Based On... widget](/docs/studio/widget-library/split-based-on.md): Learn how to split your Studio flow and connect to specific widgets based on user conditions with the Split Based On widget.
+* [Set Variables widget](/docs/studio/widget-library/set-variables.md): Learn how to save key/value pairs in the global context of your Studio flow with the SetVariables widget and dynamically update data as your flow executes.
+* [Send & Wait For Reply widget](/docs/studio/widget-library/send-wait-reply.md): Learn how to send an outgoing message, wait for a reply, and collect the user's response with the Send & Wait For Reply widget.
+* [Send Message widget](/docs/studio/widget-library/send-message.md): Send a message to a user with the Send Message widget and respond to users that message your application from an SMS or Programmable Chat channel.
+* [Send to Flex widget](/docs/studio/widget-library/send-flex.md): Learn how to transfer an incoming message or call to Flex with the Send to Flex widget.
+* [Say/Play widget](/docs/studio/widget-library/sayplay.md): Play a recorded message or dictate text to a user on call with the Say/Play widget in your Studio flow.
+* [Run Function widget](/docs/studio/widget-library/run-function.md): Execute Twilio Functions from within your Studio flow with the Run Functions widget and communicate between your flow and more complex business logic.
+* [Record Voicemail widget](/docs/studio/widget-library/record-voicemail.md): Record and transcribe a caller's message with the Record Voicemail widget.
+* [Make Outgoing Call widget](/docs/studio/widget-library/make-outgoing-call.md): Learn how to dial a contact's phone number from within your Studio Flow with the Make Call widget.
+* [Widget Library](/docs/studio/widget-library.md): Widgets are individual items that can be dragged onto the Flow canvas in Twilio Studio. They represent pieces of logic, and can connect to each other via Transitions.
+* [Make HTTP Request widget](/docs/studio/widget-library/http-request.md): Learn how to interact with code that lives outside of Studio with the Make HTTP Request widget to communicate between Studio and business logic.
+* [Gather Input On Call widget](/docs/studio/widget-library/gather-input-call.md): Gather a user's input while they are on a call with the Gather Input On Call widget for Studio and collect DTMF keypresses or text from speech recognition.
+* [Enqueue Call widget](/docs/studio/widget-library/enqueue-call.md): Enqueue a current call managed with Studio into a call queue with the Enqueue Call widget and play music for your caller until they are dequeued.
+* [Connect Virtual Agent widget](/docs/studio/widget-library/connect-virtual-agent.md): Learn how to connect a Twilio Voice call or Twilio Conversations to a Dialogflow CX agent using the Connect Virtual Agent widget.
+* [Connect Call To widget](/docs/studio/widget-library/connect-call.md): Learn how to connect an in-progress call with another phone number, Client user, SIM, SIP endpoint, or conference with the Connect Call To widget.
+* [Call Recording widget](/docs/studio/widget-library/call-recording.md): Learn how to use the Call Recording widget in your Twilio Studio flow to switch Voice Call Recording ON or OFF at any point during an incoming call flow.
+* [Studio Troubleshooting](/docs/studio/user-guide/studio-troubleshooting.md): Guide demonstrating how to use logs and revisions effectively when attempting to find problems occurring within a Flow.
+* [Studio FAQ](/docs/studio/user-guide/studio-faq.md): Frequently asked questions about Twilio Studio.
+* [Liquid Template Language](/docs/studio/user-guide/liquid-template-language.md): Learn to use the Liquid Template Language to render dynamic content in Twilio Studio.
+* [Studio User Guide](/docs/studio/user-guide.md): Design, deploy and scale customer communications seamlessly with Twilio Studio. Designed for cross-functional teams, anyone can create and modify flows.
+* [Get Started with Twilio Studio](/docs/studio/user-guide/get-started.md): Overview of setting up a Studio application including working with widgets, Liquid variables, and troubleshooting flows.
+* [Using Twilio Conversations with Studio](/docs/studio/tutorials/using-conversations-with-studio.md): Guide on how to use the Twilio Conversations integration with Studio.
+* [Use RCS messaging with Studio](/docs/studio/tutorials/use-rcs-with-studio.md): Learn how to enable RCS messaging in your Twilio Studio Flow to send and receive RCS messages.
+* [Tutorials](/docs/studio/tutorials.md): List of step-by-step tutorials demonstrating how to use Studio.
+* [Set up an SMS Autoresponder with Twilio Studio](/docs/studio/tutorials/how-to-set-up-auto-responder.md): Use Twilio Studio to create an autoresponder to greet incoming SMS or Whatsapp messages with a personalized response.
+* [Send Appointment Reminders with Twilio Studio](/docs/studio/tutorials/how-to-send-appointment-reminders.md): Send Appointment Reminders with Twilio Studio
+* [Post Messages to Slack with Twilio Studio](/docs/studio/tutorials/how-to-post-sms-to-slack.md): Post inbound SMS to a Slack feed with Twilio Studio and an incoming Slack webhook.
+* [Forward Calls with Twilio Studio](/docs/studio/tutorials/how-to-forward-calls.md): Set up call forwarding with just one Twilio Studio widget. Divert calls to your personal or business number and never miss a critical call again.
+* [Conduct an SMS Survey with Twilio Studio](/docs/studio/tutorials/how-to-conduct-a-survey.md): Conduct a Survey with Twilio Studio
+* [How to build an IVR with Twilio Studio](/docs/studio/tutorials/how-to-build-an-ivr.md): Create IVR systems without coding using Twilio Studio's drag-and-drop editor. Build and route calls efficiently with speech or keypress inputs.
+* [Build a Chatbot with Twilio Studio](/docs/studio/tutorials/how-to-build-a-chatbot.md): Learn how to build a Chatbot with Studio, Twilio's drag-and-drop virtual workflow builder.
+* [Customer Support Menu with WhatsApp and Twilio Studio](/docs/studio/tutorials/customer-support-menu.md): Build a simple customer support bot in WhatsApp using Twilio Studio. Answer common questions and take the first step to build out your WhatsApp presence!
+* [REST API v1](/docs/studio/rest-api.md): Overview of the REST API v1 for Studio including basic usage, authentication requirements, and SDKs.
+* [Flow](/docs/studio/rest-api/flow.md): Full API reference for the Flow resource in the Studio API with code samples showing how to fetch (get), read (list), and delete a Studio Flow.
+* [Execution Resource](/docs/studio/rest-api/execution.md): API reference for the Execution resource in the Studio REST API. Sample code shows how to create, fetch (get), read (list), update, and delete executions.
+* [Test User](/docs/studio/rest-api/v2/test-user.md): API reference for fetching Test Users of a Studio Flow.
+* [Step](/docs/studio/rest-api/v2/step.md): API reference for the Step resource of a Studio Flow Execution. Learn how to fetch and list Steps of an Execution using the REST API for Studio.
+* [REST API v2](/docs/studio/rest-api/v2.md): Learn the basics of triggering Studio flows programmatically with the Studio REST API.
+* [Flow](/docs/studio/rest-api/v2/flow.md): API reference for the Flow resource of a Studio Flow. Learn how to create and modify a Flow using the REST API for Studio.
+* [Execution](/docs/studio/rest-api/v2/execution.md): API reference for the Execution resource of a Studio Flow. Learn how to create and modify an Execution using the REST API for Studio.
+* [Execution Context](/docs/studio/rest-api/v2/execution-context.md): API reference for the Execution Context resource of a Studio Flow. Learn how to fetch an Execution Context using the REST API for Studio.
+
+## Sync: Shared state in the cloud
+
+* [Sync: Shared state in the cloud](/docs/sync.md): Sync, Twilio's state synchronization service, offers two-way real-time communication between browsers, mobiles, and the cloud. Find REST API docs, tutorials, user guides, and quickstarts to get you syncing in your web and mobile apps, fast.
+
+## TaskRouter: Skills-based routing for contact centers
+
+* [Skipping based on Worker availability](/docs/taskrouter/worker-presence.md): Learn why you might want to skip to the next routing step if there are no available workers and what your options are.
+* [Queueing Twilio calls with TaskRouter](/docs/taskrouter/twiml-queue-calls.md): Learn how to queue calls with TaskRouter with code samples that shows how to route calls and bridge a call to a worker.
+* [Time of Day Routing for TaskRouter](/docs/taskrouter/time-of-day-routing.md): Learn about the supported time of day expressions in TaskRouter.
+* [Lifecycle of a Task: Timeout evaluation](/docs/taskrouter/task-evaluation.md): Learn how Timeouts work with Queues and Tasks in TaskRouter.
+* [Queue Ordering](/docs/taskrouter/queue-ordering-last-first-out-lifo.md): Learn about how TaskQueue handles ordering with First In, First Out (FIFO) or Last In, First Out (LIFO).
+* [Ordering Workers](/docs/taskrouter/order-workers.md): Learn how to use the order\_by expression to designate in what order Workers are assigned tasks when using TaskRouter.
+* [Multitasking](/docs/taskrouter/multitasking.md): TaskRouter Multitasking allows a worker to handle multiple tasks of different types in parallel.
+* [Upgrade to TaskRouter SDK version 2](/docs/taskrouter/migrate-js-sdk-to-v2.md): Learn about integrating TaskRouter into your browser-based applications using TaskRouter Javascript SDK v2.
+* [Lifecycle of a Task: Workflows and Assignment](/docs/taskrouter/lifecycle-task-workflows-and-assignment.md): Learn about the lifecycle of a TaskRouter Task, how it moves through a Workflow, and how it gets assigned to a Worker.
+* [Lifecycle of a Task: Task state](/docs/taskrouter/lifecycle-task-state.md): Learn the basics of the various states of a Task, the core of TaskRouter, including the states a Task can go through as it moves from pending to completed.
+* [TaskRouter.js v2: Integrating TaskRouter with your browser-based applications](/docs/taskrouter/js-sdk.md): Learn about integrating TaskRouter into your browser-based applications using TaskRouter Javascript SDK v2.
+* [TaskRouter: Skills-based routing for contact centers](/docs/taskrouter.md): TaskRouter is a skills-based routing system that provides the heart of a contact center that you can control from your code.
+* [How TaskRouter Works](/docs/taskrouter/how-taskrouter-works.md): Learn the basics of how TaskRouter, our system for distributing tasks in your contact center, works. Includes an example application flow and useful links.
+* [Assigning Tasks to Workers: Handling Assignment Callbacks](/docs/taskrouter/handle-assignment-callbacks.md): Learn how to handle Assignment Callbacks in TaskRouter, including parameters included in the HTTP POST request and ways to respond in your code.
+* [Using TaskRouter Expressions](/docs/taskrouter/expression-syntax.md): TaskRouter uses a SQL-like expression syntax for binding Workers to TaskQueues and filtering Tasks into TaskQueues in a Workflow configuration. Learn how to compose expressions from  constants, JSON keys, as well as logical and comparison operators.
+* [Known Agent Routing](/docs/taskrouter/workflow-configuration/known-agent-routing.md): Are your customers trying to talk to the same agent that helped them previously? Optimize and personalize your customer service by leveraging preferred (known) agent routing for tasks.
+* [Workflows Overview](/docs/taskrouter/workflow-configuration.md): This page provides an overview of the basic concepts of Workflows, rules that define how tasks are distributed TaskRouter.
+* [Dynamic Call Center with Ruby and Rails](/docs/taskrouter/tutorials/dynamic-call-center-ruby-rails.md): Build a dynamic, multi-agent customer service call center with Twilio, TaskRouter, and Ruby on Rails.
+* [Dynamic call center with Python and Django](/docs/taskrouter/tutorials/dynamic-call-center-python-django.md): Build a dynamic, multi-agent customer service call center with Twilio, TaskRouter, Python, and Django.
+* [Dynamic Call Center with PHP and Laravel](/docs/taskrouter/tutorials/dynamic-call-center-php-laravel.md): Build a dynamic, multi-agent customer service call center with Twilio, TaskRouter, PHP, and Laravel.
+* [Dynamic Call Center with Node.js and Express](/docs/taskrouter/tutorials/dynamic-call-center-node-express.md): Build a dynamic, multi-agent customer service call center with Twilio, TaskRouter, Node.js, and Express.
+* [Dynamic Call Center with Java and Servlets](/docs/taskrouter/tutorials/dynamic-call-center-java-servlets.md): Build a dynamic, multi-agent customer service call center with Twilio, TaskRouter, Java, and Servlets.
+* [Dynamic Call Center with C# and ASP.NET MVC](/docs/taskrouter/tutorials/dynamic-call-center-csharp-mvc.md): Build a dynamic, multi-agent customer service call center with Twilio, TaskRouter, C#, and ASP.NET.
+* [TaskRouter resource limits](/docs/taskrouter/limits.md): Twilio TaskRouter has default limits on certain resources, configuration parameters, and endpoints. If you are running into these limits, please reach out to our support team. We're happy to help work with you to increase some of these limits or help optimize how you use TaskRouter.
+* [TaskRouter.js v2: Reconnect Logic](/docs/taskrouter/js-sdk-v2/reconnect.md): Documentation about how TaskRouter SDK v2 is reconnecting the WebSocket after disconnection.
+* [TaskRouter.js v1: Integrating TaskRouter to your browser-based applications](/docs/taskrouter/js-sdk-v1.md): Learn about integrating TaskRouter into your browser-based applications using the Javascript SDK.
+* [Reporting](/docs/taskrouter/contact-center-blueprint/reporting.md): Common reporting requirements for a contact center, including real-time dashboards and historical reports to ensure you have all the data you need.
+* [Contact Center Blueprint](/docs/taskrouter/contact-center-blueprint.md): Learn how to build a contact center on Twilio. Reference code samples, architecture guidance, and design philosophies as you build out your contact center.
+* [Using Email and TaskRouter Together](/docs/taskrouter/contact-center-blueprint/email-taskrouter.md): Learn how to add Email as a channel to your contact center, by combining a REST based third party email service with TaskRouter.
+* [Dashboards](/docs/taskrouter/contact-center-blueprint/dashboards.md): Learn about common requirements for real-time dashboards for your TaskRouter contact center including data flow, summaries, queues, and agents.
+* [Using Chat and TaskRouter Together](/docs/taskrouter/contact-center-blueprint/chat-taskrouter.md): Learn best practices for using Programmable Chat with TaskRouter for Contact Center use cases.
+* [Call Control Concepts](/docs/taskrouter/contact-center-blueprint/call-control-concepts.md): A conceptual overview of best practices for TaskRouter call control for reporting and dashboard accuracy, including holds, transfers, monitor, and barge.
+* [Workspace Resource](/docs/taskrouter/api/workspace.md): A full reference for the Workspace Resource of the TaskRouter API, with code samples to create, read, update, fetch, update, and delete a Workspace.
+* [REST API: Workspace Statistics](/docs/taskrouter/api/workspace-statistics.md): Learn about the Workspace Statistics TaskRouter provides. Find sample code for how to retrieve statistics, real-time statistics, and cumulative statistics for Workspaces.
+* [Workflow Resource](/docs/taskrouter/api/workflow.md): Full API reference for the Workflow resource in the Taskrouter REST API. Sample code shows how to create, fetch, read, update, and delete a Workflow.
+* [Workflow Statistics Resource](/docs/taskrouter/api/workflow-statistics.md): Learn about the Workflow Statistics resource, how to retrieve Workflow Statistics, RealTime Statistics, and Cumulative Statistics.
+* [Worker Reservation resource](/docs/taskrouter/api/worker-reservation.md): Full API reference for the TaskRouter API's Worker Reservation resource. Sample code shows how to fetch (get), read (list), and update a WokerReservation.
+* [Worker Channel Resource](/docs/taskrouter/api/worker-channel.md): Full API reference for the Worker Channels resource in the TaskRouter API. Sample code shows how to fetch (get), read (list), and update worker channels.
+* [Task Resource](/docs/taskrouter/api/task.md): A TaskRouter Task represents a single item of work waiting to be processed. This overview covers task attributes, versions, and a Task lifecycle.
+* [Task Queue resource](/docs/taskrouter/api/task-queue.md): Full API reference for theTaskQueue resource in the TaskRouter API. Find sample code showing how to create, fetch (get), read (list), update, and delete.
+* [Task Channel resource](/docs/taskrouter/api/task-channel.md): A full API reference for the Task Channel resource, including code samples to create, fetch, read, update, and delete Task Channels.
+* [Task Reservation Resource](/docs/taskrouter/api/reservations.md): Full API reference for the Task Reservations resource in the TaskRouter API. Find sample code that shows how to fetch (get) and update reservations.
+* [TaskRouter: REST API Reference](/docs/taskrouter/api.md): An overview of the TaskRouter API including the base URL for all TaskRouter resources and links to guides for best practices when building with this API.
+* [Activity Resource](/docs/taskrouter/api/activity.md): Learn about the Activity resource, which describes the current state of your Workers, including Activity properties, and how to create, read, update, and delete Activities.
+* [TaskRouter Python Quickstart](/docs/taskrouter/quickstart/python.md): In this Quickstart, build a simplified version of a multi-channel sales and technical support system using Twilio TaskRouter and Python.
+* [Setting up a TaskRouter Workspace: Add and Configure Workers](/docs/taskrouter/quickstart/php/setup-add-workers.md): Learn how to add and configure Workers in this part of the Setting up a TaskRouter Workspace guide.
+* [Creating Tasks and Accepting Reservations: Create a Task using the REST API](/docs/taskrouter/quickstart/php/reservations-create-task-rest.md): Learn how to create a Task using the REST API.
+* [TaskRouter: PHP quickstart](/docs/taskrouter/quickstart/php.md): In this Quickstart, build a simplified version of a multichannel sales and technical support system using Twilio TaskRouter and PHP.
+* [TaskRouter Java Quickstart](/docs/taskrouter/quickstart/java.md): In this Quickstart, build a simplified version of a multichannel sales and technical support system using Twilio TaskRouter and Java.
+* [TaskRouter .Net Quickstart](/docs/taskrouter/quickstart/csharp.md): In this Quickstart, build a simplified version of a multi-channel sales and technical support system using Twilio TaskRouter and .Net.
+* [TaskRouter.js v1 Worker: Managing workers in the browser](/docs/taskrouter/js-sdk-v1/workspace/worker.md): Comprehensive documentation about TaskRouter's JavaScript workers, used to route tasks in your web-based applications.
+* [TaskRouter.js v1 TaskQueue: Managing a TaskQueue resource in the browser](/docs/taskrouter/js-sdk-v1/workspace/taskqueue.md): Learn how to manage a TaskQueue resource in the browser using the TaskRouter Javascript SDK.
+* [TaskRouter.js v1 Workspace: Managing resources in the browser](/docs/taskrouter/js-sdk-v1/workspace.md): The TaskRouter Javascript SDK allows developers to interact with the entire TaskRouter REST API by a simple JS API.
+* [TaskRouter.js v1: Constructing JWTs: Managing access policies for client side requests](/docs/taskrouter/js-sdk-v1/workspace/constructing-jwts.md): Learn about generating JWTs from your server code as a means of authorizing which resources the client side application can access.
+* [Worker Statistics Resource](/docs/taskrouter/api/worker/statistics.md): Full API reference for the TaskRouter Worker Statistics resource. Code samples show how to fetch a resource and retrieve worker statistics.
+* [Worker Resource](/docs/taskrouter/api/worker.md): Twilio TaskRouter allows you to create, update, delete, and retrieve Workers, which are entities that can perform tasks. A Worker might be an agent working in a call center, or a salesperson handling leads.
+* [TaskRouter Events reference](/docs/taskrouter/api/event/reference.md): Learn about TaskRouter Events and find descriptions of all Event Callbacks.
+* [Event Resource](/docs/taskrouter/api/event.md): TaskRouter logs Events for each state change in the Workspace, allowing you to build historical reporting and auditing for your routing use case.
+* [REST API: TaskQueue Statistics](/docs/taskrouter/api/taskqueue-statistics.md): Full API reference for the TaskQueue Statistics resource in the TaskRouter API. Sample code shows how to retrieve real-time, cumulative, and instance TaskQueue Statistics.
+
+## Trust Hub
+
+* [Trust Hub](/docs/trust-hub.md): Your introduction to Trust Hub, Twilio's Know-Your-Customer (KYC) platform that helps you access products like SHAKEN/STIR attestation and A2P messaging.
+* [TrustHub REST API](/docs/trust-hub/trusthub-rest-api.md): Learn about all of the resources available in the TrustHub REST API.
+* [EndUser Resource](/docs/trust-hub/trusthub-rest-api/enduser-resource.md): API reference for the EndUser Resource in the TrustHub API.
+* [Console: Create a Primary Customer Profile](/docs/trust-hub/trusthub-rest-api/console-create-a-primary-customer-profile.md): Learn to create a primary customer profile in the Twilio Console, from inputting general information to submit for approval.
+* [API: Create a Secondary Customer Profile](/docs/trust-hub/trusthub-rest-api/api-create-secondary-customer-profile.md): Create a Secondary Customer Profile using the Trust Hub API.
+* [TrustProduct Resource](/docs/trust-hub/trusthub-rest-api/trust-products.md): Full API reference for the TrustProduct resource in the TrustHub API. Learn how to create, fetch, read, update, and delete.
+* [CustomerProfile Resource](/docs/trust-hub/trusthub-rest-api/customer-profiles.md): A full API reference for the CustomerProfile Resource on the TrustHub REST API, with code samples to create, fetch, read, update, and delete.
+
+## Twilio Alpha
+
+* [Twilio Alpha](/docs/alpha.md): Learn about how the Twilio Alpha program is investigating the future of customer engagement by leveraging the power of Twilio and artificial intelligence.
+
+## Twilio CLI
+
+* [Uninstall the Twilio CLI](/docs/twilio-cli/uninstall.md): Learn how to remove twilio-cli from your system
+* [Command-Line Interface (CLI) Quickstart](/docs/twilio-cli/quickstart.md): Learn how to quickly get started with the Twilio CLI to unleash the power of Twilio from your command line.
+* [CLI Plugins](/docs/twilio-cli/plugins.md): Learn how to extend the Twilio CLI by authoring (and optionally publishing) your own plugins.
+* [Twilio CLI](/docs/twilio-cli.md): Learn about the Twilio Command Line Interface
+* [Update](/docs/twilio-cli/getting-started/update.md): Learn how to update Twilio CLI to the latest version on your machine
+* [Install past versions of the Twilio CLI](/docs/twilio-cli/getting-started/past-versions.md): Learn how to install specific past versions of the twilio-cli for rare use cases
+* [Install the Twilio CLI](/docs/twilio-cli/getting-started/install.md): Learn how to install the latest version of twilio-cli on any operating system.
+* [Use the Twilio CLI Docker image](/docs/twilio-cli/getting-started/docker.md): Learn how to use and configure twilio-cli using the official Docker image.
+* [Work with webhooks](/docs/twilio-cli/general-usage/work-with-webhooks.md): Learn how to quickly connect Twilio phone numbers to webhooks or your local development environment with the Twilio CLI
+* [Subaccounts](/docs/twilio-cli/general-usage/subaccounts.md): Learn how to use Twilio subaccounts with the Twilio CLI
+* [Regional](/docs/twilio-cli/general-usage/regional.md): Learn how to make use of Twilio's regional capabilities while issuing CLI commands
+* [Profiles](/docs/twilio-cli/general-usage/profiles.md): Learn how to manage your Twilio credentials and settings in the Twilio CLI with Profiles
+* [Output formatting and filtering](/docs/twilio-cli/general-usage/output-formatting-and-filtering.md): Learn how to request different format outputs and filtered data from the Twilio CLI
+* [Logging and debugging](/docs/twilio-cli/general-usage/logging-and-debugging.md): Learn how to modify the logging level of the Twilio CLI and how it can speed up debugging
+* [CLI Limitations](/docs/twilio-cli/general-usage/limitations.md): Understand the limitations of the Twilio CLI
+* [CLI General Usage](/docs/twilio-cli/general-usage.md): Understand the basics of using the CLI. Learn how to use multiple accounts, environment variables, API core commands, webhooks, and more.
+* [Configuration](/docs/twilio-cli/general-usage/configuration.md): Learn how to configure settings for the Twilio CLI
+* [Autocomplete](/docs/twilio-cli/general-usage/autocomplete.md): Learn how to enable command autocompletion for the Twilio CLI
+* [CLI Examples](/docs/twilio-cli/examples.md): A collection of examples that show you how to do various things with Twilio's CLI.
+* [Get a phone number and send your first SMS](/docs/twilio-cli/examples/explore-sms.md): Learn how to get a Twilio phone number and send your first text message using only the command line.
+
+## Twilio Communications API
+
+* [Sender Pools](/docs/comms/sender-pools.md): Learn how to manage sender resources with Sender Pools in Twilio Communications API.
+
+* [Push Notifications API](/docs/comms/send-a-push.md): Learn how to send push notifications to Android, iOS, and web browsers using the Twilio Communications API.
+
+## Twilio Content Template Builder
+
+* [whatsapp/card](/docs/content/whatsappcard.md): Learn how to create and approve WhatsApp card templates with media and variables. Ensure compliance with WhatsApp's guidelines for seamless messaging.
+* [whatsapp/authentication](/docs/content/whatsappauthentication.md): Deliver verified one-time passwords on WhatsApp with ease using pre-approved templates. Ensure security and compliance with WhatsApp guidelines.
+* [twilio/card](/docs/content/twiliocard.md): Learn how to define and send a twilio/card content template, including required fields, supported channels, limitations, and data parameters.
+* [twilio/text](/docs/content/twilio-text.md): Learn about the \`twilio/text\` content type for plain text-based content and how to use it with content templates, variables, and supported channels.
+* [twilio/quick-reply](/docs/content/twilio-quick-reply.md): Send interactive messages with up to ten quick-reply buttons over WhatsApp or Facebook Messenger by using the twilio/quick-reply content type.
+* [twilio/pay](/docs/content/twilio-pay.md): Complete financial transactions all in app with twiliio/pay
+* [twilio/location](/docs/content/twilio-location.md): Learn how to use the \`twilio/location\` type to send location pins and optional labels in your messages.
+* [Session Definitions](/docs/content/session-definitions.md): Understand user-initiated and business-initiated WhatsApp sessions, approval needs, and how to use Twilio APIs for seamless messaging.
+* [Send templates created with the Content Template Builder](/docs/content/send-templates-created-with-the-content-template-builder.md): Learn how to send messages using templates created with the Content Template Builder in Twilio's Messaging Service.
+* [Content Templates overview](/docs/content/overview.md): Learn about the Content Template Builder and Content API to create and manage templated messages and rich content across multiple communication channels.
+* [Manage your Templates with the Content Template Builder](/docs/content/manage-your-templates-with-the-content-template-builder.md): Learn how to manage your Templates using the Content Template Builder in the Twilio Console, including searching, filtering, viewing details, and submitting Templates for WhatsApp approval.
+* [Twilio Content Template Builder](/docs/content.md): Create and send omnichannel rich content templates across any Twilio-supported channel. The Content Template Builder provides both a no-code Console UI and an API for programmatic creation and management.
+* [twilio/flows](/docs/content/flows.md): Collect multiple pieces of customer input by using Twilio Flows.
+* [Create templates with the Content Template Builder in Console](/docs/content/create-templates-with-the-content-template-builder.md): Learn how to create and manage templates across channels such as WhatsApp, RCS, Facebook Messenger, MMS, and SMS by using the Content Template Builder in Twilio Console.
+* [twilio/carousel](/docs/content/carousel.md): Drive interaction with Twilio/carousel, a versatile tool to display your services or products in a visually engaging carousel format. Incorporate media, text, and buttons in each card to enhance user experience on WhatsApp and RCS.
+* [Content API public endpoints](/docs/content/content-api-resources.md): Learn how to create, retrieve, submit for approval, and delete templates by using the Twilio Content API.
+
+## Twilio Labs
+
+* [Twilio Labs](/docs/labs.md): Twilio Labs host a variety of open-source projects that were developed by people&#x20;
+  at Twilio and the community. Every one of these projects welcomes contributions.
+* [Twilio Dev Phone](/docs/labs/dev-phone.md): Learn how to install and use the Twilio Dev Phone to send and receive calls and SMS from your local development environment.
+
+## Twilio Segment
+
+* [Twilio Segment](/docs/segment.md): Use Segment to collect and activate your customer data.
+* [Unify Onboarding Guide](/docs/segment/unify/quickstart.md): Learn how to configure and use a Unify space.
+* [Profile API](/docs/segment/unify/profile-api.md): Use the Segment Profile API for real-time, personalized customer insights. Empower your apps with user-level data for enhanced engagement and sales.
+* [Unify Overview](/docs/segment/unify.md): Use Unify to track and merge customer interactions into unified profiles. Enhance marketing with real-time insights and personalized experiences.
+* [User Deletion and Suppression](/docs/segment/privacy/user-deletion-and-suppression.md): Ensure privacy compliance with Segment's data deletion and suppression tools.
+* [Data Retention and Deletion Policy](/docs/segment/privacy/data-retention-policy.md): Discover how Segment's flexible billing and data retention model optimizes costs and ensures data security with clear retention policies for all customer tiers.
+* [Segment for Developers](/docs/segment/guides/intro-impl.md): Get started with Segment implementation to efficiently manage data flows and integrations.
+* [An introduction to Segment](/docs/segment/guides.md): Discover how Segment simplifies customer data collection and integration. Unlock insights with seamless data management, unification, and personalized user experiences.
+* [Filtering your Segment Data](/docs/segment/guides/filtering-data.md): Discover how to use Segment's data filtering options for precise control over event destinations.
+* [What is Segment?](/docs/segment/getting-started.md): Learn more about tracking first-party customer data with Segment.
+* [Getting Started Guide](/docs/segment/getting-started/implementation-guide.md): Discover Segment's in-product guide, designed to streamline your data integration process, expand data reach, and optimize workspace efficiency.
+* [Testing and Debugging](/docs/segment/getting-started/06-testing-debugging.md): Discover how to confirm Segment's functionality with tools like Source Debugger and Event Delivery. Monitor data flow and ensure successful event tracking.
+* [A Full Segment Implementation](/docs/segment/getting-started/04-full-install.md): Discover Segment's six key tracking methods to streamline data collection and enhance consistency. Learn when and how to effectively apply each one.
+* [A Basic Segment Installation](/docs/segment/getting-started/02-simple-install.md): Learn how to install Segment to implement JavaScript, PHP, or iOS libraries and optimize your analytics.
+* [How Segment works](/docs/segment/getting-started/01-what-is-segment.md): Learn more about how Segment works.
+* [Using Engage Data](/docs/segment/engage/using-engage-data.md): Personalize messages and optimize ad spend by sending Computed Traits and Audiences to Segment Destinations. Discover how to activate Engage data.
+* [Testing connections](/docs/segment/connections/test-connections.md): Validate Segment connections with Event and Mappings Testers.
+* [Connections Overview](/docs/segment/connections.md): Collect and unify your customer data with Connections, which integrates with mobile apps, CRMs, and more for a holistic view.
+* [Delivery Overview](/docs/segment/connections/delivery-overview.md): Diagnose and resolve event delivery issues with Segment's Delivery Overview. Gain insights into your data pipeline using detailed visualizations to optimize performance.
+* [SQL Traits](/docs/segment/unify/traits/sql-traits.md): Import and manage SQL Traits in Segment for enhanced personalization. Leverage data from cloud sources to build audiences and meet your business goals.
+* [Custom Traits](/docs/segment/unify/traits/custom-traits.md): Discover how to use Segment custom traits from Identify calls to enrich user profiles with demographics and account info without trait limits.
+* [Computed Traits](/docs/segment/unify/traits/computed-traits.md): Learn more about how computed traits help you to create user or account-level computations based on events and event properties.
+* [Profiles Sync Tables and Materialized Views](/docs/segment/unify/profiles-sync/tables.md): Discover how Segment's Profiles Sync enhances customer data integration with raw tables and materialized views, optimizing profile and event data management.
+* [Profiles Sync overview](/docs/segment/unify/profiles-sync/overview.md): Connect identity-resolved profiles to your data warehouse with Profiles Sync. Enrich data, analyze attribution, create models, and more.
+* [Linked Events Overview](/docs/segment/unify/data-graph/linked-events.md): Enrich event streams with Linked Events, seamlessly integrating Snowflake, BigQuery, Redshift, or Databricks for richer data and optimized insights.
+* [Data Graph](/docs/segment/unify/data-graph.md): Discover insights with the Data Graph's semantic layer. Access relational datasets for personalized marketing without constant data team support.
+* [Identity Resolution Overview](/docs/segment/unify/identity-resolution.md): Learn more about how Identity Resolution merges customer histories into single profiles for real-time insights across all interactions.
+* [Protocols Tracking Plan](/docs/segment/protocols/tracking-plan/create.md): Learn how to create a detailed Segment Tracking Plan to improve data accuracy across your sources.
+* [Data Collection Best Practices](/docs/segment/protocols/tracking-plan/best-practices.md): Maximize your app's success with our data tracking resources. Define objectives, standardize events, and improve insights for marketing and analytics teams.
+* [Typewriter](/docs/segment/protocols/apis-and-extensions/typewriter.md): Boost your analytics with Typewriter. Generate type-safe Segment libraries from your Tracking Plan to improve accuracy and performance.
+* [Consent Management Overview](/docs/segment/privacy/consent-management.md): Streamline data consent with Segment's Consent Management feature. Enforce end-user consent preferences, ensuring compliance and optimized data flow.
+* [Configure Consent Management](/docs/segment/privacy/consent-management/configure-consent-management.md): Configure consent in Segment to enforce data preferences, ensuring user-approved event routing. Improve privacy compliance with precise category mapping.
+* [MTUs, Throughput and Billing](/docs/segment/guides/usage-and-billing/mtus-and-throughput.md): Discover Segment's billing model with API calls, MTUs, and throughput. Understand usage insights, deduplication, and optimize third-party data integration.
+* [Linked Audiences](/docs/segment/engage/audiences/linked-audiences.md): Create targeted audiences with Linked Audiences to use behavioral and entity data in a no-code interface for precise marketing.
+* [Engage Audiences Overview](/docs/segment/engage/audiences.md): Use Engage Audiences to leverage events, traits, and APIs to sync across destinations, refine targeting, elevate engagement.
+* [Spec: Track](/docs/segment/connections/spec/track.md): Use Segment's Track API to seamlessly capture and describe user actions with customizable events and properties, enhancing your analytics capabilities.
+* [Spec: Screen](/docs/segment/connections/spec/screen.md): Record user interactions on mobile screens with Segment's Screen call. Send screen details and properties for seamless app tracking and insights.
+* [What is the native mobile spec?](/docs/segment/connections/spec/native-mobile-spec.md): Discover how the Native Mobile Spec automates event tracking for mobile apps, reducing engineering time and enhancing campaign analysis.
+* [Native Mobile Spec](/docs/segment/connections/spec/mobile.md): Enhance mobile analytics with Segment by using standard event names to optimize tracking and destination mapping.
+* [Spec Overview](/docs/segment/connections/spec.md): Learn more about the Segment Spec which provides guidance on meaningful data to capture, and the best format for it, across Segment's libraries and APIs.
+* [Spec: Identify](/docs/segment/connections/spec/identify.md): Tie user actions to profiles using Segment's Identify call. Capture traits like email and User ID for personalized insights.
+* [Spec: Group](/docs/segment/connections/spec/group.md): Associate users with groups using the Group API call. Manage user-group associations and update traits to tailor interactions.
+* [Spec: Common fields](/docs/segment/connections/spec/common.md): Discover how API calls in Segment vary by destination and structure with specific fields. Learn to customize integrations and optimize data flow.
+* [Best Practices for Identifying Users](/docs/segment/connections/spec/best-practices-identify.md): Maximize user insights with Segment's Identify and Track calls. Link actions to users, reduce costs, and enhance data accuracy.
+* [Spec: Alias](/docs/segment/connections/spec/alias.md): Merge unassociated user identities seamlessly using the Alias method, enhancing data connectivity and compatibility with downstream applications.
+* [Sources Overview](/docs/segment/connections/sources.md): Create sources with Segment to efficiently track customer data from websites, apps, or servers. Enhance insights and control with targeted data collection.
+* [Segment-Managed Custom Domain](/docs/segment/connections/sources/custom-domain.md): Enhance your data tracking with Custom Domain. Securely gather first-party data over HTTPS to boost user insights and maximize marketing ROI.
+* [Source Functions](/docs/segment/connections/functions/source-functions.md): Collect data from third-party apps with Source Functions, without managing infrastructure.
+* [Destination Insert Functions](/docs/segment/connections/functions/insert-functions.md): Use Destination Insert Functions to transform and enrich your data before it reaches its destination. Customize logic, enhance compliance, and optimize data flow.
+* [Functions Overview](/docs/segment/connections/functions.md): Streamline data flows by creating custom sources and destinations with Segment Functions. Transform, send, and enrich data using minimal code.
+* [Destination Functions](/docs/segment/connections/functions/destination-functions.md): Use destination functions to transform and annotate Segment events and send them to external tools or APIs.
+* [Set up Reverse ETL](/docs/segment/connections/reverse-etl/setup.md): Learn how to set up Reverse ETL.
+* [Reverse ETL](/docs/segment/connections/reverse-etl.md): Reverse ETL syncs warehouse data to tools like Salesforce and Google Ads, empowering personalized marketing and enriched customer insights.
+* [Destinations Overview](/docs/segment/connections/destinations.md): Act on real-time data with Segment Destinations. Explore compatible tools with our catalog, streamline analytics, and unlock customer insights instantly.
+* [Destination Filters](/docs/segment/connections/destinations/destination-filters.md): Use Segment's destination filters to prevent certain data from flowing into a destination.
+* [Destination Actions](/docs/segment/connections/destinations/actions.md): Control data flow with Segment's Destination Actions, enabling transparent setup and customization for efficient event data management in destinations.
+* [Public API](/docs/segment/api/public-api.md): Use the Segment Public API to manage your Segment workspaces and their resources.
+* [Config API Overview](/docs/segment/api/config-api.md): Use the Config API to programmatically manage Segment workspaces, sources, destinations, and more.
+* [Set up Profiles Sync](/docs/segment/unify/profiles-sync/profiles-sync-setup.md): Learn to set up Profiles Sync for connected data warehouses like Snowflake, Redshift, or BigQuery, enabling seamless historical backfill and sync control.
+* [Event-Triggered Journeys](/docs/segment/engage/journeys/v2.md): Build responsive, real-time marketing workflows with Event-Triggered Journeys. Automate customer experiences upon specific actions for personalized engagement.
+* [Warehouse Schemas](/docs/segment/connections/storage/warehouses/schema.md): Discover how Segment organizes and transforms your data into relational schemas for efficient querying in warehouses. Explore methods to optimize event data.
+* [Data Warehouses](/docs/segment/connections/storage/warehouses.md): Discover how to choose and manage a data warehouse effectively, from understanding your data needs to optimizing SQL analysis and user permissions.
+* [Warehouse FAQs](/docs/segment/connections/storage/warehouses/faq.md): Learn more about using warehouses with these frequently asked questions.
+* [Spec: V2 Ecommerce Events](/docs/segment/connections/spec/ecommerce/v2.md): Gain insights into customer journeys with Segment's e-commerce spec. Track events from browsing to checkout, ensuring optimal e-commerce performance.
+* [Source Schema](/docs/segment/connections/sources/schema.md): Manage event flow with Segment's Schema Controls, protecting data integrity and optimizing decisions.
+* [Quickstart: Analytics.js](/docs/segment/connections/sources/catalog/libraries/website/javascript/quickstart.md): Learn how to send data from your website to Segment and any of Segment's destinations with Analytics.js.
+* [Analytics.js Source](/docs/segment/connections/sources/catalog/libraries/website/javascript.md): Integrate Analytics.js to enhance site performance and developer experience with seamless data transfer to multiple tools.
+* [Managing identity in Analytics.js](/docs/segment/connections/sources/catalog/libraries/website/javascript/identity.md): Learn how Analytics.js manages user data by identifying, overriding, and refreshing \`userID\` and \`anonymousID\`, using settings in cookies and local storage.
+* [Self-Managed Custom Proxy](/docs/segment/connections/sources/catalog/libraries/website/javascript/custom-proxy.md): Set up a custom proxy for Analytics.js to track events through your own domain.
+* [Client-side persistence in Analytics.js](/docs/segment/connections/sources/catalog/libraries/website/javascript/cookie-validity-update.md): Learn about what data Analytics.js stores on the client and how to modify or override that storage behavior.
+* [Analytics for Python](/docs/segment/connections/sources/catalog/libraries/server/python.md): Use Segment's Python library to record analytics data from your Python code.
+* [Analytics for Node.js](/docs/segment/connections/sources/catalog/libraries/server/node.md): Use Segment's Analytics Node.js library to record analytics data from your node code.
+* [HTTP API Source](/docs/segment/connections/sources/catalog/libraries/server/http-api.md): Use Segment HTTP API for seamless data collection from any site or app. Ensure efficient data routing with flexible, high performance and integration options.
+* [Analytics-Swift for iOS and Apple](/docs/segment/connections/sources/catalog/libraries/mobile/apple.md): Transform your app's data tracking with Analytics-Swift.
+
+## Twilio SendGrid
+
+* [Twilio SendGrid](/docs/sendgrid.md): Learn to send transactional and marketing emails at scale with the platform that offers a 99% deliverability rate. From quickstarts and onboarding guides to full API reference, the Twilio SendGrid docs have everything you need to send email at scale.
+* [Twilio SendGrid user interface documentation](/docs/sendgrid/ui.md): SendGrid's user interface documentation provides information on how to navigate the SendGrid web-based interface, also known as the UI, App, and Console.
+* [Twilio SendGrid developer documentation](/docs/sendgrid/for-developers.md): SendGrid's for-developers documentation provides information on how to use and configure SendGrid's APIs and developer-focused tools, including how to send email and configure your necessary DNS changes.
+* [Email concepts](/docs/sendgrid/concepts.md): Concepts cover the basics of bulk email messaging.
+* [Email Flow](/docs/sendgrid/concepts/email-flow.md): A basic diagram and description of how each email message flows in general and through SendGrid
+* [X-Message-ID](/docs/sendgrid/glossary/x-message-id.md): \*Analytics\*. An SMTP email header that Twilio SendGrid includes in email messages it sends as event webhook metadata.
+* [Webhook](/docs/sendgrid/glossary/webhook.md): \*Analytics\*. An event-driven communication that sends data between apps using custom HTTP POST request to a URL.
+* [Web API](/docs/sendgrid/glossary/web-api.md): \*API\*. A programming interface that allows web servers and web browsers to connect and enable account and data collection for services like email.
+* [Urchin Tracking Module (UTM) parameters](/docs/sendgrid/glossary/utm-parameters.md): \*Analytics\*. Five URL parameters added to links that marketers use to track online marketing campaigns.
+* [Unsubscribe](/docs/sendgrid/glossary/unsubscribes.md): \*Email Deliverability\*. A recipient's voluntary decision to remove themself from a sender's bulk email service.
+* [Unknown User](/docs/sendgrid/glossary/unknown-user.md): \*Email Deliverability\*. The removal of recipient email address that doesn't exist on the recipient email server from a contact list.
+* [Undelivered Email](/docs/sendgrid/glossary/undelivered-email.md): \*Email Deliverability\*. A category of reasons why an email address wasn't sent to a recipient's inbox.
+* [Two Factor Authentication (2FA)](/docs/sendgrid/glossary/two-factor-authentication.md): \*Internet Security\*. Use of two or more means of user identification to grant access to a system.
+* [Trusted sender](/docs/sendgrid/glossary/trusted-sender.md): \*Reputation\*. An email sender who only sends email messages to those recipients that granted explicit permission to that sender.
+* [Triggered email](/docs/sendgrid/glossary/triggered-email.md): \*Marketing\*. An email message sent in response to specific events or actions.
+* [Triggered action](/docs/sendgrid/glossary/triggered-actions.md): \*Marketing\*. A task executed once a customer meets a pre-defined condition.
+* [Transactional email](/docs/sendgrid/glossary/transactional-email.md): \*Marketing\*. An email message sent in response to a user interaction with a web application.
+* [Transactional Email Templates](/docs/sendgrid/glossary/transactional-email-templates.md): \*Marketing\*. A predesigned email layout, and sometimes content, that you can apply to transactional emails.
+* [Transport Layer Security (TLS)](/docs/sendgrid/glossary/tls.md): \*Internet Security\*, \*Internet Standard\*. The set of rules that encrypts internet traffic between systems.
+* [Time zone](/docs/sendgrid/glossary/timezone.md): \*Internet standard\*. Local time, based on your current geographic location on the earth.
+* [Throttling](/docs/sendgrid/glossary/throttling.md): \*Email Deliverability\*. A recipient inbox provider reduces throughput of email messages below the level at which sender mail server sent the email messages.
+* [Teammates](/docs/sendgrid/glossary/teammates.md): \*Configuration\*. Option that allows multiple physical users to share access to a single Twilio SendGrid account.
+* [Reserved substitution tags](/docs/sendgrid/glossary/system-fields.md): \*Configuration\*. Placeholder labels that get replaced with personalized content in an email campaign.
+* [Suspicious Sender](/docs/sendgrid/glossary/suspicious-sender.md): \*Reputation\*. An email sender who sends email messages to recipients that never granted explicit permission to that sender.
+* [Subscriber list management](/docs/sendgrid/glossary/subscriber-list-management.md): \*Marketing\*. The validation that subscribers found in your contact lists remain active and engaged with your email marketing.
+* [Spoofing](/docs/sendgrid/glossary/spoofing.md): \*Internet Security\*. A technique where a falsified sender email addresses attempts to trick recipients into opening an email message.
+* [Sender Policy Framework (SPF)](/docs/sendgrid/glossary/spf.md): \*Internet Security\*, \*Internet Standard\*. An email authentication standard that sets which servers can send email from their domain.
+* [Spam](/docs/sendgrid/glossary/spam.md): \*Reputation\*. An email message sent to a recipient that they didn't request or want.
+* [Spam Traps](/docs/sendgrid/glossary/spam-traps.md): \*Reputation\*. Email addresses created without active owners to identify spammers and senders with poor data quality practices.
+* [Spam report](/docs/sendgrid/glossary/spam-reports.md): \*Reputation\*. A feedback mechanism that identifies electronic messages as abusing the transmission medium and reports them to an authority for remediation.
+* [Spam Filter](/docs/sendgrid/glossary/spam-filter.md): \*Email Deliverability\*. Algorithms that identify and remediate unwanted email messages.
+* [Simple Mail Transfer Protocol (SMTP)](/docs/sendgrid/glossary/smtp.md): \*Internet standard\*. The communication rules that systems follow for the reliable and efficient transfer of email messages.
+* [SMTP service](/docs/sendgrid/glossary/smtp-service.md): \*Email Deliverability\*. Third-party managed service that delivers email messages to a large audience.
+* [SMTP Server](/docs/sendgrid/glossary/smtp-server.md): \*Internet standard\*. An app or server that sends email and react to response codes from receiving servers.
+* [SMTP relay](/docs/sendgrid/glossary/smtp-relay.md): \*Internet standard\*. A system that sends email between SMTP servers on different domains.
+* [SMTP Provider](/docs/sendgrid/glossary/smtp-provider.md): \*Service Provider\*. A vendor that helps send large quantities of email messages to recipients.
+* [SMTP API](/docs/sendgrid/glossary/smtp-api.md): \*API\*. A progamming interface that provides customized email handling instructions on a per-email basis.
+* [Single send](/docs/sendgrid/glossary/single-send.md): \*Marketing\*. A non-recurring email message that communicates non-automated, non-sequential content.
+* [Sends](/docs/sendgrid/glossary/sends.md): \*Analytics\*. A request for Twilio SendGrid to deliver email to your recipients.
+* [Senders](/docs/sendgrid/glossary/senders.md): Identity of the individual, position, or organization sending an email message.
+* [Sender ID](/docs/sendgrid/glossary/sender-id.md): \*Internet Security\*. A deprecated email authentication standard that checked that a domain authorized a given email address to send on its behalf.
+* [Sender authentication](/docs/sendgrid/glossary/sender-authentication.md): \*Internet Security\*. The process that shows ISPs that you gave your mailbox provide permission to send emails on your behalf.
+* [Segments](/docs/sendgrid/glossary/segments.md): \*Marketing\*. A dynamic collection of contacts grouped based on criteria you define.
+* [Segmentation](/docs/sendgrid/glossary/segmentation.md): \*Marketing\*. The practice of channeling email traffic based on the intent and audience of email messages.
+* [Scheduled Emails](/docs/sendgrid/glossary/scheduled-emails.md): \*Marketing\*. Configuring a system to send email messages starting at a given date and time.
+* [Reverse DNS](/docs/sendgrid/glossary/reverse-dns.md): \*Internet Standard\*. Method for systems to resolve an IP address from a domain name.
+* [Reserved fields](/docs/sendgrid/glossary/reserved-fields.md): \*Configuration\*. Predefined and protected attributes provided for email contacts.
+* [Reseller email account](/docs/sendgrid/glossary/reseller-email-account.md): \*Service Provider\*. Email account created after a company entered into a partnership with Twilio.
+* [Request](/docs/sendgrid/glossary/request.md): \*Analytics\*. The record of an attempt to send an email through Twilio SendGrid.
+* [Reconfirmation email](/docs/sendgrid/glossary/reconfirmation.md): \*Reputation\*. An email message sent to existing recipients asking them to confirm that they still want your messages.
+* [Rate limiting](/docs/sendgrid/glossary/rate-limiting.md): \*Email Deliverability\*. See Throttling.
+* [Pointer record (PTR)](/docs/sendgrid/glossary/ptr.md): \*Internet standard\*. A DNS record that maps an IP address to one hostname in a domain.
+* [Programmatic media buying](/docs/sendgrid/glossary/programmatic-media-buying.md): \*Advertising\*. Process of buying paid media through sophisticated software that automates how the buying, placing, and optimizing of paid media.
+* [Preheader](/docs/sendgrid/glossary/preheader.md): \*Marketing\*. The short summary text that follows the subject line when you view an email in your inbox.
+* [Phishing](/docs/sendgrid/glossary/phishing.md): \*Internet Security\*. The act of masquerading as a trusted business to acquire personally identifiable information.
+* [Peer-initiated invitations campaign](/docs/sendgrid/glossary/peer-invitations.md): \*Marketing\*. A email marketing campaign designed to get customers to invite their friends and family.
+* [Open & Unique Open](/docs/sendgrid/glossary/opens.md): \*Analytics\*. The record of each time a customer opens your Twilio SendGrid email messages.
+* [Open relay](/docs/sendgrid/glossary/openrelay.md): \*Internet Security\*. An unsecured SMTP relay that routes email between domains.
+* [Open Rate](/docs/sendgrid/glossary/open-rate.md): \*Analytics\*. The frequency by which your customers open emails that you send.
+* [Native advertising](/docs/sendgrid/glossary/native-advertising.md): \*Advertising\*. A type of advertising that resembles the content of the surrounding medium.
+* [Mail Exchanger record (MX)](/docs/sendgrid/glossary/mx-record.md): \*Internet standard\*. A DNS record that maps the hostname in a domain that accepts email for the domain.
+* [Mail User Agent (MUA)](/docs/sendgrid/glossary/mua.md): \*Internet standard\*. An app that you use to compose and send email messages.
+* [Mail Transfer Agent (MTA)](/docs/sendgrid/glossary/mta.md): \*Internet standard\*. A system that transfers email messages from one computer to another using a client-server application architecture.
+* [Twilio SendGrid message ID](/docs/sendgrid/glossary/message-id.md): \*Marketing\*. A unique identifier that Twilio SendGrid generates and assigns to an email message for event identification purposes.
+* [Mailbox provider](/docs/sendgrid/glossary/mailbox-provider.md): \*Marketing\*. A service organization that provides transactional email services, marketing email services, or both.
+* [Mail merge](/docs/sendgrid/glossary/mail-merge.md): \*Marketing\*. A process that generates customized email messages from a generic template and store of contact data.
+* [Lists](/docs/sendgrid/glossary/lists.md): \*Marketing\*. Static collections of contacts to whom email messages can be sent.
+* [Link branding](/docs/sendgrid/glossary/link-branding.md): \*Marketing\*. Change the domain for open and click tracking links to your domain.
+* [IP address warmup](/docs/sendgrid/glossary/ip-warmup.md): \*Email Deliverability\*. The establishment of a reputation as a legitimate email sender through the gradual and regular increase in the volume of email sent from one IP address.
+* [IP Address](/docs/sendgrid/glossary/ip-address.md): \*Internet standard\*. A unique numerical address that identifies a virtual location on the internet.
+* [Invalid Email](/docs/sendgrid/glossary/invalid-email.md): \*Email Deliverability\*. The removal of recipient email address that doesn't conform to the \[Internet Engineering Task Force (IETF)]\(https://www.ietf.org/) email address syntax standards from a contact list.
+* [SendGrid Glossary](/docs/sendgrid/glossary.md): A repository of the technical terms and jargon that intrepid Twilio SendGrid developers may encounter on their building journey.
+* [Internet Message Access Protocol (IMAP)](/docs/sendgrid/glossary/imap.md): \*Internet standard\*. The communication rules that systems follow to let you read and retrieve email messages from your inbox provider.
+* [Header](/docs/sendgrid/glossary/header.md): \*Internet standard\*. Metadata that informs email recipients and servers of the routing, formatting, and security of an email message.
+* [General Data Protection Regulation of 2018](/docs/sendgrid/glossary/gdpr.md): \*Regulation\*. European Union law that regulates the handling of personal data and outlines the rights individuals have regarding their data.
+* [Frequency capping](/docs/sendgrid/glossary/frequency-capping.md): \*Advertising\*. The setting of a maximum number of times a specific viewer sees a specific ad.&#x20;
+* [Fully Qualified Domain Name (FQDN)](/docs/sendgrid/glossary/fqdn.md): \*Internet standard\*. A human-readable label that identifies a specific server on the internet.
+* [Flighting](/docs/sendgrid/glossary/flighting-in-advertising.md): \*Advertising\*. The time in which an advertising campaign runs.
+* [Feedback loop](/docs/sendgrid/glossary/feedback-loop.md): \*Reputation\*. A process where an service provider forwards emails reported as spam to a sender for removal.
+* [Expired](/docs/sendgrid/glossary/expired.md): \*Email Deliverability\*. The removal of recipient email address from a contact list when an SMTP server couldn't deliver an email message to the recipient within 72 hours.
+* [Expandable Banner](/docs/sendgrid/glossary/expandable-banner.md): \*Advertising\*. A design of a digital advertisement that increases in size when a viewer clicks or hovers over the ad.
+* [Email service provider (ESP)](/docs/sendgrid/glossary/email-service-provider.md): \*Service Provider\*. A service organization that provides transactional and marketing email services.
+* [Email reputation score](/docs/sendgrid/glossary/email-reputation-score.md): \*Reputation\*. The rating an internet service provider or inbox provider sets for email sent from your email server IP addresses.
+* [Email marketing](/docs/sendgrid/glossary/email-marketing.md): \*Marketing\*. The promotion of a commercial product or service conveyed in an email message.
+* [Email harvesting](/docs/sendgrid/glossary/email-harvesting.md): \*Reputation\*. The process of obtaining lists of valid email addresses other than affirmative consent of the recipients for the purpose of sending bulk email.
+* [Email Authentication](/docs/sendgrid/glossary/email-authentication.md): \*Internet Security\*. Technical standards to help ISPs and other receivers validate the identity of an email sender.
+* [Email API integration](/docs/sendgrid/glossary/email-api-integration.md): \*API\*. The facilitation of automating key functions through the synchronization of a sender's email service provider with their platform and software tools.
+* [Drops](/docs/sendgrid/glossary/drops.md): \*Email Deliverability\*. The removal of an email message to a specific recipient to protect the sender's reputation.
+* [Drip campaign](/docs/sendgrid/glossary/drip-campaign.md): \*Marketing\*. An email marketing strategy that sends engagement email messages on a schedule.
+* [Domain](/docs/sendgrid/glossary/domain.md): \*Internet standard\*. A human-readable branding for an individual or organization's presense on the internet.
+* [Domain authentication](/docs/sendgrid/glossary/domain-authentication.md): \*Internet Security\*. Protocols and policies that specify IP addresses and domains as proof of identity of an individual or organization sending email messages.
+* [Domain Name System](/docs/sendgrid/glossary/dns.md): \*Internet standard\*. A hierarchical system of software and systems that translate a fully qualified domain name into an IP address.
+* [Domain-based Message Authentication, Reporting and Conformance (DMARC)](/docs/sendgrid/glossary/dmarc.md): \*Internet Security\*, \*Internet Standard\*. A domain-based policy for determining the authenticity of the person or service sending email on behalf of a domain.
+* [DomainKeys Identified Mail (DKIM)](/docs/sendgrid/glossary/dkim.md): \*Internet standard\*. An domain-based email authentication protocol that helps ISPs better identify legitimate email senders.
+* [Direct response advertising](/docs/sendgrid/glossary/direct-response-advertising.md): \*Advertising\*. A advertising tactic where ad content encourages or prompts viewers of an ad to act or to engage with the ad directly.
+* [Demand-side platform (DSP)](/docs/sendgrid/glossary/demand-side-platform.md): \*Advertising\*. Software that helps advertisers or ad agencies buy digital ad inventory across publishers, supply-side platforms, and ad exchanges.
+* [Delivery](/docs/sendgrid/glossary/deliveries.md): \*Email Deliverability\*. A confirmation that an end recipient received the email that the sender had sent.
+* [Deliverability](/docs/sendgrid/glossary/deliverability.md): \*Email Deliverability\*. The measure of how many emails sent that reach their intended recipients without issue.
+* [Deferral](/docs/sendgrid/glossary/deferrals.md): \*Email Deliverability\*. A deferred status can occur when an ISP or mailbox provider can't to accept email from your IP address.
+* [Custom fields](/docs/sendgrid/glossary/custom-fields.md): \*Configuration\*. Original contact attribute added to your email contacts.
+* [Click-through rate](/docs/sendgrid/glossary/ctr.md): \*Analytics\*. A metric of interest in content linked in an email message expressed as a percentage of recipients that click a link in your email message.
+* [Complaint](/docs/sendgrid/glossary/complaint.md): \*Reputation\*. A record of an email recipient reporting an email message as spam.
+* [Canonical Name record (CNAME)](/docs/sendgrid/glossary/cname.md): \*Internet standard\*. A DNS record that maps one hostname in a domain to another hostname instead of an IP address.
+* [Clicks and unique clicks](/docs/sendgrid/glossary/clicks.md): \*Analytics\*. A record of each time a customer clicks any link in your Twilio SendGrid emails.
+* [Challenge-response spam filtering](/docs/sendgrid/glossary/challenge-response.md): \*Internet Security\*. A type of spam filter that replies with a challenge to the given sender.
+* [Content delivery network](/docs/sendgrid/glossary/cdn.md): \*Service Provider\*. A global network of servers that stores and serves copies of website content to website visitors using the server geographically closest to each website visitor.&#x20;
+* [Categories](/docs/sendgrid/glossary/categories.md): \*Analytics\*. One or more topical tags applied to an email message that aids in analyzing email campaign effectiveness.&#x20;
+* [Canadian Anti-Spam Law of 2014](/docs/sendgrid/glossary/casl.md): \*Regulation\*. Canadian law that lists the guidelines, requirements, and penalties regarding the sending of commercial bulk email.
+* [Canonicalization](/docs/sendgrid/glossary/canonicalization.md): \*Internet standard\*. The standardization of email messages formatting that enables consistent hashed values for validating email messages.
+* [CAN-SPAM Act of 2003](/docs/sendgrid/glossary/can-spam.md): \*Regulation\*. US law that lists the guidelines, requirements, and penalties regarding the sending of commercial bulk email.
+* [Campaigns](/docs/sendgrid/glossary/campaigns.md): \*Marketing\*. The act of sending customized email messages to a group of targeted recipient segments.
+* [Bulk mail folder](/docs/sendgrid/glossary/bulk-mail-folder.md): \*Email Deliverability\*. A location in a recipient's inbox into which the inbox provider routes email of questionable use or providence.
+* [Bulk email service](/docs/sendgrid/glossary/bulk-email-service.md): \*Marketing\*. Software or service through which one sender can send one or many email messages to a large list of recipients.
+* [Bounced email messages](/docs/sendgrid/glossary/bounces.md): \*Email Deliverability\*. A permanent rejection of messages sent from your IP address.
+* [Blocked email messages](/docs/sendgrid/glossary/blocks.md): \*Email Deliverability\*. A temporary rejection of messages sent from your IP address.
+* [Blocklist](/docs/sendgrid/glossary/blocklist.md): \*Email Deliverability\*. A list of IP addresses, email addresses, or domains known to ISPs or list providers for sending unsolicited or unwanted emails.
+* [Bayesian filter](/docs/sendgrid/glossary/bayesian-filter.md): \*Email Deliverability\*. A statistical technique that detects email spam.
+* [Autoresponder](/docs/sendgrid/glossary/autoresponder.md): \*Marketing\*. A system that generates email responses to actions and events.
+* [Automated email](/docs/sendgrid/glossary/automated-email.md): \*Marketing\*. A system that allows the sending of messages with content relevant to individual recipients.
+* [Allowlist](/docs/sendgrid/glossary/allow-list.md): \*Internet Security\*. A curated selection of domains, email addresses, or IP addresses that a service or system has granted explicit access.
+* [Affirmative consent](/docs/sendgrid/glossary/affirmative-consent.md): \*Reputation\*. The informed, explicit acceptance that a recipient granted you to receive your email.
+* [Affiliate marketing](/docs/sendgrid/glossary/affiliate-marketing.md): \*Marketing\*. An activity in which companies offer to pay individuals or other businesses to promote their products or services.
+* [Ad unit](/docs/sendgrid/glossary/ad-unit.md): \*Advertising\*. The container that holds the advertising copy and graphics for a digital advertisement on a screen.
+* [Ad impression](/docs/sendgrid/glossary/ad-impression.md): \*Advertising\*. One occurence of an advertisement displaying on a screen.
+* [Ad exchange](/docs/sendgrid/glossary/ad-exchange.md): \*Advertising\*. A digital marketplace where advertisers and publishers can buy and sell display, video, and mobile advertising.
+* [SendGrid v3 API reference](/docs/sendgrid/api-reference.md): The SendGrid API reference provides detailed descriptions and code samples for every Twilio SendGrid API.
+* [Create an email design](/docs/sendgrid/ui/sending-email/working-with-marketing-campaigns-email-designs.md): Twilio SendGrid creates messages based on templates called Designs. To create a template for your Single Send messages, start with the Design Library.
+* [The Weblink Substitution Tag](/docs/sendgrid/ui/sending-email/weblink.md): The Webklink tag is replaced with a link that will open the email in a Twilio SendGrid-hosted webpage. This feature makes it possible to view an email when an email client fails to open or properly render the message.
+* [Verify sending email servers with SPF](/docs/sendgrid/ui/sending-email/verify-sender-with-spf.md): Identify servers can send email from their domain with the Sender Policy Framework (SPF).
+* [Universal Links](/docs/sendgrid/ui/sending-email/universal-links.md): Learn how to set up universal links with click tracking in your emails.
+* [Substitution and Section Tags](/docs/sendgrid/ui/sending-email/substitution-and-section-tags.md): Substitution and Section Tags
+* [Unsubscribe via Subscription Tracking](/docs/sendgrid/ui/sending-email/subscription-tracking.md): Unsubscribe via Subscription Tracking
+* [Single Sends](/docs/sendgrid/ui/sending-email/single-sends.md): An overview and reference page for customers working with Twilio SendGrid Marketing Campaigns Single Sends.
+* [Senders](/docs/sendgrid/ui/sending-email/senders.md): Understand email sender identification and how to manage the sender of your email campaign with Twilio SendGrid.
+* [Authenticate a single sender](/docs/sendgrid/ui/sending-email/sender-verification.md): Understand the difference between domain authentication and verifying a single sender.
+* [List-Unsubscribe](/docs/sendgrid/ui/sending-email/list-unsubscribe.md): Include the List-Unsubscribe header to provide your recipients with an unsbuscribe link next to the From address used to deliver mail.
+* [Invalid email addresses](/docs/sendgrid/ui/sending-email/invalid-emails.md): Twilio SendGrid keeps reports of invalid email addresses for 30 days.
+* [Suppressions](/docs/sendgrid/ui/sending-email/index-suppressions.md): Twilio SendGrid suppresses emails that your recipients unsubscribe from or that recipient email servers reject.
+* [Prepare your email Marketing Campaign](/docs/sendgrid/ui/sending-email/how-to-send-email-with-marketing-campaigns.md): Use Twilio SendGrid for email marketing.
+* [Send an email with dynamic templates](/docs/sendgrid/ui/sending-email/how-to-send-an-email-with-dynamic-templates.md): Activate and customize dynamic email templates with our comprehensive guide. Master template ID retrieval and implement dynamic data with ease.
+* [Group Unsubscribes](/docs/sendgrid/ui/sending-email/group-unsubscribes.md): Allow recipients to unsubscribe from specific types of email you send, rather than everything you send, and stay out of the spam folder.
+* [Global Unsubscribes](/docs/sendgrid/ui/sending-email/global-unsubscribes.md): Recipients can unsubscribe from everything you send, rather than just a single group.
+* [Get started with Automation](/docs/sendgrid/ui/sending-email/getting-started-with-automation.md): Create an automated email series or drip campaign targeted towards a specific audience with Automation.
+* [HTML Formatting Issues](/docs/sendgrid/ui/sending-email/formatting-html.md): HTML Formatting Issues
+* [Email Testing](/docs/sendgrid/ui/sending-email/email-testing.md): Email Testing for Software Developers: Enhance your emails with features such as spam testing, inbox rendering previews, and link validation.
+* [Choose an email editor](/docs/sendgrid/ui/sending-email/editor.md): Twilio SendGrid Marketing Campaigns' editing gives you complete control over your emails. Use a flexible drag-and-drop Design editor or a robust HTML code editor.
+* [Enforce authentication with a DMARC policy](/docs/sendgrid/ui/sending-email/dmarc.md): Learn how Domain-based Message Authentication, Reporting and Conformance enforces email message authentication results.
+* [Use the Design Editor](/docs/sendgrid/ui/sending-email/design-editor.md): Twilio SendGrid Design Editor lets you design your email messages with a visual editor.
+* [Improve deliverability](/docs/sendgrid/ui/sending-email/deliverability.md): Improve Email Deliverability
+* [Cross-Platform Email Design](/docs/sendgrid/ui/sending-email/cross-platform-html-design.md): HTML Rendering - The Do's and Dont's of Cross-Platform Email Design
+* [Manage recipients who unsubscribe](/docs/sendgrid/ui/sending-email/create-and-manage-unsubscribe-groups.md): Recipients can choose to unsubscribe from your email messages. How you handle these requests factors heavily into your overall deliverability and sender reputation.
+* [Create and Edit Legacy Transactional Templates](/docs/sendgrid/ui/sending-email/create-and-edit-legacy-transactional-templates.md): Transactional email templates are pre-coded email layouts that anyone can use to easily create and send transactional emails.
+* [Use the Code Editor](/docs/sendgrid/ui/sending-email/code-editor.md): Twilio SendGrid Code Editor lets you design your email messages with HTML.
+* [Manage bounced messages](/docs/sendgrid/ui/sending-email/bounces.md): Twilio SendGrid helps prevent you from resending to a recipient whose email server rejects the messages.
+* [Manage blocked messages](/docs/sendgrid/ui/sending-email/blocks.md): How to find out if an ISP or inbox provider blocks your email.
+* [Sending Attachments with Digioh](/docs/sendgrid/ui/sending-email/attachments-with-digioh.md): Manage file size during email attachment with SendGrid's Marketing Email solution. Learn to use SMTP Relay or Web API v3 effectively.
+* [Adding Dynamic Content with Handlebars in Marketing Campaigns](/docs/sendgrid/ui/sending-email/adding-dynamic-content-with-handlebars-in-marketing-campaigns.md): The use cases on this page will help you utilize Handlebars helpers to deliver dynamic content targeted to your customers.
+* [A/B Testing Your Single Send](/docs/sendgrid/ui/sending-email/a-b-testing.md): Optimize engagement of your campaigns with A/B testing, by sending different versions of your emails to a small subset of your contacts and measuring the engagement results.
+* [Segmenting your Contacts](/docs/sendgrid/ui/managing-contacts/segmenting-your-contacts.md): Utilize the latest Marketing Campaigns for dynamic email segmentation based on various conditions. Efficient creation, refresh, and management of up to 200 segments.
+* [Formatting a CSV](/docs/sendgrid/ui/managing-contacts/formatting-a-csv.md): Directions on how to format a CSV for upload using SendGrid Marketing Campaigns
+* [Personalize and segment messages with custom fields](/docs/sendgrid/ui/managing-contacts/custom-fields.md): Custom fields help you segment your lists dynamically based on your user information.
+* [Manage contacts](/docs/sendgrid/ui/managing-contacts/create-and-manage-contacts.md): Leverage the latest Twilio SendGrid's Marketing Campaigns version. Easily manage contacts through CSV files, Signup forms, or Contact Management APIs.
+* [Building your Contact list](/docs/sendgrid/ui/managing-contacts/building-your-contact-list.md): Directions on how to effectively build your Marketing Campaigns Contact list.
+* [Integrations](/docs/sendgrid/ui/integrations.md): Integrate 3rd party tools with SendGrid Marketing Campaigns.
+* [Statistics Overview](/docs/sendgrid/ui/analytics-and-reporting/stats-overview.md): View and filter all of your SendGrid account email statistics.
+* [Spam Reports](/docs/sendgrid/ui/analytics-and-reporting/spam-reports.md): When a recipient marks your email as spam, their mail provider will let SendGrid know. We will help to prevent you from sending email to this recipient again.
+* [Marketing Campaigns Statistics](/docs/sendgrid/ui/analytics-and-reporting/marketing-campaigns-stats.md): Explore current features of Twilio SendGrid's Marketing Campaigns and Deliverability Insights for enhanced email delivery performance analysis and click tracking.
+* [Email Logs](/docs/sendgrid/ui/analytics-and-reporting/email-logs.md): Email Logs is a next-generation solution for accessing and troubleshooting detailed email data with clear, detailed, and near real-time visibility.
+* [Email Activity Feed](/docs/sendgrid/ui/analytics-and-reporting/email-activity-feed.md): Learn how to use the Email Activity Feed to view recent email-activity events, troubleshoot delivery issues, and access extended event history.
+* [Deliverability Insights](/docs/sendgrid/ui/analytics-and-reporting/deliverability-insights.md): Explore Twilio SendGrid's Deliverability Insights, a dashboard providing detailed insights into email delivery performance.
+* [Set up secure click tracking](/docs/sendgrid/ui/analytics-and-reporting/click-tracking-ssl.md): Set up and manage SSL-enabled click and open tracking with Twilio SendGrid. Understand sender authentication setup, SSL operation, and data access via UI or API.
+* [Click Tracking & HTML Best Practices](/docs/sendgrid/ui/analytics-and-reporting/click-tracking-html-best-practices.md): Click Tracking & HTML Best Practices
+* [Bounce and Block Classifications](/docs/sendgrid/ui/analytics-and-reporting/bounce-and-block-classifications.md): Understand Twilio SendGrid's SMTP bounce and block response classification. Use the Email Activity API or Event Webhook for insights on message failures.
+* [Verifying your Account](/docs/sendgrid/ui/account-and-settings/verifying-your-account.md): Signed up with SendGrid? Learn more about the steps to complete first...
+* [Upgrade your plan](/docs/sendgrid/ui/account-and-settings/upgrading-your-plan.md): Upgrade your SendGrid plan to enhance email sending capabilities. Explore flexible options to meet your business needs.
+* [Two-factor authentication](/docs/sendgrid/ui/account-and-settings/two-factor-authentication.md): Two-Factor Authentication gives you an extra layer of security to protect your Twilio SendGrid account.
+* [Twilio Login Overview](/docs/sendgrid/ui/account-and-settings/twilio-login-overview.md): Learn how to connect your SendGrid or Segment accounts with your Twilio account from the Twilio Console.
+* [Troubleshooting Sender Authentication](/docs/sendgrid/ui/account-and-settings/troubleshooting-sender-authentication.md): Troubleshoot your sender authentication.
+* [Troubleshooting Delays and Latency](/docs/sendgrid/ui/account-and-settings/troubleshooting-delays-and-latency.md): Troubleshooting Delays and Latency
+* [Tracking settings](/docs/sendgrid/ui/account-and-settings/tracking.md): Track clicks, opens, and subscriptions with Twilio SendGrid
+* [Teammates](/docs/sendgrid/ui/account-and-settings/teammates.md): Add and manage Teammates using the SendGrid UI
+* [Teammate Permissions](/docs/sendgrid/ui/account-and-settings/teammate-permissions.md): Reference all the permissions or scopes available for a SendGrid Teammate
+* [Subusers](/docs/sendgrid/ui/account-and-settings/subusers.md): Create and Manage Subusers
+* [SendGrid Single Sign-On](/docs/sendgrid/ui/account-and-settings/sso.md): Twilio SendGrid's Single Sign-On system integrates with platforms like Okta and Azure. Easy setup and administration for API Pro and Premier Plans.
+* [Twilio SendGrid Single Sign-On with Azure Active Directory](/docs/sendgrid/ui/account-and-settings/sso-azure-ad.md): Follow this guide to configure Twilio SendGrid's Single Sign-On with Microsoft Azure Active Directory using SAML 2.0 for user authentication.
+* [Resetting your Username and Password](/docs/sendgrid/ui/account-and-settings/resetting-your-username-and-password.md): Steps for resetting your username and password using the SendGrid UI
+* [Mail Settings](/docs/sendgrid/ui/account-and-settings/mail.md): Manage your SendGrid mail settings
+* [Troubleshooting account login issues](/docs/sendgrid/ui/account-and-settings/log-in-issues.md): Troubleshooting account login issues
+* [IP Pools](/docs/sendgrid/ui/account-and-settings/ip-pools.md): Using IP Pools to manage your sender reputation
+* [IP Access Management](/docs/sendgrid/ui/account-and-settings/ip-access-management.md): Control which IPs have access to your SendGrid account.
+* [Inbound Parse](/docs/sendgrid/ui/account-and-settings/inbound-parse.md): Manage your Inbound parse settings
+* [How to set up reverse DNS](/docs/sendgrid/ui/account-and-settings/how-to-set-up-reverse-dns.md): Set up reverse DNS to improve your deliverability and security of your emails.
+* [How to set up link branding](/docs/sendgrid/ui/account-and-settings/how-to-set-up-link-branding.md): Set up link branding to improve your deliverability and security of your emails.
+* [Configure domain authentication](/docs/sendgrid/ui/account-and-settings/how-to-set-up-domain-authentication.md): Set up domain and sender authentication to improve deliverability and security of emails.
+* [Verify message integrity with DKIM](/docs/sendgrid/ui/account-and-settings/dkim-records.md): Learn how DomainKeys Identified Mail (DKIM) verifies that the content of an email message doesn't change in transit.
+* [Dedicated IP addresses](/docs/sendgrid/ui/account-and-settings/dedicated-ip-addresses.md): Dedicated IP addresses
+* [Add a Custom SSL Configuration](/docs/sendgrid/ui/account-and-settings/custom-ssl-configurations.md): Set up a custom SSL for click and open tracking by establishing link branding on your account. Avoid DNS validation errors.
+* [Configuring Sign in with Apple](/docs/sendgrid/ui/account-and-settings/configuring-sign-in-with-apple.md): Configure your authenticated domain to support Sign in with Apple and successfully deliver email to Apple's Private Email Relay addresses.
+* [Billing](/docs/sendgrid/ui/account-and-settings/billing.md): Manage your SendGrid billing settings
+* [API Keys](/docs/sendgrid/ui/account-and-settings/api-keys.md): Manage your SendGrid API Keys
+* [Account Details](/docs/sendgrid/ui/account-and-settings/account.md): Manage your SendGrid account settings
+* [Account Under Review](/docs/sendgrid/ui/account-and-settings/account-under-review.md): If your account is suspended or is otherwise under review, learn how to bring your account into good standing.
+* [Accessing email account associated with SendGrid](/docs/sendgrid/ui/account-and-settings/accessing-email-account-associated-with-sendgrid.md): Accessing email account associated with SendGrid
+* [Twilio SendGrid Event Webhook Overview](/docs/sendgrid/for-developers/tracking-events/twilio-sendgrid-event-webhook-overview.md): Understand the SendGrid Event Webhook and how to integrate it to better manage your email program with event data.
+* [Event Webhook Node.js Code Example](/docs/sendgrid/for-developers/tracking-events/nodejs-code-example.md): Explore how to parse emails using Node and Express, and post via Event Webhook. The sendgrid.biz/parse guide simplifies the process.
+* [Getting started with the Event Webhook](/docs/sendgrid/for-developers/tracking-events/getting-started-event-webhook.md): Use RequestBin to get started or to troubleshoot your Event Webhook.
+* [Getting Started with the Event Webhook Security Features](/docs/sendgrid/for-developers/tracking-events/getting-started-event-webhook-security-features.md): Secure the Event Webhook using the Signed Webhook, OAuth 2.0, or both.
+* [Event Webhook Reference](/docs/sendgrid/for-developers/tracking-events/event.md): Full Event Webhook event list and descriptions, event examples, and the objects each event contains.
+* [Event Webhook C# Code Example](/docs/sendgrid/for-developers/tracking-events/csharp-code-example.md): Implement email parsing from the SendGrid domain and post to a specific URL using our proven methods in ApiController.
+* [Sending Email with Microsoft Azure](/docs/sendgrid/for-developers/partners/microsoft-azure-2021.md): Learn how to send email with Twilio SendGrid's newest Azure integration
+* [Migrating from a partner account](/docs/sendgrid/for-developers/partners/account-migration.md): Sometimes if a SendGrid partner no longer supports SendGrid core functionality, you may want to migrate your account to a regular SendGrid account.
+* [Configure the inbound parse webhook](/docs/sendgrid/for-developers/parsing-email/setting-up-the-inbound-parse-webhook.md): How to set up the inbound parse webhook to process and parse incoming email
+* [Inbound Email Parse Webhook](/docs/sendgrid/for-developers/parsing-email/inbound-email.md): Utilize SendGrid's Parse API to parse incoming emails and attachments efficiently. Mitigate data loss and ensure email delivery success.
+* [Migrate from Twilio SendGrid API v2 to v3](/docs/sendgrid/for-developers/migration-guides/v2-to-v3-api.md): Follow our guide to successfully migrate from SendGrid API v2 to v3. Improve performance and access updated features.
+* [v3 API Python Code Example](/docs/sendgrid/for-developers/sending-email/v3-python-code-example.md): Integrate Twilio SendGrid using the Python client library with complete documentation. Detailed example with API integration tips and resources.
+* [v3 Mail Send FAQ](/docs/sendgrid/for-developers/sending-email/v3-mail-send-faq.md): Leverage SendGrid's v3 Mail Send, the improved Web API endpoint, for effective email management. Enhanced JSON schema, better validation, and easy migration.
+* [v3 API Java Code Example](/docs/sendgrid/for-developers/sending-email/v3-java-code-example.md): Integrate SendGrid Java with your system, access the client library on GitHub. Use an API Key for seamless integration.
+* [v3 API C# Code Example](/docs/sendgrid/for-developers/sending-email/v3-csharp-code-example.md): Integrate effortlessly with SendGrid C#, a fully documented client library on GitHub. An API Key is essential for integration.
+* [Using Handlebars](/docs/sendgrid/for-developers/sending-email/using-handlebars.md): Utilize Twilio's SendGrid Dynamic Transactional Templates and Marketing Campaigns for seamless message personalizations and efficient data integration.
+* [Upgrade your authentication method to API keys](/docs/sendgrid/for-developers/sending-email/upgrade-your-authentication-method-to-api-keys.md): How to upgrade your authentication methods in your code to use API keys
+* [Unique Arguments](/docs/sendgrid/for-developers/sending-email/unique-arguments.md): Add unique arguments to customize your SMTP emails event tracking
+* [Support for TLS 1.2](/docs/sendgrid/for-developers/sending-email/support-for-tls-12.md): Twilio SendGrid ends support for TLS 1.0 and TLS 1.1. Learn how to test your infrastructure to ensure that you are supporting TLS 1.2 or higher.
+* [Substitution Tags](/docs/sendgrid/for-developers/sending-email/substitution-tags.md): Section tags allow you to substitute in content for individual recipients in an SMTP message.
+* [Stopping an in-progress send](/docs/sendgrid/for-developers/sending-email/stopping-an-in-progress-send.md): Can I stop a send in progress?
+* [SMTP Errors and Troubleshooting](/docs/sendgrid/for-developers/sending-email/smtp-errors-and-troubleshooting.md): SMTP Response codes and troubleshooting tips
+* [Single Sends 2020 Update](/docs/sendgrid/for-developers/sending-email/single-sends-2020-update.md): Instructions for migrating to the updated Single Sends API
+* [Sender Identity](/docs/sendgrid/for-developers/sending-email/sender-identity.md): Understanding the difference between Domain Authentication and verifying a Single Sender.
+* [Segmentation Query Language Reference](/docs/sendgrid/for-developers/sending-email/segmentation-query-language.md): SendGrid Segmentation Query Language Reference
+* [Scheduling Email](/docs/sendgrid/for-developers/sending-email/scheduling-email.md): How can I schedule emails to send at specific times?
+* [Sandbox Mode](/docs/sendgrid/for-developers/sending-email/sandbox-mode.md): Learn how to use Sandbox Mode when sending mail over SendGrid's Web API v3.
+* [Ruby on Rails](/docs/sendgrid/for-developers/sending-email/rubyonrails.md): View instructions on how to easily send email with Ruby on Rails using SendGrid, by setting up setting up ActionMailer or using a gem.
+* [Email API Quickstart for Ruby](/docs/sendgrid/for-developers/sending-email/quickstart-ruby.md): Sending your first email using the SendGrid REST API and Ruby.
+* [Email API Quickstart: How to Send Email with Python](/docs/sendgrid/for-developers/sending-email/quickstart-python.md): Sending your first email using the SendGrid REST API and Python.
+* [Email API Quickstart for PHP](/docs/sendgrid/for-developers/sending-email/quickstart-php.md): Sending your first email using the SendGrid REST API and PHP.
+* [Email API Quickstart for Node.js](/docs/sendgrid/for-developers/sending-email/quickstart-nodejs.md): Sending your first email using the SendGrid REST API and Node.js.
+* [Email API Quickstart for Go](/docs/sendgrid/for-developers/sending-email/quickstart-go.md): Sending your first email using the SendGrid REST API and Go.
+* [Postfix](/docs/sendgrid/for-developers/sending-email/postfix.md): Setup SendGrid as a Postfix relay host for better deliverability and advanced statistics on your email.
+* [Personalizations](/docs/sendgrid/for-developers/sending-email/personalizations.md): Learn how to use personalizations to customize your messages sent over the Web API v3.
+* [API Libraries](/docs/sendgrid/for-developers/sending-email/libraries.md): Send email and interact with SendGrid using your favorite language including Python, Go, Node.js, Ruby, PHP, Java, C#, Perl, Objective-C, and more.
+* [Send Email in Laravel](/docs/sendgrid/for-developers/sending-email/laravel.md): View instructions on how to easily send email with Laravel using SendGrid, by setting up setting up Laravel's Mailables Class.
+* [Integrating with the SMTP API](/docs/sendgrid/for-developers/sending-email/integrating-with-the-smtp-api.md): Learn how to set your systems up to use SendGrid's SMTP API to integrate and send emails.
+* [How to Create a Subuser with the API](/docs/sendgrid/for-developers/sending-email/how-to-create-a-subuser-with-the-api.md): How to Create a Subuser with the API
+* [Getting Started with Transactional Email](/docs/sendgrid/for-developers/sending-email/getting-started-with-transactional-emails.md): Using SendGrid to send Transactional Email.
+* [How to send an Email with SMTP](/docs/sendgrid/for-developers/sending-email/getting-started-smtp.md): Use Telnet to send your first SMTP email. SendGrid's software allows developers to specify custom handling instructions for email using an X-SMTPAPI header inserted into the message.
+* [Getting Started with the Email Activity Feed API](/docs/sendgrid/for-developers/sending-email/getting-started-email-activity-api.md): Use the Email Activity Feed query language to get started with the Email Activity Feed API.
+* [Enforced TLS](/docs/sendgrid/for-developers/sending-email/enforced-tls.md): Learn to retrieve or update Enforced TLS settings using our provided endpoints. Ensure recipients support TLS 1.1 or above.
+* [Email API Quickstart for Java](/docs/sendgrid/for-developers/sending-email/email-quickstart-for-java.md): Send emails easily with SendGrid's Mail Send API and Java following this quickstart guide. Covers setup, sending, and troubleshooting.
+* [Email API Quickstart for C#](/docs/sendgrid/for-developers/sending-email/email-api-quickstart-for-c.md): Learn to send emails using Twilio SendGrid Mail Send API and C# with our comprehensive guide. Master setup, installation, and code development.
+* [Django](/docs/sendgrid/for-developers/sending-email/django.md): View instructions on how to send email with Django using SendGrid, by setting up setting up Django's built in mail library.
+* [cURL Examples for Common Use Cases](/docs/sendgrid/for-developers/sending-email/curl-examples.md): Schedule or cancel emails effectively within a 72-hour timeframe using the send\_at parameter and Cancel Scheduled Sends endpoint.
+* [Cross Origin Resource Sharing (CORS)](/docs/sendgrid/for-developers/sending-email/cors.md): CORS is a security feature of modern browsers to keep browser users secure.
+* [Working with Categories](/docs/sendgrid/for-developers/sending-email/categories.md): Learn how to utilize SendGrid's PII fields, improve email analytics, categorize emails, and understand category limits effectively.
+* [Building an X-SMTPAPI Header](/docs/sendgrid/for-developers/sending-email/building-an-x-smtpapi-header.md): Learn how to build email content, add recipients and schedule your send.
+* [Automate Adding Subusers with the SendGrid API](/docs/sendgrid/for-developers/sending-email/automating-subusers.md): Use the SendGrid API to add Subusers to your account.
+* [Authentication](/docs/sendgrid/for-developers/sending-email/authentication.md): Authenticating with the Twilio SendGrid API.
+* [Getting started with the SendGrid API](/docs/sendgrid/for-developers/sending-email/api-getting-started.md): Sending your first email using the SendGrid REST API.
+* [Encrypt with TLS](/docs/sendgrid/concepts/security/tls.md): Twilio uses Transport Layer Security when delivering email.
+* [Secure your Twilio account](/docs/sendgrid/concepts/security/secure-account.md): Follow good security&#x20;
+* [Abuse awareness](/docs/sendgrid/concepts/security/abuse-awareness.md): Identify how email can be attacked.
+* [Warming Up an IP Address](/docs/sendgrid/concepts/reputation/warm-up-ip-addresses.md): Learn how to warmup your new dedicated IP address and why it's important.
+* [Establish and maintain reputation](/docs/sendgrid/concepts/reputation/establish-maintain-reputation.md): Give ISPs, inbox providers, and blocklist providers reasons to trust your email messages.
+* [Manage Unsubscribes](/docs/sendgrid/concepts/deliverability/unsubscribes.md): Set how you plan to manage recipients' requests to unsubscribe from your emails.
+* [Deferrals](/docs/sendgrid/concepts/deliverability/deferrals.md): Learn about email deferrals, why messages are temporarily delayed by receiving servers, and how to address common causes.
+* [Blocklists](/docs/sendgrid/concepts/deliverability/blocklists.md): Learn how blocklists work, how you get on them, and how you get off them.
+* [Blocklist provider insights](/docs/sendgrid/concepts/deliverability/blocklist-provider-insights.md): Discover how blocklist providers monitor and act on issues with IP addresses.
+* [Yahoo](/docs/sendgrid/concepts/inbox-provider-insights/yahoo.md): Authentication requirements that Yahoo and Yahoo-served email services use.
+* [Orange email security and reputation](/docs/sendgrid/concepts/inbox-provider-insights/orange.md): Authentication requirements that Orange email services use.
+* [Microsoft](/docs/sendgrid/concepts/inbox-provider-insights/microsoft.md): Authentication requirements that Microsoft Outlook and Microsoft 365 email services use.
+* [Inbox provider authentication requirements](/docs/sendgrid/concepts/inbox-provider-insights.md): Authentication requirements that popular inbox providers use.
+* [Google](/docs/sendgrid/concepts/inbox-provider-insights/google.md): Authentication requirement that Gmail and Google-hosted email services use.
+* [Apple iCloud](/docs/sendgrid/concepts/inbox-provider-insights/apple.md): Authentication requirements that Apple iCloud email services use.
+* [Test Event Notification Settings](/docs/sendgrid/api-reference/webhooks/test-event-notification-settings.md): Test Event Webhook on SendGrid using specialized endpoint. Facilitate POST requests, verify OAuth properties, and make API calls for subusers.
+* [Get an Event Webhook](/docs/sendgrid/api-reference/webhooks/get-an-event-webhook.md): Retrieve a single Event Webhook by its ID using the API endpoint at https://api.sendgrid.com. Detailed event data and settings returned efficiently.
+* [Retrieve paged transactional templates.](/docs/sendgrid/api-reference/transactional-templates/retrieve-paged-transactional-templates.md): Discover how to create, retrieve and manage up to 300 unique transactional email templates with the easy-to-use API provided.
+* [Retrieve a single transactional template.](/docs/sendgrid/api-reference/transactional-templates/retrieve-a-single-transactional-template.md): Leverage an HTML template for creating transactional emails. Manage multiple transactional templates and efficiently fetch details using an endpoint.
+* [Create a transactional template.](/docs/sendgrid/api-reference/transactional-templates/create-a-transactional-template.md): Create HTML templates for transactional emails on SendGrid. Manage up to 300 unique templates per account, with dynamic content replacement.
+* [Retrieve global email statistics](/docs/sendgrid/api-reference/stats/retrieve-global-email-statistics.md): "Track email activity efficiently using SendGrid's API. Access detailed stats like click and open rates, avoiding spam complaints, and more."
+* [Create Single Send](/docs/sendgrid/api-reference/single-sends/create-single-send.md): Leverage your audience lists with Single Send API. Manage email messages for marketing campaigns, newsletters, legal notices, and more. No templates required.
+* [Create a parse setting](/docs/sendgrid/api-reference/settings-inbound-parse/create-a-parse-setting.md): Set up Twilio SendGrid's Inbound Parse Webhook to receive emails at your desired URL. Configure domain, DNS, and API calls efficiently.
+* [Mail Send](/docs/sendgrid/api-reference/mail-send/mail-send.md): Optimize emailing with SendGrid's Mail Send endpoint. Create dynamic templates, schedule emails, track click rates, and manage subscriptions efficiently.
+* [Mail Send API Overview](/docs/sendgrid/api-reference/mail-send.md): A high-level overview of the Mail Send endpoint in the SendGrid v3 Web API.
+* [Errors](/docs/sendgrid/api-reference/mail-send/errors.md): Troubleshoot error code 400 during SendGrid API use. Explore solutions independently or engage Twilio SendGrid Support Team resources.
+* [Responses](/docs/sendgrid/api-reference/how-to-use-the-sendgrid-v3-api/responses.md): Explore the responses that the Twilio SendGrid Web API v3 returns.
+* [Requests](/docs/sendgrid/api-reference/how-to-use-the-sendgrid-v3-api/requests.md): Leverage the power of SendGrid's Web API v3 for a multi-featured, RESTful API experience. Enable batch retrieval and search by field features.
+* [Rate Limits](/docs/sendgrid/api-reference/how-to-use-the-sendgrid-v3-api/rate-limits.md): Explore SendGrid's Web API v3 features with this comprehensive guide. Understand rate limits, status codes, and more for efficient API calls.
+* [On Behalf Of](/docs/sendgrid/api-reference/how-to-use-the-sendgrid-v3-api/on-behalf-of.md): Utilize SendGrid's Web API v3, a user-friendly RESTful API; perform bulk actions and sub-account admin with the 'On Behalf Of' header.
+* [Errors](/docs/sendgrid/api-reference/how-to-use-the-sendgrid-v3-api/errors.md): Explore SendGrid's Web API v3: a fully featured, easily integratable RESTful API supporting 7 languages. Handles errors with detailed status codes.
+* [Authorization](/docs/sendgrid/api-reference/how-to-use-the-sendgrid-v3-api/authorization.md): Explore SendGrid's Web API v3, a RESTful API supporting seven languages, and learn to authenticate using API keys with specific scopes.
+* [Authentication](/docs/sendgrid/api-reference/how-to-use-the-sendgrid-v3-api/authentication.md): Explore the Twilio SendGrid Web API v3, a REST API with SDK support in seven languages. Ensure secure, controllable account access with API keys.
+* [Email Logs](/docs/sendgrid/api-reference/email-logs.md): Search and retrieve detailed email delivery and engagement data with the Email Logs API. Gain event-level visibility to troubleshoot and validate message outcomes in near real time.
+* [Filter messages by ID](/docs/sendgrid/api-reference/email-logs/filter-messages-by-id.md): Retrieve detailed event-level data for a specific message using the Email Logs API, including its delivery timeline and status updates.
+* [Filter all messages](/docs/sendgrid/api-reference/email-logs/filter-all-messages.md): Search stored email messages using the Email Logs API and return message-level results with key delivery attributes.
+* [Real Time Email Address Validation - API Reference](/docs/sendgrid/api-reference/email-address-validation/validate-an-email.md): Integrate real-time Email Address Validation to your Twilio SendGrid App. Ensures validity, assesses bounce likelihood, identifies role/group accounts.
+* [Request a Bulk Email Address Validation Upload URL](/docs/sendgrid/api-reference/email-address-validation/request-bulk-email-address-validation-upload-url.md): Ensures validity, assesses bounce likelihood, identifies role/group accounts. This endpoint allows you to request a presigned URL and headers to upload a CSV file for bulk email address validation.
+* [Email Address Validation](/docs/sendgrid/api-reference/email-address-validation.md): Reduce bounce rate and improve your sender reputation by validating email addresses with the Email Address Validation API.
+* [Request a CSV](/docs/sendgrid/api-reference/email-activity/request-a-csv.md): Harness the power of the Email Activity Feed API to analyze stored messages. Use the Twilio SendGrid App for email activity tracking.
+* [Filter messages by message ID](/docs/sendgrid/api-reference/email-activity/filter-messages-by-message-id.md): Use the Email Activity Feed API for efficient querying, downloading, and inspecting emails in Twilio SendGrid. Access bounced messages, sender/recipient details, event info, and more.
+* [Filter all messages](/docs/sendgrid/api-reference/email-activity/filter-all-messages.md): Access and analyze your stored email messages using the Email Activity Feed API. Purchase additional history for enhanced data retrieval.
+* [Download CSV](/docs/sendgrid/api-reference/email-activity/download-csv.md): Access Email Activity Feed API purchase extra email activity history for comprehensive message data analysis.
+* [Validate a domain authentication.](/docs/sendgrid/api-reference/domain-authentication/validate-a-domain-authentication.md): Authenticate your domain with SendGrid for email, eliminate 'via' or 'sent on behalf of' messages, and utilize your personal sending domain.
+* [Authenticate a domain](/docs/sendgrid/api-reference/domain-authentication/authenticate-a-domain.md): Authenticating domains with SendGrid simplifies email sending. Enjoy personalized sender domains, managed SPF records, and automated or custom security options.
+* [Create Design](/docs/sendgrid/api-reference/designs-api/create-design.md): Manage your email layouts with Twilio SendGrid's Designs API. Create, alter, or delete designs using a RESTful interface without UI dependency.
+* [Contacts](/docs/sendgrid/api-reference/contacts.md): The Twilio SendGrid Marketing Campaigns Contacts API allows you to add, update, and delete contacts in your Marketing Campaigns account.
+* [Import Contacts](/docs/sendgrid/api-reference/contacts/import-contacts.md): Use our API endpoint to import up to 1 million contacts via a CSV. Asynchronous process allows gzip compression and custom field mappings.
+* [Delete Contacts](/docs/sendgrid/api-reference/contacts/delete-contacts.md): Leverage the SendGrid API for bulk deleting of contacts. Ensure efficient contact management and avoid data loss with regular backups.
+* [Add or update a contact](/docs/sendgrid/api-reference/contacts/add-or-update-a-contact.md): Insert or update up to 30,000 contacts.
+* [Retrieve all bounces](/docs/sendgrid/api-reference/bounces-api/retrieve-all-bounces.md): Manage bounced emails and retrieve up to 500 instances per query with SendGrid's suppression settings in Twilio app, honing API parameters.
+* [Delete API keys](/docs/sendgrid/api-reference/api-keys/delete-api-keys.md): Utilize API keys to validate access to SendGrid services without changing credentials. Manage actions with specific scopes via the Twilio SendGrid App.
+* [Create API keys](/docs/sendgrid/api-reference/api-keys/create-api-keys.md): Manage and refine API keys using Twilio SendGrid App. Efficiently access SendGrid services with full control and scope for limited actions.
+* [API Key Permissions](/docs/sendgrid/api-reference/api-key-permissions.md): Utilize Twilio SendGrid API keys for secure and efficient access to v3 API endpoints. Manage different permissions for seamless integration.
+* [Delete Account](/docs/sendgrid/api-reference/account-provisioning-api-account-operations/delete-account.md): Delete an account under your organization with the Account Provisioning API
+* [Account Provisioning API Overview](/docs/sendgrid/api-reference/account-provisioning-api.md): The Twilio SendGrid Account Provisioning API provides a platform for Twilio SendGrid resellers to manage their customer accounts. This API is for companies that have a formal reseller partnership with Twilio SendGrid.
+* [Remove IPs](/docs/sendgrid/api-reference/account-ip-provisioning-api-ip-operations/remove-ips.md): Remove IP addresses from a customer account with the IP Provisioning API
+* [List IPs](/docs/sendgrid/api-reference/account-ip-provisioning-api-ip-operations/list-ips.md): Retrieve a list of IP addresses associated with a customer account
+* [Add IPs](/docs/sendgrid/api-reference/account-ip-provisioning-api-ip-operations/add-ips.md): Add IP addresses to a customer account with the IP Provisioning API
+* [Using CloudFlare as your Content Delivery Network (CDN)](/docs/sendgrid/ui/sending-email/content-delivery-networks/using-cloudflare-as-your-content-delivery-network-cdn.md): Setup your Content Delivery Network with CloudFlare for effective click tracking. Follow our step-by-step guide and enhance your SSL setup process.
+* [Content Delivery Networks](/docs/sendgrid/ui/sending-email/content-delivery-networks.md): Integrate Twilio SendGrid with CDNs such as CloudFront, CloudFlare, Fastly, KeyCDN for efficient content delivery and security management.
+* [Email Address Validation Overview](/docs/sendgrid/ui/managing-contacts/email-address-validation.md): Remove invalid email addresses from your lists, decrease your bounce rate, and improve your sender reputation with the Email Address Validation API.
+
+## Twilio Video
+
+* [Twilio Video Webinar](/docs/video/webinar.md): View this webinar presentation to learn more about Twilio Video.
+* [Adding Virtual Backgrounds](/docs/video/video-processors.md): Apply transformations and filters, such as blurring and virtual backgrounds, to a Programmable VideoTrack using the Video Processors JavaScript library and the JavaScript SDK
+* [Components of a Twilio Video app](/docs/video/video-app-components.md): Learn about the main components required to build a multi-participant video application using Twilio Video.
+* [Using the Network Quality API](/docs/video/using-network-quality-api.md): An introduction to the Network Quality API for Programmable Video with guidance on using Network Quality effectively in your Rooms applications.
+* [Using the DataTrack API - JavaScript](/docs/video/using-datatrack-api.md): Follow sample code and learn how to use the DataTrack API to send messages between participants connected to a room in your Programmable Video application.
+* [Specify Audio and Video Constraints in JavaScript](/docs/video/specify-audio-and-video-constraints.md): Sample code and instructions that show how to set constraints on a Programmable Video LocalAudioTrack and LocalVideoTrack for optimization.
+* [Telemedicine Virtual Visits](/docs/video/solutions-blueprint-telemedicine-virtual-visits.md): This guide will walk through a standard implementation of Twilio Programmable Video for telehealth applications using best practices.
+* [Reconnection States and Events](/docs/video/reconnection-states-and-events.md): An introduction to Programmable Video reconnection states and events, providing guidance and sample code to show how to use them in your applications.
+* [Programmable Video Quotas and Limits](/docs/video/programmable-video-limits.md): Learn about account-based quotas and system-wide limits for Programmable Video rooms and participants.
+* [Platform SDK Support Policy](/docs/video/platform-sdk-support-policy.md): Find information on how long iOS, Android, and JavaScript SDK versions are officially supported by Twilio.
+* [Twilio Video technical overview](/docs/video/overview.md): Learn how Twilio Video works and explore the resources you can use as you build, scale, and troubleshoot your applications.
+* [Noise Cancellation](/docs/video/noise-cancellation.md): Learn how to add noise cancellation from Krisp.ai to Video Rooms. You can filter out hundreds of types of unwanted background noises from audio tracks with AI-based noise cancellation.
+* [Networking Considerations for Video Applications](/docs/video/networking-considerations.md): Learn about network aspects to consider when building a Twilio Video application.
+* [Media Security](/docs/video/media-security.md): Learn about Twilio Programmable Video's security, encryption, and the protocols it uses.
+* [Managing codecs](/docs/video/managing-codecs.md): An in-depth guide to managing codecs in Programmable Video to help you understand supported codecs, interoperability, limitations, and known issues.
+* [Legacy Video Room Types](/docs/video/legacy-room-types.md): An overview of legacy Twilio Video Room types: Peer-to-Peer, WebRTC Go, Small Group Rooms, and audio-only Group Rooms
+* [JavaScript Platform Overview](/docs/video/javascript.md): Learn how to start working with the Programmable Video JavaScript SDK, which lets you add real-time voice and video to your web applications.
+* [Twilio Video Quickstart for JavaScript](/docs/video/javascript-getting-started.md): Quickstart for the JavaScript SDK for Twilio Video: connect to a room, set up local media, work with remote participants, and participate in a room.
+* [Video iOS Platform Overview](/docs/video/ios.md): Integrate Programmable Video into your iOS application using the Video SDK, starting with this example iOS application for on mobile phones and tablets.
+* [iOS Video Application Recommendations and Best Practices](/docs/video/ios-recommendations-best-practices.md): Recommendations and best practices for building with the Programmable Video iOS SDK, including handling local media, background the application, and error handling.
+* [Twilio Video Quickstart for iOS](/docs/video/ios-getting-started.md): Learn the basics of building an iOS app using Twilio Video.
+* [Twilio Video](/docs/video.md): Use Twilio Programmable Video to add video to your web or mobile app. Create applications with video calling functionality, recording, virtual backgrounds, screensharing, diagnostic tooling, and more.
+* [Video guides and tutorials](/docs/video/guides.md): Find guides for building, optimizing, and troubleshooting your Twilio Video application.
+* [Guide to Scaling Applications](/docs/video/guide-to-scaling-applications.md): This guide describes some implementation considerations for your video application to allow it to scale efficiently with Twilio.
+* [Detecting the Dominant Speaker](/docs/video/detecting-dominant-speaker.md): Learn how to detect the dominant speaker in a Video Room for Android, iOS, and JavaScript applications.
+* [Configuring Audio, Video Input and Output devices](/docs/video/configuring-audio-video-input-and-output-devices.md): This guide will show you how to configure audio and video input and output devices in your Programmable Video Rooms applications.
+* [Building a JS Video App: Recommendations and Best Practices](/docs/video/build-js-video-application-recommendations-and-best-practices.md): Recommendations and best practices for building with the Programmable Video JavaScript SDK, including browser support, local media, and error handling.
+* [Video Android Platform Overview](/docs/video/android.md): Integrate Programmable Video into your Android application using the Video SDK using this sample application as a guide.
+* [Android Video Application Recommendations and Best Practices](/docs/video/android-recommendations-best-practices.md): Recommendations and best practices for building with the Programmable Video Android SDK, including managing audio focus, handling local media, and error handling.
+* [Twilio Video Quickstart for Android](/docs/video/android-getting-started.md): Learn how to build a video application with Twilio's Video API and the Twilio Android SDK in this Twilio Video Quickstart.
+* [Add Programmable Voice Participants to Video Rooms](/docs/video/adding-programmable-voice-participants-video-rooms.md): Learn how to add Programmable Voice callers as participants in video rooms using the TwiML \<Room> noun within the \<Connect> verb. You can connect inbound calls to your Twilio phone number as well as outgoing calls from your Twilio phone number to video rooms.
+* [Video Log Analyzer API](/docs/video/troubleshooting/video-log-analyzer-api.md): Full reference for the Programmable Video Log Analyzer API. Sample code shows how to get a list of rooms and participants and a room's video log data.
+* [Preflight API](/docs/video/troubleshooting/preflight-api.md): How to access and use the Preflight API for testing connectivity to the Twilio Cloud.
+* [Pre-call Testing and Diagnostics](/docs/video/troubleshooting/pre-call-testing-and-diagnostics.md): Learn about tools for understanding clients' connections and diagnosing any potential problems before, during, or after a Twilio Video call.
+* [JavaScript Room Monitor](/docs/video/troubleshooting/javascript-room-monitor.md): In this overview, learn about the JavaScript Room Monitor. See what browsers are supported, how to add the monitor to your application, and how to use the monitor.
+* [JavaScript Logger](/docs/video/troubleshooting/javascript-logger.md): Learn how to install the JavaScript Logger via npm or Twilio's CDN, then learn how to set the logging level and intercept logs.
+* [Video Insights](/docs/video/troubleshooting/insights.md): Use Video Insights to observe your video application, discover trends, and troubleshoot room and participant issues. View an overview dashboard of all your video rooms, dig into detected issues, and see quality metric graphs for all participants.
+* [Firewall and Network Configuration](/docs/video/ip-addresses.md): Configure your firewall for Twilio Programmable Video. Includes IP address ranges, ports, protocols, proxy bypass guidance, and troubleshooting for enterprise network environments.
+* [Video Regions and Global Low Latency](/docs/video/tutorials/video-regions-and-global-low-latency.md): Learn about how geolocation of media and signaling servers impacts call quality. Selecting the right geolocation setting improves the video call experience and reduces call latency. See how to set the signaling and media region for your Twilio Video Rooms depending on your users' locations.
+* [Using the Network Bandwidth Profile API](/docs/video/tutorials/using-bandwidth-profile-api.md): Learn how to use the Programmable Video Network Bandwidth Profile API to assign a higher bandwidth to tracks, protect audio quality and manage resources.
+* [User Identity & Access Tokens for Programmable Video](/docs/video/tutorials/user-identity-access-tokens.md): Learn how to control user identity and room permissions in your Programmable Video applications, including access tokens, room access, and time-to-live.
+* [Understanding Video Rooms](/docs/video/tutorials/understanding-video-rooms.md): Learn the foundational concepts behind Programmable Video Rooms.
+* [Understanding Video Rooms APIs](/docs/video/tutorials/understanding-video-rooms-apis.md): Go in-depth with all things Video Rooms API for Programmable Video with this guide.
+* [Understanding Video Recordings and Compositions](/docs/video/tutorials/understanding-video-recordings-and-compositions.md): An explainer of the technical concepts behind Programmable Video recordings and compositions.
+* [Storing into AWS S3](/docs/video/tutorials/storing-aws-s3.md): Learn how to store your Video Recordings and Compositions in your own AWS S3 bucket, rather than in Twilio's cloud.
+* [Get Started with Twilio Video Part 1: Creating a Server with Python/Flask](/docs/video/tutorials/get-started-with-twilio-video-python-flask-server.md): The first part of a two-part tutorial for creating a video web application with a Python3/Flask backend (part 1) and a JavaScript frontend (part 2).
+* [Get Started with Twilio Video Part 2: Creating the Frontend](/docs/video/tutorials/get-started-with-twilio-video-python-flask-frontend.md): The second part of a two-part tutorial for creating a video web application with a Python3/Flask backend (part 1) and a JavaScript frontend (part 2).
+* [Get Started with Twilio Video Part 1: Creating a server with Node or Express](/docs/video/tutorials/get-started-with-twilio-video-node-express-server.md): Learn how to build a browser-based video application using Node and Express. In this part of the two-part tutorial, build out an Access Token server to generate tokens for users who want to join your video chat application.
+* [Get Started with Twilio Video Part 2: Creating the Frontend](/docs/video/tutorials/get-started-with-twilio-video-node-express-frontend.md): Learn how to create a browser-based video application using JavaScript. This is the second part of a tutorial for building a Twilio Video app using Node/Express for the server and JavaScript for the frontend.
+* [Encrypting your Stored Media](/docs/video/tutorials/encrypting-your-stored-media.md): Learn how to encrypt Twilio Video Recordings and Compositions. Use this feature when you need to ensure your recorded media is encrypted end-to-end.
+* [Developing High Quality Video Applications](/docs/video/tutorials/developing-high-quality-video-applications.md): This guide provides advice for building higher-quality video applications, covering terminology and concepts, requirements, and room quality.
+* [Real-time Transcriptions for Video](/docs/video/api/transcriptions.md): Enable real-time video transcriptions using this AI-powered tool from Twilio. Convert speech to text, choose your speech model, and customize your app's UI.
+* [Track Subscriptions](/docs/video/api/track-subscriptions.md): Full API reference for all things Track Subscription in the Programmable Video API. Learn how to use these resources, complete with sample code.
+* [Status Callbacks](/docs/video/api/status-callbacks.md): Receive events related to your video Rooms via HTTP request with Twilio's Programmable Video Rooms Status Callbacks.
+* [REST API: Rooms](/docs/video/api/rooms-resource.md): Share video and audio tracks to a room, and receive video and audio tracks from other participants in a room with Twilio Programmable Video.
+* [Programmable Video Rest API: Recordings](/docs/video/api/recordings-resource.md): Full API reference for the Recordings resource in the Programmable Video APIs for Rooms and Recordings, complete with sample code.
+* [Recording Rules](/docs/video/api/recording-rules.md): Use the recording rules REST API to specify which participants' audio and video tracks should be recorded in a video room.
+* [PublishedTrack](/docs/video/api/publishedtrack.md): A full API reference for the Published Track resource of the Programmable Video REST API.
+* [Participants](/docs/video/api/participants.md): Full API reference for the Participant resource in the Programmable Video API. Sample code shows how to retrieve (get), remove, or update participants.
+* [Programmable Video REST API](/docs/video/api.md): Create and complete video rooms, query their status, retrieve recording files, configure webhooks, and more with Twilio's Programmable Video REST API.
+* [External S3 Recordings](/docs/video/api/external-s3-recordings.md): The Recording Settings REST API lets you store recordings in external S3 storage buckets. View URI Schemes, the
+  Recording Settings instance resource, and known limitations.
+* [Encrypted Recordings](/docs/video/api/encrypted-recordings.md): An API reference for the Twilio Recording Settings REST API that lets you configure Twilio to store your recordings encrypted.
+* [Compositions](/docs/video/api/compositions-resource.md): Full API reference for the Composition resource in the Programmable Video API. Create (post), fetch (get), delete, and modify compositions.
+* [Composition Hooks](/docs/video/api/composition-hooks.md): Learn about Composition Hooks and their instance and list resources, plus see some examples.
+
+## Twilio for Salesforce
+
+* [Twilio for Salesforce](/docs/salesforce.md): Learn what you can do with Twilio's managed package for Salesforce. We include ProcessBuilder, Apex, running SMS campaigns, and sending 1:1 messages.
+
+## Unified Profiles (Public Beta)
+
+* [Choose the traits to use (Public Beta)](/docs/unified-profiles/traits.md): Show customer traits in Unified Profiles to make important customer information available to your agents.
+* [Set up and configure Unified Profiles (Public Beta)](/docs/unified-profiles/setup.md): Learn how to set up and configure Unified Profiles.
+* [Connect your Segment space (Public Beta)](/docs/unified-profiles/segment-space.md): Learn how to connect your Segment space to work with Unified Profiles.
+* [Known issues and limitations in Unified Profiles (Public Beta)](/docs/unified-profiles/limitations.md): Known issues and limitations in Unified Profiles.
+* [Unified Profiles (Public Beta)](/docs/unified-profiles.md): Provide your teams with information about each customer to enhance their understanding of customer intent and enable them to personalize every conversation.
+* [Confirm or update your customer identifier settings (Public Beta)](/docs/unified-profiles/identifiers.md): Unified Profiles uses customer identifiers to search for customer profiles. You can configure these identifiers.
+
+## Verify
+
+* [Viewing Logs with Twilio Console](/docs/verify/viewing-logs-with-twilio-console.md): Learn how to view the logs of your Verify Service using the Twilio Console interface in this guide.
+* [Verify Transactions for PSD2](/docs/verify/verifying-transactions-psd2.md): Learn how to use Twilio's Verify API to verify transactions in a way that is compliant with Payment Service Directive 2 (PSD2).
+* [Verify SNA Live Test Number](/docs/verify/verify-sna-live-test-number.md): Learn how to use Twilio's Verify Silent Network Auth Live Test Number for testing SNA with your own personal number.
+* [Verify Events](/docs/verify/verify-events.md): Verify Events provides instant information on your Verify Service's activity, allowing you to tap into events via webhook or other streaming technology.
+* [Verify Countries and Regions Deliverability](/docs/verify/verify-countries-and-regions-deliverability.md): Learn about what countries and regions have deliverability support with Twilio's Verify API.
+* [Verification Stream](/docs/verify/verification.md): Verify Events provides information on verification statuses, tracking the overall lifecycle of a verification.
+* [Getting Started with Verification Templates](/docs/verify/verification-templates.md): Learn more about the available templates Twilio Verify can use to send Verifications and how to configure them.
+* [Verify supported languages](/docs/verify/supported-languages.md): Learn about the different languages and locales Twilio Verify supports for sending Verifications in this guide.
+* [Singapore Sender ID Handling](/docs/verify/singapore.md): How Verify handles Sender IDs when sending to Singapore
+* [Verify RCS Upgrade](/docs/verify/rcs.md): Twilio Verify delivers OTPs via RCS channel
+* [Message Status Stream](/docs/verify/message-status.md): Subscribe to specific message status events to identify and respond to issues impacting message delivery by carriers. The message status stream is equivalent to the outbound message event's stream provided by Twilio Programmable Messaging.
+* [Verify](/docs/verify.md): Verification API with support for multiple channels. Verify user identity and reduce fraud with built-in support for global delivery and translations.
+* [Verify Channel Selection](/docs/verify/fallback-scenarios.md): Discover how to enhance OTP verification success with fallback scenarios and optimal channel selection, including SMS, WhatsApp, and RCS.
+* [Verification and two-factor authentication best practices](/docs/verify/developer-best-practices.md): Developer best practices for phone and user verification with SMS, voice, email, WhatsApp, TOTP and push channels. Reduce fraud with these tips and tricks.
+* [Default Languages for Phone Number Country Codes](/docs/verify/default-phone-verification-languages.md): Learn about how Twilio's Verify API automatically resolves a verification's language based on phone number country code and see the supported mappings.
+* [Consent and Opt-in Policy](/docs/verify/consent-opt-in.md): Twilio Verify Short Code consent and opt-in compliance rules
+* [Verify Automatic SMS Fallback Overview](/docs/verify/automatic-channel-selection.md): Learn about how to use Twilio Verify API's automatic SMS Fallback feature in this overview.
+* [Verify vs. Authy](/docs/verify/authy-vs-verify.md): The Verify API is a consolidated version of earlier versions of our phone verification and 2FA APIs.
+* [Verification Channels](/docs/verify/authentication-channels.md): Choosing the right authentication channels for your app can help increase 2FA adoption and keep your customers secure. Twilio's Verify API supports several channels including SMS, Voice, Email, Passkeys, and TOTP.
+* [App Verification with Twilio SMS](/docs/verify/app-verification.md): Learn how to verify Android phone numbers without requiring a user to type in a code with Twilio SMS
+* [Verify WhatsApp Overview](/docs/verify/whatsapp.md): Learn more about sending one-time passcode (OTP) user verifications via WhatsApp with Twilio's Verify WhatsApp Overview.
+* [Bring Your Own WhatsApp Sender](/docs/verify/whatsapp/byo.md): Bring your own WhatsApp Sender to Verify WhatsApp
+* [Verify TOTP Technical Overview](/docs/verify/totp/technical-overview.md): Learn about the technical specifics of Twilio's Verify API TOTP verification feature in this overview.
+* [Verify TOTP Overview](/docs/verify/totp.md): Learn more about sending time-based one-time passcode (TOTP) user verifications via Twilio's Verify API TOTP Overview.
+* [Verify Silent Network Auth Technical Overview](/docs/verify/sna/tech-overview.md): Technical overview and sequence diagram for the Twilio Verify Silent Network Auth feature
+* [Verify Silent Network Auth Overview](/docs/verify/sna.md): Learn about Twilio Verify's Silent Network Auth verifications in this overview.
+* [Verify SMS overview](/docs/verify/sms.md): Learn how to implement SMS-based phone verification and two-factor authentication with Twilio Verify.
+* [Verify TOTP Quickstart](/docs/verify/quickstarts/totp.md): Learn how to send Time-based One-Time Passwords (TOTP) verifications so you can authenticate users with apps like Authy or Google Authenticator.
+* [Verify Python Flask Quickstart](/docs/verify/quickstarts/python-flask.md): This quickstart shows you how to send your first SMS verification with the Verify REST API, the Twilio Python SDK, and the Flask micro-framework
+* [Verify PHP Laravel Quickstart](/docs/verify/quickstarts/php-laravel.md): Learn how to send an SMS verification with the Verify API, Twilio's PHP helper library, and the Laravel web framework in this quickstart.
+* [Verify Node.js Express Quickstart](/docs/verify/quickstarts/node-express.md): Learn how to send an SMS verification with the Verify REST API, the Twilio Node.js SDK, and Express.js in this quickstart.
+* [Verify Quickstarts](/docs/verify/quickstarts.md): Find links to all Verify quickstarts and learn how to verify user identity with Veriy and your supported programming language of choice.
+* [Verify C# ASP.NET Core Quickstart](/docs/verify/quickstarts/csharp-asp-net-core-mvc.md): Learn how to verify phone numbers using the Verify REST API, the Twilio C# SDK, and C# ASP.NET Core with this quickstart.
+* [Verify Push Client Library Technical Overview](/docs/verify/push/technical-overview.md): Learn more about with Twilio's Verify Push SDK in this technical overview with sequence diagrams, sample app demos, data models and definitions.
+* [Verify Push & Silent Device Approval Overview](/docs/verify/push.md): Learn how to add a push authentication factor to verify users in your app with Twilio's Verify Push overview.
+* [Verify Geo Permissions](/docs/verify/preventing-toll-fraud/verify-geo-permissions.md): Learn how to configure Geo Permissions for Twilio's Verify API in order to disable verification sends to specific countries to help prevent fraud.
+* [Verify Fraud Guard](/docs/verify/preventing-toll-fraud/sms-fraud-guard.md): Learn how to prevent SMS pumping fraud with Twilio's Verify SMS Fraud Guard overview.
+* [Preventing Fraud in Verify](/docs/verify/preventing-toll-fraud.md): SMS pumping and voice toll fraud attacks cause inflated traffic to your app and higher costs. Learn how fraudsters can take advantage of your application and how to stop them.
+* [Send Email Verifications with Verify and Twilio SendGrid](/docs/verify/email.md): Set up your Twilio account to send verification emails with Verify and Twilio SendGrid with step-by-step instructions, complete with sample code.
+* [Verify Push Webhooks](/docs/verify/api/webhooks.md): API reference for Verify Push webhooks and how they can be used to notify your application's backend in real-time when verification statuses change.
+* [Verifications](/docs/verify/api/verification.md): Full API reference for the Verifications resource in the Verify API. Sample code shows how to create (start), fetch (get), and update verifications.
+* [Verification Check](/docs/verify/api/verification-check.md): Full API reference for the Verification Check resource in the Verify API. Sample code shows how to check verifications with a phone number, email, or SID.
+* [Verification Attempts Summary](/docs/verify/api/verification-attempts-summary.md): Full API reference for the Verification Attempts Summary resource in the Twilio Verify API. Sample code shows how to get and fetch Verification Attempt Summaries.
+* [Templates](/docs/verify/api/templates.md): Templates are predefined and approved messages that allow you to customize your SMS or Voice Verifications.
+* [Services](/docs/verify/api/service.md): Full API reference for the Services resource in the Verify API. Sample code shows how to create, fetch, list, update, and delete Services.
+* [Service Rate Limits](/docs/verify/api/service-rate-limits.md): Full API reference for the Service Rate Limits resource for the Twilio Verify API. Sample code shows how to create, fetch, list, update, and delete.
+* [Service Rate Limit Buckets](/docs/verify/api/service-rate-limit-buckets.md): Full API reference for the Service Rate Limit Bucket resource in the Twilio Verify API. Sample code shows how to create, fetch, list all, update, and delete a Bucket.
+* [Safe List](/docs/verify/api/safe-list.md): Full API reference for the Safe List resource in the Twilio Verify API. Sample code shows how to add, check, and remove a phone number from the Safe List.
+* [Protect Your Verify Application with Service Rate Limits](/docs/verify/api/programmable-rate-limits.md): Learn how to protect your Verify application with Service Rate Limits, which let you define verification rate limits.
+* [Verify API](/docs/verify/api.md): Simplify user verification with Verify API. Send OTPs via SMS, call, WhatsApp, and more for enhanced security.
+* [Factor Resource](/docs/verify/api/factor.md): Full API reference for the Factor resource in the Verify API for TOTP and Push. Sample code shows how to create, fetch, read, update, and delete a Factor.
+* [Customization Options](/docs/verify/api/customization-options.md): Sample code that shows how to customize verification codes with Verify and information on message templates and localizations for communications.
+* [Challenge Resource](/docs/verify/api/challenge.md): Full API reference for the Challenge resource in the Twilio Verify API for TOTP and Push. Sample code shows how to create, fetch, read, and update a Challenge.
+* [Verification Attempts](/docs/verify/api/attempts.md): Full API reference for the Verification Attempts resource in the Twilio Verify API. Sample code shows how to fetch and list Verification Attempts.
+* [Access Token Resource](/docs/verify/api/access-token.md): Full API reference for the Access Token resource in the Twilio Verify API. Sample code shows how to create and fetch Access Tokens.
+* [Rate Limits and Timeouts](/docs/verify/api/rate-limits-and-timeouts.md): Learn about rate limits for requesting the status of a verification and the duration of token validity when building with Verify.
+
+## WhatsApp Business Platform with Twilio
+
+* [Register WhatsApp senders using Self Sign-up](/docs/whatsapp/self-sign-up.md): Learn how to register a WhatsApp sender using the Self Sign-up in the Twilio Console.
+* [Test WhatsApp messaging with the Sandbox](/docs/whatsapp/sandbox.md): With the Twilio Sandbox for WhatsApp, you can start prototyping with Twilio API functionality and sending WhatsApp messages right away: outbound and inbound messages, status callbacks, and more!
+* [Rich Messaging Features in the Twilio API for WhatsApp](/docs/whatsapp/message-features.md): Twilio supports the latest WhatsApp-specific features to make it easier for your customers to engage with you. Reach your customers through WhatsApp using the Twilio API for WhatsApp.
+* [Key Concepts and Terms for the WhatsApp Business Platform with Twilio](/docs/whatsapp/key-concepts.md): This document provides an overview of the key concepts and terms required to start using the WhatsApp Business Platform with Twilio.
+* [WhatsApp Business Platform with Twilio](/docs/whatsapp.md): Integrate WhatsApp messaging into your business with Twilio APIs.
+* [Guidance on WhatsApp Media Messages](/docs/whatsapp/guidance-whatsapp-media-messages.md): Guidance for content-type and media file size limits. Send media messages in WhatsApp using the Twilio API for WhatsApp.
+* [Editing your WhatsApp Business Profile](/docs/whatsapp/editing-your-whatsapp-business-profile.md): Learn how to edit your WhatsApp Business Profile to display accurate business information to your end-users.
+* [Using Buttons In WhatsApp](/docs/whatsapp/buttons.md): Instructions and sample code that show how to add quick-reply or call-to-action buttons to your WhatsApp messages to increase engagement with customers.
+* [The WhatsApp Business Platform with Twilio: Best Practices and FAQs](/docs/whatsapp/best-practices-and-faqs.md): Best practices and FAQs on WhatsApp and the Twilio API for WhatsApp. Learn how to get started with a WhatsApp integration including samples.
+* [Using WhatsApp Business Accounts with Twilio](/docs/whatsapp/tutorial/whatsapp-business-account.md): Learn about WhatsApp Official Business Accounts ("green tick") and how to request one for your Twilio WhatsApp sender
+* [Send WhatsApp notification messages with templates](/docs/whatsapp/tutorial/send-whatsapp-notification-messages-templates.md): Create and send WhatsApp notification message templates using Twilio API. Learn template categories, approval process, and implementation examples.
+* [Send and Receive Media Messages with WhatsApp in Python](/docs/whatsapp/tutorial/send-and-receive-media-messages-whatsapp-python.md): How to send media messages with the Twilio API for WhatsApp. Add media attachments like images, audio files, and PDF documents to WhatsApp messages with Twilio.
+* [Send and Receive Media Messages with WhatsApp in PHP](/docs/whatsapp/tutorial/send-and-receive-media-messages-whatsapp-php.md): Learn how to send media messages with the Twilio API for WhatsApp. Add media attachments like images, audio files, and PDF documents to WhatsApp messages with Twilio.
+* [Send and Receive Media Messages with WhatsApp in Node.js](/docs/whatsapp/tutorial/send-and-receive-media-messages-whatsapp-nodejs.md): How to send media messages with the Twilio API for WhatsApp. Add media attachments like images, audio files, and PDF documents to WhatsApp messages with Twilio.
+* [Send and Receive Media Messages with WhatsApp in C#/ASP.NET](/docs/whatsapp/tutorial/send-and-receive-media-messages-whatsapp-csharp-aspnet.md): How to send media messages with the Twilio API for WhatsApp. Add media attachments like images, audio files, and PDF documents to WhatsApp messages with Twilio.
+* [Send and Receive Media Messages with the Twilio API for WhatsApp](/docs/whatsapp/tutorial/send-and-receive-media-messages-twilio-api-whatsapp.md): Find links to step-by-step tutorials to learn how to use the Programmable Messaging API to send and receive WhatsApp media messages from your applications.
+* [Message template approvals and statuses](/docs/whatsapp/tutorial/message-template-approvals-statuses.md): Understand the approval process, common rejection reasons, and best practices for WhatsApp message templates.
+* [Twilio API for WhatsApp Tutorials](/docs/whatsapp/tutorial.md): Tutorials and sample code for sending, receiving images, PDFs, and audio, reminders, notifications, messages with the Twilio API for WhatsApp.
+* [Quickstart: Send and receive WhatsApp messages](/docs/whatsapp/quickstart.md): Quickstart guide and sample code for developers to try the WhatsApp Business Platform with Twilio. Start connecting with WhatsApp users.
+* [Overview of the WhatsApp Business Platform with Twilio](/docs/whatsapp/api.md): Complete Twilio API for WhatsApp overview showing API calls, parameters, message formatting, and common examples and responses.
+* [List of Corresponding Twilio and WhatsApp Error Codes](/docs/whatsapp/api/error-code-mapping.md): A table of the corresponding Twilio and WhatsApp error codes. Debug efficiently with a mapping of common Twilio error codes to their WhatsApp counterpart.
+* [Senders API - WhatsApp](/docs/whatsapp/api/senders.md): Register and manage your Twilio WhatsApp Senders using the Senders API
+
+## api
+
+* [Error and Warning Dictionary](/docs/api/errors.md): Explore the full list of all possible Twilio REST API error codes.


### PR DESCRIPTION
## Summary
- Add TwilioDocr for parsing Twilio documentation from llms.txt format
- Handle relative URLs (Twilio uses `/docs/...` paths) by prepending base domain
- Implement markdown-first fetching with HTML fallback (same pattern as Vercel)
- Add comprehensive test suite with full 1,536 line fixture (1100+ entries)
- Add Makefile commands for easy installation

## Key Features
- **Relative URL handling**: Converts `/docs/sms.md` → `https://www.twilio.com/docs/sms.md`
- **Smart content fetching**: Try markdown first, fallback to HTML on 404
- **Domain whitelist**: Allows both `twilio.com` and `www.twilio.com`
- **Comprehensive tests**: 12 tests covering parsing, search, URL handling, and fallback

## Test Results
All 12 tests pass in 0.30s:
- Index parsing (1100+ entries)
- Relative URL conversion
- Section hierarchy tracking
- Tag extraction
- URL validation
- Markdown/HTML fallback
- Search functionality

## Installation
```bash
# Production (from PyPI)
make add-twilio

# Development (local code)
make add-twilio-local
```

## Test plan
- [x] All 12 tests pass locally
- [x] Code formatted with ruff
- [x] Tested with MCP in Claude Code - search returns relevant results
- [ ] CI tests pass (automated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)