### PR TITLE
Add PyPI version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 </p>
 
 <p align="center">
+  <a href="https://pypi.org/project/docr-mcp/"><img src="https://img.shields.io/pypi/v/docr-mcp.svg" alt="PyPI"></a>
   <a href="https://github.com/JacobHuang91/docr-mcp/actions"><img src="https://github.com/JacobHuang91/docr-mcp/workflows/CI/badge.svg" alt="Tests"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python 3.10+"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>


### PR DESCRIPTION
Add PyPI version badge to README for better visibility of the latest published version.

Badge will show the current version (v0.3.0) with a link to https://pypi.org/project/docr-mcp/